### PR TITLE
IGVF-277-add-buckets

### DIFF
--- a/cdk/requirements.txt
+++ b/cdk/requirements.txt
@@ -1,3 +1,3 @@
 aws-cdk-lib==2.61.0
 constructs>=10.0.0,<11.0.0
-git+https://github.com/IGVF-DACC/shared-infrastructure@add-resources-for-other-accounts#egg=shared_infrastructure
+git+https://github.com/IGVF-DACC/shared-infrastructure@IGVF-393-add-upload-user#egg=shared_infrastructure


### PR DESCRIPTION
No functional change, just keeping `shared-infrastructure` version updated with `igvfd`.