### PR TITLE
IGVF-244 Change h1 titles to a bolder style

### DIFF
--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -11,6 +11,7 @@ config: Dict[str, Any] = {
     'environment': {
         'demo': {
             'pipeline': 'DemoDeploymentPipelineStack',
+            'backend_url': 'https://igvfd-dev.demo.igvf.org'
         },
         'dev': {
             'pipeline': 'DemoDeploymentPipelineStack',

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -11,7 +11,6 @@ config: Dict[str, Any] = {
     'environment': {
         'demo': {
             'pipeline': 'DemoDeploymentPipelineStack',
-            'backend_url': 'https://igvfd-dev.demo.igvf.org'
         },
         'dev': {
             'pipeline': 'DemoDeploymentPipelineStack',

--- a/components/page-title.js
+++ b/components/page-title.js
@@ -10,7 +10,11 @@ import GlobalContext from "./global-context";
 const PageTitle = ({ pageTitle = "" }) => {
   const { page } = useContext(GlobalContext);
 
-  return <h1 className="mb-5 text-4xl font-thin">{pageTitle || page.title}</h1>;
+  return (
+    <h1 className="mb-5 text-3xl font-medium text-gray-700">
+      {pageTitle || page.title}
+    </h1>
+  );
 };
 
 PageTitle.propTypes = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "auth0-js": "^9.19.0",
         "autoprefixer": "^10.4.7",
         "coveralls": "^3.1.1",
-        "cypress": "^10.4.0",
+        "cypress": "^9.7.0",
         "eslint": "^8.17.0",
         "eslint-config-next": "^12.1.6",
         "eslint-config-prettier": "^8.5.0",
@@ -3326,9 +3326,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.4.0.tgz",
-      "integrity": "sha512-OM7F8MRE01SHQRVVzunid1ZK1m90XTxYnl+7uZfIrB4CYqUDCrZEeSyCXzIbsS6qcaijVCAhqDL60SxG8N6hew==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.7.0.tgz",
+      "integrity": "sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3670,9 +3670,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.208",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.208.tgz",
-      "integrity": "sha512-diMr4t69FigAGUk2KovP0bygEtN/9AkqEVkzjEp0cu+zFFbZMVvwACpTTfuj1mAmFR5kNoSW8wGKDFWIvmThiQ==",
+      "version": "1.4.210",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.210.tgz",
+      "integrity": "sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -12467,9 +12467,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.4.0.tgz",
-      "integrity": "sha512-OM7F8MRE01SHQRVVzunid1ZK1m90XTxYnl+7uZfIrB4CYqUDCrZEeSyCXzIbsS6qcaijVCAhqDL60SxG8N6hew==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.7.0.tgz",
+      "integrity": "sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -12744,9 +12744,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.208",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.208.tgz",
-      "integrity": "sha512-diMr4t69FigAGUk2KovP0bygEtN/9AkqEVkzjEp0cu+zFFbZMVvwACpTTfuj1mAmFR5kNoSW8wGKDFWIvmThiQ==",
+      "version": "1.4.210",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.210.tgz",
+      "integrity": "sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ==",
       "dev": true
     },
     "emittery": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "auth0-js": "^9.19.0",
         "autoprefixer": "^10.4.7",
         "coveralls": "^3.1.1",
-        "cypress": "^9.7.0",
+        "cypress": "^10.4.0",
         "eslint": "^8.17.0",
         "eslint-config-next": "^12.1.6",
         "eslint-config-prettier": "^8.5.0",
@@ -3326,9 +3326,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.7.0.tgz",
-      "integrity": "sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.4.0.tgz",
+      "integrity": "sha512-OM7F8MRE01SHQRVVzunid1ZK1m90XTxYnl+7uZfIrB4CYqUDCrZEeSyCXzIbsS6qcaijVCAhqDL60SxG8N6hew==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -9957,9 +9957,9 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.0.tgz",
+      "integrity": "sha512-xzm2t63xTV/f7+bGMSRzLhUNk1ajv/tDoaD5OeGyC3cFo2fl7My9Z4hS3q2VdQ7JaLvTxErO8Jp5pRIFGMD/zg==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -12467,9 +12467,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.7.0.tgz",
-      "integrity": "sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.4.0.tgz",
+      "integrity": "sha512-OM7F8MRE01SHQRVVzunid1ZK1m90XTxYnl+7uZfIrB4CYqUDCrZEeSyCXzIbsS6qcaijVCAhqDL60SxG8N6hew==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -17396,9 +17396,9 @@
       }
     },
     "yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.0.tgz",
+      "integrity": "sha512-xzm2t63xTV/f7+bGMSRzLhUNk1ajv/tDoaD5OeGyC3cFo2fl7My9Z4hS3q2VdQ7JaLvTxErO8Jp5pRIFGMD/zg==",
       "dev": true
     },
     "yauzl": {


### PR DESCRIPTION
igvf-ui currently uses a very fine large typeface for the page titles, both the collection pages (e.g. /awards) and individual pages (e.g. /awards/HG012012).

This ticket changes that to a bolder font. To avoid looking too overwhelming on the page, I also make the text slightly smaller, and slightly gray instead of black.