### PR TITLE
IGVF-287 Fix crash with donors that don’t have an alias property

### DIFF
--- a/components/common-data-items.js
+++ b/components/common-data-items.js
@@ -53,7 +53,7 @@ export const DonorDataItems = ({ donor, parents, children }) => {
         </>
       )}
       {children}
-      {donor.aliases.length > 0 && (
+      {donor.aliases?.length > 0 && (
         <>
           <DataItemLabel>Aliases</DataItemLabel>
           <DataItemValue>


### PR DESCRIPTION
Don’t assume donor.alias exists before checking its length.