### PR TITLE
IGVF-442 Fix post-login redirect for URIs with query strings

### DIFF
--- a/components/navigation.js
+++ b/components/navigation.js
@@ -125,13 +125,14 @@ function NavigationSignInItem({ id, children }) {
    * We only know it was successful once `useAuth0` returns true in `isAuthenticated`.
    */
   function handleAuthClick() {
-    // Save the current path in auth0-react appState so we can redirect to it after signin, unless
-    // the user is on the authentication-error page, in which case we redirect to the home page
-    // after sign-in so the user doesn't see an authentication error after a good sign-in.
+    // Save the current path and query string in session storage so we can redirect to it after
+    // signin, unless the user is on the authentication-error page, in which case we redirect to
+    // the home page after sign-in so the user doesn't see an authentication error after a good
+    // sign-in.
     setRedirectTo(
       window.location.pathname === AUTH_ERROR_URI
         ? "/"
-        : window.location.pathname
+        : `${window.location.pathname}${window.location.search}`
     );
     loginWithRedirect();
   }

--- a/cypress/e2e/authentication-redirect.cy.js
+++ b/cypress/e2e/authentication-redirect.cy.js
@@ -1,0 +1,80 @@
+describe("Test that the post-login redirect goes to the correct URI", () => {
+  it("should redirect to the correct URI for a simple object page", () => {
+    // Navigate to a gene page.
+    cy.visit("/");
+    cy.get("[data-testid=genes]").click();
+    cy.get(`[data-testid^="search-list-item"]`).should(
+      "have.length.at.least",
+      1
+    );
+    cy.get(`[aria-label^="View details for"]`).first().click();
+
+    // Test that the gene page has the correct elements.
+    cy.url().should("include", "/genes/ENSG00000");
+    cy.get("h1").should("have.length", 1);
+    cy.get("div").should("have.class", "border-panel bg-panel");
+
+    // Sign in.
+    cy.log(`CYPRESSENV: ${Cypress.env("AUTH_USERNAME")}`);
+    cy.loginAuth0(
+      Cypress.env("AUTH_USERNAME"),
+      Cypress.env("AUTH_PASSWORD"),
+      true
+    );
+    cy.contains("Cypress Testing");
+    cy.wait(1000);
+
+    // Confirm that we redirect back to the gene page.
+    cy.url().should("include", "/genes/ENSG00000");
+  });
+
+  it("should redirect to the correct URI for the search page", () => {
+    // Navigate to the Page list page and confirm it has the correct elements.
+    cy.visit("/");
+    cy.get("[data-testid=pages]").click();
+    cy.url().should("include", "/search?type=Page");
+    cy.get("h1").should("have.length", 1);
+    cy.get("h1").contains("Page");
+    cy.get(`[data-testid^="search-list-item"]`).should(
+      "have.length.at.least",
+      1
+    );
+
+    // Sign in.
+    cy.log(`CYPRESSENV: ${Cypress.env("AUTH_USERNAME")}`);
+    cy.loginAuth0(
+      Cypress.env("AUTH_USERNAME"),
+      Cypress.env("AUTH_PASSWORD"),
+      true
+    );
+    cy.contains("Cypress Testing");
+    cy.wait(1000);
+
+    // Confirm that we redirect back to the Page list page.
+    cy.url().should("include", "/search?type=Page");
+  });
+
+  it("should redirect to the correct path for the report page", () => {
+    // Navigate to the Page report page and confirm it has the correct elements.
+    cy.visit("/");
+    cy.get("[data-testid=users]").click();
+    cy.get(`[label="Select report view"]`).click();
+    cy.url().should("include", "/report?type=User");
+    cy.get("h1").should("have.length", 1);
+    cy.get("h1").contains("User");
+    cy.get(`[role="table"]`);
+
+    // Sign in.
+    cy.log(`CYPRESSENV: ${Cypress.env("AUTH_USERNAME")}`);
+    cy.loginAuth0(
+      Cypress.env("AUTH_USERNAME"),
+      Cypress.env("AUTH_PASSWORD"),
+      true
+    );
+    cy.contains("Cypress Testing");
+    cy.wait(1000);
+
+    // Confirm that we redirect back to the User report page.
+    cy.url().should("include", "/report?type=User");
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -32,10 +32,13 @@
  * https://github.com/charklewis/auth0-cypress
  * @param {string} username - The username to use for the login.
  * @param {string} password - The password to use for the login.
+ * @param {boolean} isPrepSkipped - Whether or not to skip login prep.
  */
-Cypress.Commands.add("loginAuth0", (username, password) => {
-  cy.visit("http://localhost:3000/");
-  cy.clearLocalStorage();
+Cypress.Commands.add("loginAuth0", (username, password, isPrepSkipped) => {
+  if (!isPrepSkipped) {
+    cy.visit("http://localhost:3000/");
+    cy.clearLocalStorage();
+  }
 
   const client_id = Cypress.env("AUTH_CLIENT_ID");
   const client_secret = Cypress.env("AUTH_CLIENT_SECRET");


### PR DESCRIPTION
I didn’t realize that `window.location.pathname` is what it says: the path name — not including the query string. I now combine the pathname with the query string in `window.location.search`. `window.location.href` also exists and includes the query string, but it also includes the protocol and domain, which we don’t need for this.