### PR TITLE
IGVF-318 Get rid of the console /api/mapprofiles error

### DIFF
--- a/pages/api/mapprofile/[profile].js
+++ b/pages/api/mapprofile/[profile].js
@@ -1,4 +1,4 @@
-import FetchRequest, { HTTP_STATUS_CODE } from "../../lib/fetch-request";
+import FetchRequest, { HTTP_STATUS_CODE } from "../../../lib/fetch-request";
 
 /**
  * Given the schema name in the query parameters like ?profile=<schema_name>
@@ -9,15 +9,17 @@ const mapprofile = (req, res) => {
   if (req.method === "GET") {
     if (req.query.profile) {
       const request = new FetchRequest({ cookie: req.headers.cookie });
-      request.getObject(`/${req.query.profile}/?limit=0`).then((response) => {
-        if (FetchRequest.isResponseSuccess(response)) {
-          return res.status(HTTP_STATUS_CODE.OK).json(response);
-        } else {
-          res
-            .status(HTTP_STATUS_CODE.BAD_REQUEST)
-            .json({ error: "Bad Request" });
-        }
-      });
+      return request
+        .getObject(`/${req.query.profile}/?limit=0`)
+        .then((response) => {
+          if (FetchRequest.isResponseSuccess(response)) {
+            return res.status(HTTP_STATUS_CODE.OK).json(response);
+          } else {
+            res
+              .status(HTTP_STATUS_CODE.BAD_REQUEST)
+              .json({ error: "Bad Request" });
+          }
+        });
     } else {
       res.status(HTTP_STATUS_CODE.BAD_REQUEST).json({ error: "Bad Request" });
     }


### PR DESCRIPTION
Turns out this error was caused by not returning the getObjects promise from the mapprofiles API route function. I also changed the mapprofiles endpoint to use a dynamic route, so instead of `/api/mapprofiles?query=<profile>` we use `/api/mapprofiles/<profile>` which seemed more straightforward.

I also stopped requesting the access_key collection because you have to be signed in for this to work, and we don’t create access keys using the editor UI anyway. Keenan said we have to keep the access_key collection privileged.