### PR TITLE
IGVF-252 Add gene object and collection pages

### DIFF
--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -11,6 +11,7 @@ config: Dict[str, Any] = {
     'environment': {
         'demo': {
             'pipeline': 'DemoDeploymentPipelineStack',
+            'backend_url': 'https://igvfd-test-data-inserts.demo.igvf.org'
         },
         'dev': {
             'pipeline': 'DemoDeploymentPipelineStack',

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -11,7 +11,6 @@ config: Dict[str, Any] = {
     'environment': {
         'demo': {
             'pipeline': 'DemoDeploymentPipelineStack',
-            'backend_url': 'https://igvfd-test-data-inserts.demo.igvf.org'
         },
         'dev': {
             'pipeline': 'DemoDeploymentPipelineStack',

--- a/components/icon.js
+++ b/components/icon.js
@@ -38,6 +38,26 @@ const Icon = {
       />
     </svg>
   ),
+  Gene: ({ className = null }) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      viewBox="0 0 20 20"
+      stroke="currentColor"
+      fill="none"
+    >
+      <g className="stroke-2">
+        <path
+          d="M14.2,1
+	c-2.2,2.2,2.6,7,0.4,9.2c-2.2,2.2-7-2.6-9.2-0.4s2.6,7,0.4,9.2"
+        />
+        <path
+          d="M1,14.2
+	c2.2-2.2,7,2.6,9.2,0.4c2.2-2.2-2.6-7-0.4-9.2s7,2.6,9.2,0.4"
+        />
+      </g>
+    </svg>
+  ),
   Sample: ({ className = null }) => (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -99,6 +119,9 @@ Icon.Award.propTypes = {
   className: PropTypes.string,
 };
 Icon.Donor.propTypes = {
+  className: PropTypes.string,
+};
+Icon.Gene.propTypes = {
   className: PropTypes.string,
 };
 Icon.Sample.propTypes = {

--- a/components/navigation.js
+++ b/components/navigation.js
@@ -346,6 +346,16 @@ const Navigation = ({ navigationClick }) => {
         </NavigationHrefItem>
       </NavigationGroupItem>
       <NavigationHrefItem
+        id="genes"
+        href="/genes"
+        navigationClick={navigationClick}
+      >
+        <NavigationIcon>
+          <Icon.Gene />
+        </NavigationIcon>
+        Genes
+      </NavigationHrefItem>
+      <NavigationHrefItem
         id="labs"
         href="/labs"
         navigationClick={navigationClick}

--- a/cypress/e2e/app.cy.js
+++ b/cypress/e2e/app.cy.js
@@ -22,6 +22,10 @@ describe("Navigation", () => {
     cy.get("[data-testid=human-donors]").should("not.exist");
     cy.get("[data-testid=rodent-donors]").should("not.exist");
 
+    cy.get("[data-testid=genes]").click();
+    cy.url().should("include", "/genes");
+    cy.get("[data-testid=collection-view-switch]").should("exist");
+
     cy.get("[data-testid=labs]").click();
     cy.url().should("include", "/labs");
     cy.get("[data-testid=collection-view-switch]").should("exist");

--- a/package-lock.json
+++ b/package-lock.json
@@ -3670,9 +3670,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.208",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.208.tgz",
-      "integrity": "sha512-diMr4t69FigAGUk2KovP0bygEtN/9AkqEVkzjEp0cu+zFFbZMVvwACpTTfuj1mAmFR5kNoSW8wGKDFWIvmThiQ==",
+      "version": "1.4.210",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.210.tgz",
+      "integrity": "sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -12744,9 +12744,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.208",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.208.tgz",
-      "integrity": "sha512-diMr4t69FigAGUk2KovP0bygEtN/9AkqEVkzjEp0cu+zFFbZMVvwACpTTfuj1mAmFR5kNoSW8wGKDFWIvmThiQ==",
+      "version": "1.4.210",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.210.tgz",
+      "integrity": "sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ==",
       "dev": true
     },
     "emittery": {

--- a/pages/genes/[id].js
+++ b/pages/genes/[id].js
@@ -1,0 +1,100 @@
+// node_modules
+import PropTypes from "prop-types";
+// components
+import Breadcrumbs from "../../components/breadcrumbs";
+import {
+  DataArea,
+  DataItemLabel,
+  DataItemValue,
+  DataPanel,
+} from "../../components/data-area";
+import PagePreamble from "../../components/page-preamble";
+import Status from "../../components/status";
+import { EditableItem } from "../../components/edit";
+// lib
+import buildBreadcrumbs from "../../lib/breadcrumbs";
+import errorObjectToProps from "../../lib/errors";
+import FetchRequest from "../../lib/fetch-request";
+
+const Gene = ({ gene }) => {
+  return (
+    <>
+      <Breadcrumbs />
+      <EditableItem item={gene}>
+        <PagePreamble />
+        <DataPanel>
+          <DataArea>
+            <DataItemLabel>Status</DataItemLabel>
+            <DataItemValue>
+              <Status status={gene.status} />
+            </DataItemValue>
+            <DataItemLabel>NCBI Entrez GeneID</DataItemLabel>
+            <DataItemValue>{gene.geneid}</DataItemValue>
+            <DataItemLabel>NCBI Entrez Gene Status</DataItemLabel>
+            <DataItemValue>{gene.ncbi_entrez_status}</DataItemValue>
+            <DataItemLabel>Gene Symbol</DataItemLabel>
+            <DataItemValue>{gene.symbol}</DataItemValue>
+            <DataItemLabel>Taxa</DataItemLabel>
+            <DataItemValue>{gene.taxa}</DataItemValue>
+            {gene.name && (
+              <>
+                <DataItemLabel>Name</DataItemLabel>
+                <DataItemValue>{gene.name}</DataItemValue>
+              </>
+            )}
+            {gene.synonyms?.length > 0 && (
+              <>
+                <DataItemLabel>Synonyms</DataItemLabel>
+                <DataItemValue>{gene.synonyms.join(", ")}</DataItemValue>
+              </>
+            )}
+            {gene.locations?.length > 0 && (
+              <>
+                <DataItemLabel>Gene Locations</DataItemLabel>
+                <DataItemValue>
+                  <ul>
+                    {gene.locations.map((location, index) => (
+                      <li key={index} className="flex items-center">
+                        {`${location.chromosome}:${location.start}-${location.end}`}
+                        <div className="ml-2 bg-gray-300 px-1.5 text-xs font-semibold dark:bg-gray-700">
+                          {location.assembly}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </DataItemValue>
+              </>
+            )}
+          </DataArea>
+        </DataPanel>
+      </EditableItem>
+    </>
+  );
+};
+
+Gene.propTypes = {
+  // Data for gene displayed on the page
+  gene: PropTypes.object.isRequired,
+};
+
+export default Gene;
+
+export const getServerSideProps = async ({ params, req }) => {
+  const request = new FetchRequest({ cookie: req.headers.cookie });
+  const gene = await request.getObject(`/genes/${params.id}/`);
+  if (FetchRequest.isResponseSuccess(gene)) {
+    const breadcrumbs = await buildBreadcrumbs(
+      gene,
+      "title",
+      req.headers.cookie
+    );
+    return {
+      props: {
+        gene,
+        pageContext: { title: gene.title },
+        breadcrumbs,
+      },
+    };
+  }
+  return errorObjectToProps(gene);
+};

--- a/pages/genes/index.js
+++ b/pages/genes/index.js
@@ -1,0 +1,76 @@
+// node_modules
+import PropTypes from "prop-types";
+// components
+import Breadcrumbs from "../../components/breadcrumbs";
+import {
+  Collection,
+  CollectionContent,
+  CollectionHeader,
+  CollectionItem,
+  CollectionItemName,
+} from "../../components/collection";
+import { NoCollectionData } from "../../components/no-content";
+import PagePreamble from "../../components/page-preamble";
+// lib
+import buildBreadcrumbs from "../../lib/breadcrumbs";
+import errorObjectToProps from "../../lib/errors";
+import FetchRequest from "../../lib/fetch-request";
+
+const GeneList = ({ genes }) => {
+  return (
+    <>
+      <Breadcrumbs />
+      <PagePreamble />
+      <Collection>
+        {genes.length > 0 ? (
+          <>
+            <CollectionHeader count={genes.length} />
+            <CollectionContent collection={genes}>
+              {genes.map((gene) => (
+                <CollectionItem
+                  key={gene.uuid}
+                  testid={gene.uuid}
+                  href={gene["@id"]}
+                  label={`Lab ${gene.title}`}
+                  status={gene.status}
+                >
+                  <CollectionItemName>{gene.title}</CollectionItemName>
+                  <div>{gene.geneid}</div>
+                </CollectionItem>
+              ))}
+            </CollectionContent>
+          </>
+        ) : (
+          <NoCollectionData />
+        )}
+      </Collection>
+    </>
+  );
+};
+
+GeneList.propTypes = {
+  // Genes to display in the list
+  genes: PropTypes.array.isRequired,
+};
+
+export default GeneList;
+
+export const getServerSideProps = async ({ req }) => {
+  const request = new FetchRequest({ cookie: req.headers.cookie });
+  const genes = await request.getCollection("genes");
+  if (FetchRequest.isResponseSuccess(genes)) {
+    const breadcrumbs = await buildBreadcrumbs(
+      genes,
+      "title",
+      req.headers.cookie
+    );
+    return {
+      props: {
+        genes: genes["@graph"],
+        pageContext: { title: genes.title },
+        breadcrumbs,
+      },
+    };
+  }
+  return errorObjectToProps(genes);
+};


### PR DESCRIPTION
I think from now on we have to name the object files in /pages/ to [id].js because igvfd has been changing its paths to not use uuids. Things still work, but it seems misleading to have params.uuid contain something that’s not a uuid. We might even want to go back and rename the other object pages to [id].js, at least if they need modification for another ticket.

These gene pages follow the same pattern as existing object and collection pages, so code review shouldn’t take that much effort. I did add a new icon for navigation.