### PR TITLE
IGVF-375 Implement facets and facet groups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - run:
           name: Clone igvfd
           environment:
-            - IGVFD_BRANCH: dev
+            - IGVFD_BRANCH: IGVF-475-facet-configs
           command: |
             git clone https://github.com/IGVF-DACC/igvfd.git --branch $IGVFD_BRANCH
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - run:
           name: Clone igvfd
           environment:
-            - IGVFD_BRANCH: IGVF-475-facet-configs
+            - IGVFD_BRANCH: dev
           command: |
             git clone https://github.com/IGVF-DACC/igvfd.git --branch $IGVFD_BRANCH
       - run:

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,6 +52,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
+            'backend_url': 'https://igvfd-igvf-475-facet-configs.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,7 +52,6 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-igvf-475-facet-configs.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/components/__tests__/checkbox.test.js
+++ b/components/__tests__/checkbox.test.js
@@ -14,7 +14,7 @@ describe("Test the <Checkbox> component", () => {
     expect(label).toBeInTheDocument();
 
     const checkbox = screen.getByRole("checkbox");
-    expect(checkbox).toHaveAttribute("name", "checkbox-test");
+    expect(checkbox).toHaveAttribute("aria-label", "checkbox-test");
     expect(checkbox).not.toBeChecked();
 
     fireEvent.click(checkbox);

--- a/components/__tests__/data-area.test.js
+++ b/components/__tests__/data-area.test.js
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import {
+  DataArea,
+  DataAreaTitle,
+  DataItemLabel,
+  DataItemValue,
+  DataPanel,
+} from "../data-area";
+import Status from "../status";
+
+describe("Test the DataArea component", () => {
+  it("properly renders a data panel with default Tailwind CSS classes", () => {
+    render(
+      <>
+        <DataPanel>
+          <DataArea>
+            <DataItemLabel>Status</DataItemLabel>
+            <DataItemValue>
+              <Status status="in progress" />
+            </DataItemValue>
+          </DataArea>
+        </DataPanel>
+        <DataAreaTitle>Treatments</DataAreaTitle>
+      </>
+    );
+
+    const dataPanel = screen.getByTestId("datapanel");
+    expect(dataPanel).toBeInTheDocument();
+
+    const dataArea = screen.getByTestId("dataarea");
+    expect(dataArea).toBeInTheDocument();
+
+    const dataAreaTitle = screen.getByTestId("dataareatitle");
+    expect(dataAreaTitle).toBeInTheDocument();
+
+    const dataItemLabel = screen.getByTestId("dataitemlabel");
+    expect(dataItemLabel).toBeInTheDocument();
+
+    const title = screen.getByTestId("dataitemvalue");
+    expect(title).toBeInTheDocument();
+  });
+
+  it("properly renders a data panel with custom Tailwind CSS classes", () => {
+    render(
+      <>
+        <DataPanel className="text-xs">
+          <DataArea>
+            <DataItemLabel className="font-black">Status</DataItemLabel>
+            <DataItemValue>
+              <Status status="in progress" />
+            </DataItemValue>
+          </DataArea>
+        </DataPanel>
+        <DataAreaTitle>Treatments</DataAreaTitle>
+      </>
+    );
+
+    const dataPanel = screen.getByTestId("datapanel");
+    expect(dataPanel).toBeInTheDocument();
+    expect(dataPanel).toHaveClass("text-xs");
+
+    const dataArea = screen.getByTestId("dataarea");
+    expect(dataArea).toBeInTheDocument();
+
+    const dataAreaTitle = screen.getByTestId("dataareatitle");
+    expect(dataAreaTitle).toBeInTheDocument();
+
+    const dataItemLabel = screen.getByTestId("dataitemlabel");
+    expect(dataItemLabel).toBeInTheDocument();
+    expect(dataItemLabel).toHaveClass("font-black");
+
+    const title = screen.getByTestId("dataitemvalue");
+    expect(title).toBeInTheDocument();
+  });
+});

--- a/components/access-keys.js
+++ b/components/access-keys.js
@@ -377,7 +377,7 @@ AccessKeyItem.propTypes = {
  */
 export function AccessKeyList({ children }) {
   return (
-    <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+    <div className="mt-2 grid grid-cols-1 gap-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
       {children}
     </div>
   );

--- a/components/checkbox.js
+++ b/components/checkbox.js
@@ -12,11 +12,11 @@ export default function Checkbox({
   children,
 }) {
   return (
-    <label data-testid="checkbox-label" className={className}>
+    <label data-testid="checkbox-label" className={`flex ${className}`}>
       <input
         className="mr-1"
         type="checkbox"
-        name={name}
+        aria-label={name}
         checked={checked}
         onChange={onChange}
       />

--- a/components/common-data-items.js
+++ b/components/common-data-items.js
@@ -209,7 +209,7 @@ export function BiosampleDataItems({
   source = null,
   donors = [],
   biosampleTerm = null,
-  diseaseTerms,
+  diseaseTerms = null,
   pooledFrom,
   partOf,
   options = {
@@ -288,13 +288,13 @@ export function BiosampleDataItems({
           </DataItemValue>
         </>
       )}
-      {diseaseTerms.length > 0 && (
+      {diseaseTerms?.length > 0 && (
         <>
           <DataItemLabel>Disease Terms</DataItemLabel>
           <DataItemValue>
             <SeparatedList>
               {diseaseTerms.map((diseaseTerm) => (
-                <Link href={diseaseTerm["@id"]} key={diseaseTerm.uuid}>
+                <Link href={diseaseTerm["@id"]} key={diseaseTerm["@id"]}>
                   {diseaseTerm.term_name}
                 </Link>
               ))}
@@ -339,7 +339,7 @@ BiosampleDataItems.propTypes = {
   // Sample ontology for the biosample
   biosampleTerm: PropTypes.object,
   // Disease ontology for the biosample
-  diseaseTerms: PropTypes.arrayOf(PropTypes.object).isRequired,
+  diseaseTerms: PropTypes.arrayOf(PropTypes.object),
   // Biosample(s) Pooled From
   pooledFrom: PropTypes.arrayOf(PropTypes.object),
   // Part of Biosample

--- a/components/data-area.js
+++ b/components/data-area.js
@@ -18,7 +18,10 @@ import PropTypes from "prop-types";
  */
 export function DataPanel({ className = "", children }) {
   return (
-    <div className={`border border-panel bg-panel p-4 ${className}`}>
+    <div
+      className={`border border-panel bg-panel p-4 ${className}`}
+      data-testid="datapanel"
+    >
       {children}
     </div>
   );
@@ -36,7 +39,12 @@ DataPanel.propTypes = {
  */
 export function DataArea({ children }) {
   return (
-    <div className="md:grid md:grid-cols-data-item md:gap-4">{children}</div>
+    <div
+      className="md:grid md:grid-cols-data-item md:gap-4"
+      data-testid="dataarea"
+    >
+      {children}
+    </div>
   );
 }
 
@@ -44,7 +52,11 @@ export function DataArea({ children }) {
  * Displays the title above a data panel or table.
  */
 export function DataAreaTitle({ children }) {
-  return <h2 className="mt-4 mb-1 text-2xl font-light">{children}</h2>;
+  return (
+    <h2 className="mt-4 mb-1 text-2xl font-light" data-testid="dataareatitle">
+      {children}
+    </h2>
+  );
 }
 
 /**
@@ -54,6 +66,7 @@ export function DataItemLabel({ className = "", children }) {
   return (
     <div
       className={`mt-4 break-words font-semibold text-data-label first:mt-0 dark:text-gray-400 md:mt-0 ${className}`}
+      data-testid="dataitemlabel"
     >
       {children}
     </div>
@@ -70,7 +83,10 @@ DataItemLabel.propTypes = {
  */
 export function DataItemValue({ children }) {
   return (
-    <div className="mb-4 font-medium text-data-value last:mb-0 md:mb-0">
+    <div
+      className="mb-4 font-medium text-data-value last:mb-0 md:mb-0"
+      data-testid="dataitemvalue"
+    >
       {children}
     </div>
   );

--- a/components/facets/__tests__/.eslintrc.json
+++ b/components/facets/__tests__/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "jest": true
+  },
+  "rules": {
+    "no-import-assign": "off"
+  }
+}

--- a/components/facets/__tests__/facet-groups.test.js
+++ b/components/facets/__tests__/facet-groups.test.js
@@ -1,0 +1,713 @@
+import { render, screen, within } from "@testing-library/react";
+import {
+  getFacetsInGroup,
+  FacetGroup,
+  FacetGroupButton,
+} from "../facet-groups";
+
+jest.mock("next/router", () => {
+  // Mock the window.location object so we can test the router.push() function.
+  const location = new URL("https://www.example.com");
+  location.assign = jest.fn();
+  location.replace = jest.fn();
+  location.reload = jest.fn();
+  delete window.location;
+  window.location = location;
+
+  return {
+    useRouter() {
+      return {
+        route: "/",
+        pathname: "",
+        query: "",
+        asPath: "",
+        push: jest.fn().mockImplementation((href) => {
+          window.location.href = `https://www.example.com${href}`;
+        }),
+      };
+    },
+  };
+});
+
+describe("Test the `<FacetGroupButton>` component", () => {
+  it("renders a non-selected facet group button with no selected facet terms", () => {
+    const onClick = jest.fn();
+    const searchResults = {
+      "@id": "/search?type=HumanDonor",
+      filters: [
+        {
+          field: "type",
+          term: "HumanDonor",
+          remove: "/report",
+        },
+      ],
+    };
+    const facetGroup = {
+      name: "HumanDonor",
+      title: "Donor",
+      facet_fields: ["life_stage", "sex"],
+    };
+
+    render(
+      <FacetGroupButton
+        searchResults={searchResults}
+        group={facetGroup}
+        isSelected={false}
+        onClick={onClick}
+      />
+    );
+
+    // Check that the button is rendered with the correct text and icon Tailwind CSS classes.
+    const groupButton = screen.getByRole("button", { name: /Donor/ });
+    expect(groupButton).toBeInTheDocument();
+    expect(groupButton).toHaveClass(
+      "border-facet-group-button bg-facet-group-button text-facet-group-button"
+    );
+    const buttonIcon = screen.getByTestId("icon-filter");
+    expect(buttonIcon).toBeInTheDocument();
+    expect(buttonIcon).toHaveClass(
+      "[&>g>circle]:fill-none [&>g>circle]:stroke-black [&>g>g]:stroke-black"
+    );
+
+    // Check that the aria-label is correct.
+    expect(groupButton).toHaveAttribute("aria-label", "Donor filter group");
+
+    groupButton.click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a selected facet group button with no selected facet terms", () => {
+    const onClick = jest.fn();
+    const searchResults = {
+      "@id": "/search?type=HumanDonor",
+      filters: [
+        {
+          field: "type",
+          term: "HumanDonor",
+          remove: "/search?sex=female",
+        },
+      ],
+    };
+    const facetGroup = {
+      name: "HumanDonor",
+      title: "Donor",
+      facet_fields: ["life_stage", "sex"],
+    };
+
+    render(
+      <FacetGroupButton
+        searchResults={searchResults}
+        group={facetGroup}
+        isSelected={true}
+        onClick={onClick}
+      />
+    );
+
+    const groupButton = screen.getByRole("button", { name: /Donor/ });
+    expect(groupButton).toBeInTheDocument();
+    expect(groupButton).toHaveClass(
+      "border-facet-group-button-selected bg-facet-group-button-selected text-facet-group-button-selected"
+    );
+    const buttonIcon = screen.getByTestId("icon-filter");
+    expect(buttonIcon).toBeInTheDocument();
+    expect(buttonIcon).toHaveClass(
+      "[&>g>circle]:fill-none [&>g>circle]:stroke-black [&>g>g]:stroke-black"
+    );
+
+    // Check that the aria-label is correct.
+    expect(groupButton).toHaveAttribute(
+      "aria-label",
+      "Donor selected filter group"
+    );
+
+    groupButton.click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a non-selected facet group button with selected facet terms", () => {
+    const onClick = jest.fn();
+    const searchResults = {
+      "@id": "/search?type=HumanDonor&sex=female",
+      filters: [
+        {
+          field: "sex",
+          term: "female",
+          remove: "/search?type=HumanDonor",
+        },
+        {
+          field: "type",
+          term: "HumanDonor",
+          remove: "/search?sex=female",
+        },
+      ],
+    };
+    const facetGroup = {
+      name: "HumanDonor",
+      title: "Donor",
+      facet_fields: ["life_stage", "sex"],
+    };
+
+    render(
+      <FacetGroupButton
+        searchResults={searchResults}
+        group={facetGroup}
+        isSelected={false}
+        onClick={onClick}
+      />
+    );
+
+    const groupButton = screen.getByRole("button", { name: /Donor/ });
+    expect(groupButton).toBeInTheDocument();
+    expect(groupButton).toHaveClass(
+      "border-facet-group-button bg-facet-group-button text-facet-group-button"
+    );
+    const buttonIcon = screen.getByTestId("icon-filter");
+    expect(buttonIcon).toBeInTheDocument();
+    expect(buttonIcon).toHaveClass(
+      "[&>g>circle]:fill-black [&>g>g]:stroke-white"
+    );
+
+    // Check that the aria-label is correct.
+    expect(groupButton).toHaveAttribute("aria-label", "Donor filter group");
+
+    groupButton.click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a selected facet group button with selected facet terms", () => {
+    const onClick = jest.fn();
+    const searchResults = {
+      "@id": "/search?type=HumanDonor&sex=female",
+      filters: [
+        {
+          field: "sex",
+          term: "female",
+          remove: "/search?type=HumanDonor",
+        },
+        {
+          field: "type",
+          term: "HumanDonor",
+          remove: "/search?sex=female",
+        },
+      ],
+    };
+    const facetGroup = {
+      name: "HumanDonor",
+      title: "Donor",
+      facet_fields: ["life_stage", "sex"],
+    };
+
+    render(
+      <FacetGroupButton
+        searchResults={searchResults}
+        group={facetGroup}
+        isSelected={true}
+        onClick={onClick}
+      />
+    );
+
+    const groupButton = screen.getByRole("button", { name: /Donor/ });
+    expect(groupButton).toBeInTheDocument();
+    expect(groupButton).toHaveClass(
+      "border-facet-group-button-selected bg-facet-group-button-selected text-facet-group-button-selected"
+    );
+    const buttonIcon = screen.getByTestId("icon-filter");
+    expect(buttonIcon).toBeInTheDocument();
+    expect(buttonIcon).toHaveClass(
+      "[&>g>circle]:fill-black [&>g>g]:stroke-white"
+    );
+
+    groupButton.click();
+
+    // Check that the aria-label is correct.
+    expect(groupButton).toHaveAttribute(
+      "aria-label",
+      "Donor selected filter group"
+    );
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Test the `getFacetsInGroup()` function", () => {
+  it("returns only the facets in the given group", () => {
+    const searchResults = {
+      "@id": "/search?type=HumanDonor",
+      facets: [
+        {
+          field: "type",
+          title: "Data Type",
+        },
+        {
+          field: "sex",
+          title: "Sex",
+        },
+        {
+          field: "lab.title",
+          title: "Lab",
+        },
+      ],
+    };
+    const facetGroup = {
+      name: "HumanDonor",
+      title: "Donor",
+      facet_fields: ["life_stage", "sex"],
+    };
+
+    const groupFacets = getFacetsInGroup(searchResults, facetGroup);
+    expect(groupFacets.length).toBe(1);
+    expect(groupFacets[0]).toEqual({
+      field: "sex",
+      title: "Sex",
+    });
+  });
+
+  it("returns all facets except 'type' when no group given", () => {
+    const searchResults = {
+      "@id": "/search?type=HumanDonor",
+      facets: [
+        {
+          field: "type",
+          title: "Data Type",
+        },
+        {
+          field: "sex",
+          title: "Sex",
+        },
+        {
+          field: "lab.title",
+          title: "Lab",
+        },
+      ],
+    };
+
+    const groupFacets = getFacetsInGroup(searchResults, null);
+    expect(groupFacets.length).toBe(2);
+    expect(groupFacets[0]).toEqual({
+      field: "sex",
+      title: "Sex",
+    });
+    expect(groupFacets[1]).toEqual({
+      field: "lab.title",
+      title: "Lab",
+    });
+  });
+});
+
+describe("Test the `<FacetGroup>` component", () => {
+  it("renders a single facet group with no selected terms", () => {
+    const searchResults = {
+      "@id": "/search?type=HumanDonor",
+      facets: [
+        {
+          field: "type",
+          title: "Data Type",
+          terms: [
+            {
+              key: "Donor",
+              doc_count: 7,
+            },
+            {
+              key: "HumanDonor",
+              doc_count: 7,
+            },
+          ],
+        },
+        {
+          field: "sex",
+          title: "Sex",
+          terms: [
+            {
+              key: "female",
+              doc_count: 6,
+            },
+            {
+              key: "male",
+              doc_count: 1,
+            },
+          ],
+        },
+        {
+          field: "award.component",
+          title: "Award",
+          terms: [
+            {
+              key: "networks",
+              doc_count: 4,
+            },
+            {
+              key: "data coordination",
+              doc_count: 3,
+            },
+          ],
+        },
+        {
+          field: "lab.title",
+          title: "Lab",
+          terms: [
+            {
+              key: "Chongyuan Luo, UCLA",
+              doc_count: 4,
+            },
+            {
+              key: "J. Michael Cherry, Stanford",
+              doc_count: 3,
+            },
+          ],
+        },
+      ],
+    };
+    const facetGroup = {
+      name: "HumanDonor",
+      title: "Donor",
+      facet_fields: ["lab.title", "sex"],
+    };
+
+    render(<FacetGroup searchResults={searchResults} group={facetGroup} />);
+
+    // Test that two facets get rendered.
+    const facets = screen.getAllByTestId(/^facet-/);
+    expect(facets.length).toBe(2);
+
+    // Check that the facets have the predicted order and correct titles.
+    let facetTitle = within(facets[0]).getByRole("heading", { name: /Sex/ });
+    expect(facetTitle).toBeInTheDocument();
+    facetTitle = within(facets[1]).getByRole("heading", { name: /Lab/ });
+    expect(facetTitle).toBeInTheDocument();
+
+    // Make sure each facet has the correct number of terms.
+    const facetList = within(facets[0]).getByRole("list");
+    const facetTerms = within(facetList).getAllByRole("listitem");
+    expect(facetTerms.length).toBe(2);
+
+    // Check that the first term has the correct label and is not checked.
+    let facetTermCheckbox = within(facetTerms[0]).getByRole("checkbox");
+    expect(facetTermCheckbox).toBeInTheDocument();
+    expect(facetTermCheckbox).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/^female with 6 results$/)
+    );
+    expect(facetTermCheckbox).not.toHaveAttribute("checked");
+
+    // Check that the second term has the correct label and is not checked.
+    facetTermCheckbox = within(facetTerms[1]).getByRole("checkbox");
+    expect(facetTermCheckbox).toBeInTheDocument();
+    expect(facetTermCheckbox).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/^male with 1 result$/)
+    );
+    expect(facetTermCheckbox).not.toHaveAttribute("checked");
+
+    // Make sure clicking a facet term updates the URL.
+    facetTermCheckbox = within(facetTerms[0]).getByRole("checkbox");
+    facetTermCheckbox.click();
+    expect(window.location.search).toBe("?type=HumanDonor&sex=female");
+  });
+
+  it("renders a single facet group with selected terms", () => {
+    const searchResults = {
+      "@id":
+        "/search?type=HumanDonor&sex=female&lab.title=Chongyuan+Luo%2C+UCLA",
+      facets: [
+        {
+          field: "type",
+          title: "Data Type",
+          terms: [
+            {
+              key: "Donor",
+              doc_count: 7,
+            },
+            {
+              key: "HumanDonor",
+              doc_count: 7,
+            },
+          ],
+        },
+        {
+          field: "sex",
+          title: "Sex",
+          terms: [
+            {
+              key: "female",
+              doc_count: 6,
+            },
+            {
+              key: "male",
+              doc_count: 1,
+            },
+          ],
+        },
+        {
+          field: "award.component",
+          title: "Award",
+          terms: [
+            {
+              key: "networks",
+              doc_count: 4,
+            },
+            {
+              key: "data coordination",
+              doc_count: 3,
+            },
+          ],
+        },
+        {
+          field: "lab.title",
+          title: "Lab",
+          terms: [
+            {
+              key: "Chongyuan Luo, UCLA",
+              doc_count: 4,
+            },
+            {
+              key: "J. Michael Cherry, Stanford",
+              doc_count: 3,
+            },
+          ],
+        },
+      ],
+    };
+    const facetGroup = {
+      name: "HumanDonor",
+      title: "Donor",
+      facet_fields: ["lab.title", "sex"],
+    };
+
+    render(<FacetGroup searchResults={searchResults} group={facetGroup} />);
+
+    // Test that two facets get rendered.
+    const facets = screen.getAllByTestId(/^facet-/);
+    expect(facets.length).toBe(2);
+
+    // Check that the facets have the predicted order and correct titles.
+    let facetTitle = within(facets[0]).getByRole("heading", { name: /Sex/ });
+    expect(facetTitle).toBeInTheDocument();
+    facetTitle = within(facets[1]).getByRole("heading", { name: /Lab/ });
+    expect(facetTitle).toBeInTheDocument();
+
+    // Make sure each facet has the correct number of terms.
+    const facetList = within(facets[0]).getByRole("list");
+    const facetTerms = within(facetList).getAllByRole("listitem");
+    expect(facetTerms.length).toBe(2);
+
+    // Check that the first term has the correct label and is not checked.
+    let facetTermCheckbox = within(facetTerms[0]).getByRole("checkbox");
+    expect(facetTermCheckbox).toBeInTheDocument();
+    expect(facetTermCheckbox).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/^female with 6 results$/)
+    );
+    expect(facetTermCheckbox).toHaveAttribute("checked");
+
+    // Check that the second term has the correct label and is not checked.
+    facetTermCheckbox = within(facetTerms[1]).getByRole("checkbox");
+    expect(facetTermCheckbox).toBeInTheDocument();
+    expect(facetTermCheckbox).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/^male with 1 result$/)
+    );
+    expect(facetTermCheckbox).not.toHaveAttribute("checked");
+
+    // Make sure clicking a facet term updates the URL.
+    facetTermCheckbox = within(facetTerms[0]).getByRole("checkbox");
+    facetTermCheckbox.click();
+    expect(window.location.search).toBe(
+      "?type=HumanDonor&lab.title=Chongyuan+Luo%2C+UCLA"
+    );
+  });
+
+  it("renders facets without a group and with selected terms", () => {
+    const searchResults = {
+      "@id": "/search?type=HumanDonor&award.component=networks",
+      facets: [
+        {
+          field: "type",
+          title: "Data Type",
+          terms: [
+            {
+              key: "Donor",
+              doc_count: 7,
+            },
+            {
+              key: "HumanDonor",
+              doc_count: 7,
+            },
+          ],
+        },
+        {
+          field: "sex",
+          title: "Sex",
+          terms: [
+            {
+              key: "female",
+              doc_count: 6,
+            },
+            {
+              key: "male",
+              doc_count: 1,
+            },
+          ],
+        },
+        {
+          field: "award.component",
+          title: "Award",
+          terms: [
+            {
+              key: "networks",
+              doc_count: 4,
+            },
+            {
+              key: "data coordination",
+              doc_count: 3,
+            },
+          ],
+        },
+      ],
+    };
+
+    render(<FacetGroup searchResults={searchResults} />);
+
+    // Test that two facets get rendered -- no "type" facet should ever render.
+    const facets = screen.getAllByTestId(/^facet-/);
+    expect(facets.length).toBe(2);
+
+    // Make sure no facet group buttons exist.
+    const facetGroupButtonSection = screen.queryByTestId(
+      "facet-group-button-section"
+    );
+    expect(facetGroupButtonSection).not.toBeInTheDocument();
+
+    // Check that the facets have the predicted order and correct titles.
+    let facetTitle = within(facets[0]).getByRole("heading", { name: /Sex/ });
+    expect(facetTitle).toBeInTheDocument();
+    facetTitle = within(facets[1]).getByRole("heading", { name: /Award/ });
+    expect(facetTitle).toBeInTheDocument();
+
+    // Make sure each facet has the correct number of terms.
+    let facetList = within(facets[0]).getByRole("list");
+    let facetTerms = within(facetList).getAllByRole("listitem");
+    expect(facetTerms.length).toBe(2);
+    facetList = within(facets[1]).getByRole("list");
+    facetTerms = within(facetList).getAllByRole("listitem");
+    expect(facetTerms.length).toBe(2);
+
+    // Check that the first term of the second facet has the correct label and is checked.
+    let facetTermCheckbox = within(facetTerms[0]).getByRole("checkbox");
+    expect(facetTermCheckbox).toBeInTheDocument();
+    expect(facetTermCheckbox).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/^networks with 4 results$/)
+    );
+    expect(facetTermCheckbox).toHaveAttribute("checked");
+
+    // Check that the second term has the correct label and is not checked.
+    facetTermCheckbox = within(facetTerms[1]).getByRole("checkbox");
+    expect(facetTermCheckbox).toBeInTheDocument();
+    expect(facetTermCheckbox).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/^data coordination with 3 results$/)
+    );
+    expect(facetTermCheckbox).not.toHaveAttribute("checked");
+
+    // Make sure clicking a facet term updates the URL.
+    facetTermCheckbox = within(facetTerms[0]).getByRole("checkbox");
+    facetTermCheckbox.click();
+    expect(window.location.search).toBe("?type=HumanDonor");
+  });
+
+  it("renders facets without a group and with no selected terms", () => {
+    const searchResults = {
+      "@id": "/search?type=HumanDonor",
+      facets: [
+        {
+          field: "type",
+          title: "Data Type",
+          terms: [
+            {
+              key: "Donor",
+              doc_count: 7,
+            },
+            {
+              key: "HumanDonor",
+              doc_count: 7,
+            },
+          ],
+        },
+        {
+          field: "sex",
+          title: "Sex",
+          terms: [
+            {
+              key: "female",
+              doc_count: 6,
+            },
+            {
+              key: "male",
+              doc_count: 1,
+            },
+          ],
+        },
+        {
+          field: "award.component",
+          title: "Award",
+          terms: [
+            {
+              key: "networks",
+              doc_count: 4,
+            },
+            {
+              key: "data coordination",
+              doc_count: 3,
+            },
+          ],
+        },
+      ],
+    };
+
+    render(<FacetGroup searchResults={searchResults} />);
+
+    // Test that two facets get rendered -- no "type" facet should ever render.
+    const facets = screen.getAllByTestId(/^facet-/);
+    expect(facets.length).toBe(2);
+
+    // Make sure no facet group buttons exist.
+    const facetGroupButtonSection = screen.queryByTestId(
+      "facet-group-button-section"
+    );
+    expect(facetGroupButtonSection).not.toBeInTheDocument();
+
+    // Check that the facets have the predicted order and correct titles.
+    let facetTitle = within(facets[0]).getByRole("heading", { name: /Sex/ });
+    expect(facetTitle).toBeInTheDocument();
+    facetTitle = within(facets[1]).getByRole("heading", { name: /Award/ });
+    expect(facetTitle).toBeInTheDocument();
+
+    // Make sure each facet has the correct number of terms.
+    const facetList = within(facets[0]).getByRole("list");
+    const facetTerms = within(facetList).getAllByRole("listitem");
+    expect(facetTerms.length).toBe(2);
+
+    // Check that the first term has the correct label and is not checked.
+    let facetTermCheckbox = within(facetTerms[0]).getByRole("checkbox");
+    expect(facetTermCheckbox).toBeInTheDocument();
+    expect(facetTermCheckbox).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/^female with 6 results$/)
+    );
+    expect(facetTermCheckbox).not.toHaveAttribute("checked");
+
+    // Check that the second term has the correct label and is not checked.
+    facetTermCheckbox = within(facetTerms[1]).getByRole("checkbox");
+    expect(facetTermCheckbox).toBeInTheDocument();
+    expect(facetTermCheckbox).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/^male with 1 result$/)
+    );
+    expect(facetTermCheckbox).not.toHaveAttribute("checked");
+
+    // Make sure clicking a facet term updates the URL.
+    facetTermCheckbox = within(facetTerms[0]).getByRole("checkbox");
+    facetTermCheckbox.click();
+    expect(window.location.search).toBe("?type=HumanDonor&sex=female");
+  });
+});

--- a/components/facets/__tests__/facet-section.test.js
+++ b/components/facets/__tests__/facet-section.test.js
@@ -1,0 +1,380 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import FacetSection from "../facet-section";
+
+jest.mock("next/router", () => {
+  // Mock the window.location object so we can test the router.push() function.
+  const location = new URL("https://www.example.com");
+  location.assign = jest.fn();
+  location.replace = jest.fn();
+  location.reload = jest.fn();
+  delete window.location;
+  window.location = location;
+
+  return {
+    useRouter() {
+      return {
+        route: "/",
+        pathname: "",
+        query: "",
+        asPath: "",
+        push: jest.fn().mockImplementation((href) => {
+          window.location.href = `https://www.example.com${href}`;
+        }),
+      };
+    },
+  };
+});
+
+describe("Test <FacetSection> component", () => {
+  it("renders the correct facets without facet groups", () => {
+    const searchResults = {
+      "@id": "/search?type=Gene",
+      facet_groups: [],
+      facets: [
+        {
+          field: "type",
+          title: "Data Type",
+          terms: [
+            {
+              key: "Gene",
+              doc_count: 7,
+            },
+          ],
+          total: 7,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "taxa",
+          title: "Taxa",
+          terms: [
+            {
+              key: "Homo sapiens",
+              doc_count: 5,
+            },
+            {
+              key: "Mus musculus",
+              doc_count: 2,
+            },
+          ],
+          total: 7,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "status",
+          title: "Status",
+          terms: [
+            {
+              key: "released",
+              doc_count: 7,
+            },
+          ],
+          total: 7,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+      ],
+      filters: [
+        {
+          field: "type",
+          term: "Gene",
+          remove: "/search",
+        },
+      ],
+    };
+
+    render(<FacetSection searchResults={searchResults} />);
+
+    // Check for no facet group buttons.
+    const facetGroupButtonSection = screen.queryByTestId("facet-group-buttons");
+    expect(facetGroupButtonSection).toBeNull();
+
+    // Check for the correct number of facets.
+    const facetSections = screen.getAllByTestId(/^facet-/);
+    expect(facetSections).toHaveLength(2);
+
+    // Make sure the first facet has the correct title.
+    const facetTitle = within(facetSections[0]).getByRole("heading", {
+      name: /^Taxa$/,
+    });
+    expect(facetTitle).toBeInTheDocument();
+
+    // Make sure the first facet has the correct terms.
+    let terms = within(facetSections[0]).getAllByTestId(/^facetterm-/);
+    expect(terms).toHaveLength(2);
+    expect(terms[0]).toHaveTextContent(/^Homo sapiens/);
+    expect(terms[0]).toHaveTextContent(/5$/);
+    expect(terms[1]).toHaveTextContent(/^Mus musculus/);
+    expect(terms[1]).toHaveTextContent(/2$/);
+
+    // Make sure the second facet has the correct terms.
+    terms = within(facetSections[1]).getAllByTestId(/^facetterm-/);
+    expect(terms).toHaveLength(1);
+    expect(terms[0]).toHaveTextContent(/^released/);
+    expect(terms[0]).toHaveTextContent(/7$/);
+  });
+
+  it("renders the correct facets with facet groups", () => {
+    const searchResults = {
+      "@id": "/search?type=AssayTerm",
+      facet_groups: [
+        {
+          name: "AssayTerm",
+          title: "Assay",
+          facet_fields: ["assay_slims", "category_slims", "objective_slims"],
+        },
+        {
+          name: "AssayTerm",
+          title: "Quality",
+          facet_fields: ["status"],
+        },
+      ],
+      facets: [
+        {
+          field: "type",
+          title: "Data Type",
+          terms: [
+            {
+              key: "AssayTerm",
+              doc_count: 7,
+            },
+            {
+              key: "OntologyTerm",
+              doc_count: 7,
+            },
+          ],
+          total: 7,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "assay_slims",
+          title: "Assay Type",
+          terms: [
+            {
+              key: "Massively parallel reporter assay",
+              doc_count: 2,
+            },
+            {
+              key: "DNA binding",
+              doc_count: 1,
+            },
+          ],
+          total: 7,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "status",
+          title: "Status",
+          terms: [
+            {
+              key: "released",
+              doc_count: 7,
+            },
+          ],
+          total: 7,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+      ],
+      filters: [
+        {
+          field: "type",
+          term: "Gene",
+          remove: "/search",
+        },
+      ],
+    };
+
+    render(<FacetSection searchResults={searchResults} />);
+
+    // Check for the correct number facet group buttons.
+    const facetGroupButtonSection =
+      screen.queryByTestId(/^facetgroup-buttons$/);
+    expect(facetGroupButtonSection).toBeInTheDocument();
+    const facetGroupButtons = within(facetGroupButtonSection).getAllByRole(
+      "button"
+    );
+    expect(facetGroupButtons).toHaveLength(2);
+
+    // Check for the correct number of facets.
+    const facetSections = screen.getAllByTestId(/^facet-/);
+    expect(facetSections).toHaveLength(1);
+
+    // Make sure the first facet has the correct title.
+    const facetTitle = within(facetSections[0]).getByRole("heading", {
+      name: /^Assay Type$/,
+    });
+    expect(facetTitle).toBeInTheDocument();
+
+    // Make sure the first facet has the correct terms.
+    let terms = within(facetSections[0]).getAllByTestId(/^facetterm-/);
+    expect(terms).toHaveLength(2);
+    expect(terms[0]).toHaveTextContent(/^Massively parallel reporter assay/);
+    expect(terms[0]).toHaveTextContent(/2$/);
+    expect(terms[1]).toHaveTextContent(/^DNA binding/);
+    expect(terms[1]).toHaveTextContent(/1$/);
+
+    // Make sure the Status facet doesn't exist because its group isn't selected.
+    const statusFacet = screen.queryByTestId(/^facettitle-status$/);
+    expect(statusFacet).toBeNull();
+  });
+
+  it("renders no facets if only a type facet exists", () => {
+    const searchResults = {
+      "@id": "/search?type=Gene",
+      facet_groups: [],
+      facets: [
+        {
+          field: "type",
+          title: "Data Type",
+          terms: [
+            {
+              key: "Gene",
+              doc_count: 7,
+            },
+          ],
+          total: 7,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+      ],
+      filters: [
+        {
+          field: "type",
+          term: "Gene",
+          remove: "/search",
+        },
+      ],
+    };
+
+    render(<FacetSection searchResults={searchResults} />);
+
+    // Check for no facet group buttons.
+    const facetGroupButtonSection = screen.queryByTestId("facet-group-buttons");
+    expect(facetGroupButtonSection).toBeNull();
+
+    // Check for no facets.
+    const facetSections = screen.queryAllByTestId(/^facet-/);
+    expect(facetSections).toHaveLength(0);
+  });
+
+  it("selects the correct facet group when clicking one", () => {
+    const searchResults = {
+      "@id": "/search?type=AssayTerm",
+      facet_groups: [
+        {
+          name: "AssayTerm",
+          title: "Assay",
+          facet_fields: ["assay_slims"],
+        },
+        {
+          name: "AssayTerm",
+          title: "Quality",
+          facet_fields: ["status"],
+        },
+      ],
+      facets: [
+        {
+          field: "type",
+          title: "Data Type",
+          terms: [
+            {
+              key: "AssayTerm",
+              doc_count: 7,
+            },
+            {
+              key: "OntologyTerm",
+              doc_count: 7,
+            },
+          ],
+          total: 7,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "assay_slims",
+          title: "Assay Type",
+          terms: [
+            {
+              key: "Massively parallel reporter assay",
+              doc_count: 2,
+            },
+            {
+              key: "DNA binding",
+              doc_count: 1,
+            },
+          ],
+          total: 7,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "status",
+          title: "Status",
+          terms: [
+            {
+              key: "released",
+              doc_count: 7,
+            },
+          ],
+          total: 7,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+      ],
+      filters: [
+        {
+          field: "type",
+          term: "Gene",
+          remove: "/search",
+        },
+      ],
+    };
+
+    render(<FacetSection searchResults={searchResults} />);
+
+    // Check for the correct number facet group buttons.
+    const facetGroupButtonSection =
+      screen.queryByTestId(/^facetgroup-buttons$/);
+    const facetGroupButtons = within(facetGroupButtonSection).getAllByRole(
+      "button"
+    );
+    expect(facetGroupButtons).toHaveLength(2);
+
+    // Check that the first button has an aria label indicating it's selected and the second button
+    // has an aria label indicating it's not.
+    expect(facetGroupButtons[0]).toHaveAttribute(
+      "aria-label",
+      "Assay selected filter group"
+    );
+    expect(facetGroupButtons[1]).toHaveAttribute(
+      "aria-label",
+      "Quality filter group"
+    );
+
+    // Click the second button and check that its new aria label indicates it's selected and the
+    // first button's aria label indicates it's not.
+    fireEvent.click(facetGroupButtons[1]);
+    expect(facetGroupButtons[0]).toHaveAttribute(
+      "aria-label",
+      "Assay filter group"
+    );
+    expect(facetGroupButtons[1]).toHaveAttribute(
+      "aria-label",
+      "Quality selected filter group"
+    );
+  });
+});

--- a/components/facets/__tests__/facet-tags.test.js
+++ b/components/facets/__tests__/facet-tags.test.js
@@ -1,0 +1,298 @@
+import { render, screen, within } from "@testing-library/react";
+import FacetTags from "../facet-tags";
+
+describe("Test the <FacetTags> component", () => {
+  it("renders the correct number of tags for the given search results", () => {
+    const searchResults = {
+      "@id":
+        "/search?type=Publication&published_by=ENCODE&award.component=data+coordination",
+      facets: [
+        {
+          field: "type",
+          title: "Data Type",
+          terms: [
+            {
+              key: "Publication",
+              doc_count: 1,
+            },
+          ],
+          total: 1,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "published_by",
+          title: "Published By",
+          terms: [
+            {
+              key: "ENCODE",
+              doc_count: 1,
+            },
+          ],
+          total: 1,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "lab.title",
+          title: "Lab",
+          terms: [
+            {
+              key: "J. Michael Cherry, Stanford",
+              doc_count: 1,
+            },
+          ],
+          total: 1,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "award.component",
+          title: "Award",
+          terms: [
+            {
+              key: "data coordination",
+              doc_count: 1,
+            },
+          ],
+          total: 1,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "status",
+          title: "Status",
+          terms: [
+            {
+              key: "released",
+              doc_count: 1,
+            },
+          ],
+          total: 1,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+      ],
+      filters: [
+        {
+          field: "published_by",
+          term: "ENCODE",
+          remove: "/search?type=Publication&award.component=data+coordination",
+        },
+        {
+          field: "award.component",
+          term: "data coordination",
+          remove: "/search?type=Publication&published_by=ENCODE",
+        },
+        {
+          field: "type",
+          term: "Publication",
+          remove:
+            "/search?published_by=ENCODE&award.component=data+coordination",
+        },
+      ],
+    };
+
+    render(<FacetTags searchResults={searchResults} />);
+
+    // Make sure the correct number of tags are rendered and they have the correct content.
+    const tagSection = screen.getByTestId("facettags");
+    const tags = within(tagSection).getAllByRole("link");
+    expect(tags.length).toBe(2);
+    expect(tags[0]).toHaveTextContent(/^Published By/);
+    expect(tags[0]).toHaveTextContent(/ENCODE$/);
+    expect(tags[1]).toHaveTextContent(/^Award/);
+    expect(tags[1]).toHaveTextContent(/data coordination$/);
+  });
+
+  it("renders no tags if only the 'type' filter exists", () => {
+    const searchResults = {
+      "@id": "/search?type=Publication",
+      facets: [
+        {
+          field: "type",
+          title: "Data Type",
+          terms: [
+            {
+              key: "Publication",
+              doc_count: 1,
+            },
+          ],
+          total: 1,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "published_by",
+          title: "Published By",
+          terms: [
+            {
+              key: "ENCODE",
+              doc_count: 1,
+            },
+          ],
+          total: 1,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "lab.title",
+          title: "Lab",
+          terms: [
+            {
+              key: "J. Michael Cherry, Stanford",
+              doc_count: 1,
+            },
+          ],
+          total: 1,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "award.component",
+          title: "Award",
+          terms: [
+            {
+              key: "data coordination",
+              doc_count: 1,
+            },
+          ],
+          total: 1,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "status",
+          title: "Status",
+          terms: [
+            {
+              key: "released",
+              doc_count: 1,
+            },
+          ],
+          total: 1,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+      ],
+      filters: [
+        {
+          field: "type",
+          term: "Publication",
+          remove:
+            "/search?published_by=ENCODE&award.component=data+coordination",
+        },
+      ],
+    };
+
+    render(<FacetTags searchResults={searchResults} />);
+
+    // Make sure no tags get rendered.
+    const tagSection = screen.queryByTestId("facettags");
+    expect(tagSection).toBeNull();
+  });
+
+  it("renders the filter field instead of the facet title if that odd case occurs", () => {
+    const searchResults = {
+      "@id":
+        "/search?type=Publication&published_by=ENCODE&award.component=data+coordination",
+      facets: [
+        {
+          field: "type",
+          title: "Data Type",
+          terms: [
+            {
+              key: "Publication",
+              doc_count: 1,
+            },
+          ],
+          total: 1,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "lab.title",
+          title: "Lab",
+          terms: [
+            {
+              key: "J. Michael Cherry, Stanford",
+              doc_count: 1,
+            },
+          ],
+          total: 1,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "award.component",
+          title: "Award",
+          terms: [
+            {
+              key: "data coordination",
+              doc_count: 1,
+            },
+          ],
+          total: 1,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+        {
+          field: "status",
+          title: "Status",
+          terms: [
+            {
+              key: "released",
+              doc_count: 1,
+            },
+          ],
+          total: 1,
+          type: "terms",
+          appended: false,
+          open_on_load: false,
+        },
+      ],
+      filters: [
+        {
+          field: "published_by",
+          term: "ENCODE",
+          remove: "/search?type=Publication&award.component=data+coordination",
+        },
+        {
+          field: "award.component",
+          term: "data coordination",
+          remove: "/search?type=Publication&published_by=ENCODE",
+        },
+        {
+          field: "type",
+          term: "Publication",
+          remove:
+            "/search?published_by=ENCODE&award.component=data+coordination",
+        },
+      ],
+    };
+
+    render(<FacetTags searchResults={searchResults} />);
+
+    // Make sure the correct number of tags are rendered and they have the correct content.
+    const tagSection = screen.getByTestId("facettags");
+    const tags = within(tagSection).getAllByRole("link");
+    expect(tags.length).toBe(2);
+    expect(tags[0]).toHaveTextContent(/^published_by/);
+    expect(tags[0]).toHaveTextContent(/ENCODE$/);
+    expect(tags[1]).toHaveTextContent(/^Award/);
+    expect(tags[1]).toHaveTextContent(/data coordination$/);
+  });
+});

--- a/components/facets/__tests__/facet-term.test.js
+++ b/components/facets/__tests__/facet-term.test.js
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import FacetTerm from "../facet-term";
+
+describe("Test the <FacetTerms> component", () => {
+  it("renders an unchecked facet term with a result count of 1", () => {
+    const term = {
+      doc_count: 1,
+      key: "Massively parallel reporter assay",
+    };
+    const onClick = jest.fn();
+
+    render(
+      <FacetTerm
+        field="assay_slims"
+        term={term}
+        isChecked={false}
+        onClick={onClick}
+      />
+    );
+
+    const facetTerm = screen.getByTestId(`facetterm-${term.key}`);
+    expect(facetTerm).toBeInTheDocument();
+    const label = within(facetTerm).getByLabelText(
+      `${term.key} with ${term.doc_count} result`
+    );
+    expect(label).toBeInTheDocument();
+    const resultCount = within(facetTerm).getByText(term.doc_count);
+    expect(resultCount).toBeInTheDocument();
+    const checkbox = within(facetTerm).getByRole("checkbox");
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).not.toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a checked facet term with a result count greater than 1", () => {
+    const term = {
+      doc_count: 2,
+      key: "Massively parallel reporter assay",
+    };
+    const onClick = jest.fn();
+
+    render(
+      <FacetTerm
+        field="assay_slims"
+        term={term}
+        isChecked={true}
+        onClick={onClick}
+      />
+    );
+
+    const facetTerm = screen.getByTestId(`facetterm-${term.key}`);
+    expect(facetTerm).toBeInTheDocument();
+    const label = within(facetTerm).getByLabelText(
+      `${term.key} with ${term.doc_count} results`
+    );
+    expect(label).toBeInTheDocument();
+    const resultCount = within(facetTerm).getByText(term.doc_count);
+    expect(resultCount).toBeInTheDocument();
+    const checkbox = within(facetTerm).getByRole("checkbox");
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/facets/__tests__/facet.test.js
+++ b/components/facets/__tests__/facet.test.js
@@ -1,0 +1,59 @@
+import { render, screen, within } from "@testing-library/react";
+import Facet from "../facet";
+import FacetTerm from "../facet-term";
+
+describe("Test the <Facet> component", () => {
+  it("renders a single facet and its child terms", () => {
+    const onTermClick = jest.fn();
+
+    const facet = {
+      field: "treatments.treatment_term_name",
+      title: "Treatments",
+      terms: [
+        {
+          key: "new compound",
+          doc_count: 1,
+        },
+        {
+          key: "resorcinol",
+          doc_count: 1,
+        },
+      ],
+    };
+
+    render(
+      <Facet key={facet.field} facet={facet}>
+        {facet.terms.map((term) => {
+          return (
+            <FacetTerm
+              key={term.key}
+              field={facet.field}
+              term={term}
+              isChecked={term.key === "resorcinol" ? true : false}
+              onClick={onTermClick}
+            />
+          );
+        })}
+      </Facet>
+    );
+
+    // Make sure the facet title has the correct contents.
+    expect(screen.getByTestId(`facettitle-${facet.field}`)).toHaveTextContent(
+      facet.title
+    );
+
+    // Make sure the facet has the correct number of terms and the correct contents.
+    const terms = screen.getAllByTestId(/^facetterm-/);
+    expect(terms).toHaveLength(facet.terms.length);
+    expect(terms[0]).toHaveTextContent(facet.terms[0].key);
+    expect(terms[0]).toHaveTextContent(facet.terms[0].doc_count);
+    expect(terms[1]).toHaveTextContent(facet.terms[1].key);
+    expect(terms[1]).toHaveTextContent(facet.terms[1].doc_count);
+
+    // Make sure the second term is checked.
+    let checkbox = within(terms[0]).getByRole("checkbox");
+    expect(checkbox).not.toHaveAttribute("checked");
+    checkbox = within(terms[1]).getByRole("checkbox");
+    expect(checkbox).toHaveAttribute("checked");
+  });
+});

--- a/components/facets/facet-groups.js
+++ b/components/facets/facet-groups.js
@@ -1,0 +1,167 @@
+// node_modules
+import { useRouter } from "next/router";
+import PropTypes from "prop-types";
+// components/facets
+import FacetTerm from "./facet-term";
+import Facet from "./facet";
+// components
+import Icon from "../icon";
+// lib
+import QueryString from "../../lib/query-string";
+import { splitPathAndQueryString } from "../../lib/query-utils";
+
+/**
+ * Get the currently selected facet terms that exist in the given facet group.
+ * @param {object} searchResults Search results from data provider
+ * @param {object} facetGroup Facet group to check filters against
+ * @returns {array} Array of facet fields that have selected terms
+ */
+function getSelectedFacetTermsInGroup(searchResults, facetGroup) {
+  return facetGroup.facet_fields.filter((facetField) =>
+    searchResults.filters.find((filter) => filter.field === facetField)
+  );
+}
+
+/**
+ * Get all facets in the search results that are in the given facet group. If no facet group is
+ * specified, return all facets except for the "type" facet.
+ * @param {object} searchResults Search results from data provider
+ * @param {object} facetGroup Group of facets to get existing facets from
+ * @returns {array} Facet objects in the group that exist in the search results
+ */
+export function getFacetsInGroup(searchResults, facetGroup) {
+  if (facetGroup) {
+    return searchResults.facets.filter((facet) =>
+      facetGroup.facet_fields.includes(facet.field)
+    );
+  }
+  return searchResults.facets.filter((facet) => facet.field !== "type");
+}
+
+/**
+ * Display the filtering icon for facet group buttons. The icon appears filled if
+ * `areFacetTermsSelected` evaluates true, and empty if false.
+ */
+function FacetGroupButtonIcon({ areFacetTermsSelected }) {
+  const className = areFacetTermsSelected
+    ? "[&>g>circle]:fill-black [&>g>g]:stroke-white"
+    : "[&>g>circle]:fill-none [&>g>circle]:stroke-black [&>g>g]:stroke-black";
+
+  return <Icon.Filter className={`h-4 w-4 ${className}`} />;
+}
+
+FacetGroupButtonIcon.propTypes = {
+  // True if selected facets exist in the group
+  areFacetTermsSelected: PropTypes.bool.isRequired,
+};
+
+const facetGroupButtonClasses = {
+  selected:
+    "border-facet-group-button-selected bg-facet-group-button-selected text-facet-group-button-selected",
+  unselected:
+    "border-facet-group-button bg-facet-group-button text-facet-group-button",
+};
+
+/**
+ * Displays the button for the specified facet group, and calls the parent when the user clicks
+ * this button. The specified group might be the conjured "All" group, which contains all facets
+ * in the search results for objects that have no defined facet groups in its config.
+ */
+export function FacetGroupButton({
+  searchResults,
+  group,
+  isSelected,
+  onClick,
+}) {
+  const facetsInGroup = getSelectedFacetTermsInGroup(searchResults, group);
+  const buttonClasses = isSelected
+    ? facetGroupButtonClasses.selected
+    : facetGroupButtonClasses.unselected;
+
+  return (
+    <button
+      onClick={() => onClick(group)}
+      className={`${buttonClasses} flex grow basis-[calc(50%-0.125rem)] items-center justify-between self-start rounded border px-2 py-1 text-left`}
+      aria-label={`${group.title}${isSelected ? " selected" : ""} filter group`}
+    >
+      {group.title}
+      <FacetGroupButtonIcon areFacetTermsSelected={facetsInGroup.length > 0} />
+    </button>
+  );
+}
+
+FacetGroupButton.propTypes = {
+  // Search results from the data provider
+  searchResults: PropTypes.object.isRequired,
+  // facet_group object from the config for this button
+  group: PropTypes.object.isRequired,
+  // True if the group is selected
+  isSelected: PropTypes.bool.isRequired,
+  // Tells the parent component to select this group and show its child facets
+  onClick: PropTypes.func.isRequired,
+};
+
+/**
+ * Displays all the facets within a facet group. It also handles the user clicking on a facet
+ * term to add or remove it from the search query, and navigates to the URL with the updated query
+ * string.
+ */
+export function FacetGroup({ searchResults, group = null }) {
+  const router = useRouter();
+
+  // Generate a query based on the current URL to update once the user clicks a facet term.
+  const { path, queryString } = splitPathAndQueryString(searchResults["@id"]);
+  const query = new QueryString(queryString);
+
+  // Get all the facet objects from the search results that are in the facet group.
+  const facetsInGroup = getFacetsInGroup(searchResults, group);
+
+  /**
+   * When the user clicks a facet term, add or remove it from the query string and navigate
+   * to the new URL.
+   * @param {string} field Field of the facet that the user clicked a term within
+   * @param {string} term Term that the user clicked within a facet
+   */
+  function onTermClick(field, term) {
+    const matchingTerms = query.getKeyValues(field);
+    if (matchingTerms.includes(term.key)) {
+      query.deleteKeyValue(field, term.key);
+    } else {
+      query.addKeyValue(field, term.key);
+    }
+    router.push(`${path}?${query.format()}`);
+  }
+
+  return (
+    <>
+      {facetsInGroup.map((facet) => {
+        // Find the facet object in the search results that matches the facet field in the facet
+        // group.
+        const fieldTerms = query.getKeyValues(facet.field);
+        return (
+          <Facet key={facet.field} facet={facet}>
+            {facet.terms.map((term) => {
+              const isChecked = fieldTerms.includes(term.key);
+              return (
+                <FacetTerm
+                  key={term.key}
+                  field={facet.field}
+                  term={term}
+                  isChecked={isChecked}
+                  onClick={onTermClick}
+                />
+              );
+            })}
+          </Facet>
+        );
+      })}
+    </>
+  );
+}
+
+FacetGroup.propTypes = {
+  // Search results from data provider
+  searchResults: PropTypes.object.isRequired,
+  // Facet group to display because the user selected it
+  group: PropTypes.object,
+};

--- a/components/facets/facet-section.js
+++ b/components/facets/facet-section.js
@@ -1,0 +1,66 @@
+// node_modules
+import PropTypes from "prop-types";
+import { useState } from "react";
+// components/facets
+import { FacetGroup, FacetGroupButton, getFacetsInGroup } from "./facet-groups";
+// components
+import { DataPanel } from "../../components/data-area";
+// lib
+import { getVisibleFacets } from "../../lib/facets";
+
+/**
+ * Display the facet area that contains the buttons for the facet groups. If the user clicks a
+ * facet-group button, display the modal containing the facets for that group.
+ */
+export default function FacetSection({ searchResults }) {
+  // Get the facet groups, or build a fake one containing all the facets if the search results
+  // have no facet groups.
+  const facetGroups =
+    searchResults.facet_groups.length > 0 ? searchResults.facet_groups : [];
+
+  // Filter out facet groups that have no facets.
+  const facetGroupsWithFacets = facetGroups.filter((facetGroup) => {
+    const facetsInGroup = getFacetsInGroup(searchResults, facetGroup);
+    return facetsInGroup.length > 0;
+  });
+
+  // Facet group selected by the user clicking on its button, bringing up the facets for that group.
+  const [selectedGroup, setSelectedGroup] = useState(facetGroupsWithFacets[0]);
+
+  // Determine if we shouldn't show the facet groups at all. This is the case when there are no
+  // facet groups, and the search results have no displayable facets.
+  const visibleFacets = getVisibleFacets(searchResults.facets);
+  if (visibleFacets.length > 0) {
+    return (
+      <DataPanel className="mb-4 lg:mb-0 lg:w-72 lg:shrink-0 lg:grow-0 lg:overflow-y-auto">
+        {facetGroupsWithFacets.length > 0 && (
+          <div
+            className="flex flex-wrap content-start gap-0.5 text-sm font-semibold"
+            data-testid="facetgroup-buttons"
+          >
+            {facetGroupsWithFacets.map((facetGroup) => {
+              return (
+                <FacetGroupButton
+                  key={facetGroup.title}
+                  searchResults={searchResults}
+                  group={facetGroup}
+                  isSelected={facetGroup.title === selectedGroup?.title}
+                  onClick={(group) => setSelectedGroup(group)}
+                />
+              );
+            })}
+          </div>
+        )}
+        <FacetGroup searchResults={searchResults} group={selectedGroup} />
+      </DataPanel>
+    );
+  }
+
+  // No displayable facets.
+  return null;
+}
+
+FacetSection.propTypes = {
+  // Search results from data provider
+  searchResults: PropTypes.object.isRequired,
+};

--- a/components/facets/facet-tags.js
+++ b/components/facets/facet-tags.js
@@ -1,0 +1,83 @@
+// node_modules
+import { XMarkIcon } from "@heroicons/react/20/solid";
+import Link from "next/link";
+import PropTypes from "prop-types";
+// lib
+import { getVisibleFacets } from "../../lib/facets";
+
+/**
+ * Facet tags show a list of the currently selected facet terms. Clicking each tag clears that facet
+ * term from the query string. This acts as a shortcut to removing the facet terms using the facet
+ * modals.
+ */
+
+/**
+ * Display a single facet tag specified by the `filter` object of the relevant facet term copied
+ * from the search-results object.
+ */
+function FacetTag({ filter, facets }) {
+  const facetForFilter = facets.find((facet) => facet.field === filter.field);
+  const title = facetForFilter ? facetForFilter.title : filter.field;
+
+  return (
+    <Link
+      href={filter.remove}
+      className="flex items-center rounded border border-emerald-400 bg-emerald-200 py-0.5 pl-1 pr-0 text-gray-700 no-underline dark:border-emerald-600 dark:bg-emerald-900 dark:text-gray-200"
+      aria-label={`Clear ${title} filter for ${filter.term}`}
+      key={filter.field}
+    >
+      <div>
+        <div className="text-xs leading-4">{title}</div>
+        <div className="text-sm font-semibold leading-4">{filter.term}</div>
+      </div>
+      <XMarkIcon className="ml-2 block h-4 w-4" />
+    </Link>
+  );
+}
+
+FacetTag.propTypes = {
+  // Filter object from search results
+  filter: PropTypes.shape({
+    // Object property the filter represents
+    field: PropTypes.string.isRequired,
+    // Value of the object property
+    term: PropTypes.string.isRequired,
+    // URI to remove this filter from the query string
+    remove: PropTypes.string.isRequired,
+  }).isRequired,
+  // `facets` property from search results
+  facets: PropTypes.arrayOf(PropTypes.shape({ field: PropTypes.string }))
+    .isRequired,
+};
+
+/**
+ * Displays a list of tags showing the currently selected facets. Clicking each tag clears that
+ * facet term from the query string. This acts as a shortcut to removing the facet terms using the
+ * facet modals.
+ */
+export default function FacetTags({ searchResults }) {
+  // All selected facet terms appear in the `filters` property of the search results except for the
+  // hidden facet fields.
+  const removableFilters = getVisibleFacets(searchResults.filters);
+  if (removableFilters.length > 0) {
+    return (
+      <div className="mb-2 flex flex-wrap gap-1" data-testid="facettags">
+        {removableFilters.map((filter) => (
+          <FacetTag
+            filter={filter}
+            facets={searchResults.facets}
+            key={`${filter.field}-${filter.term}`}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  // No selected facet terms, so display no facet tags.
+  return null;
+}
+
+FacetTags.propTypes = {
+  // Search results from data provider
+  searchResults: PropTypes.object.isRequired,
+};

--- a/components/facets/facet-term.js
+++ b/components/facets/facet-term.js
@@ -1,0 +1,41 @@
+// node_modules
+import PropTypes from "prop-types";
+// components
+import Checkbox from "../checkbox";
+
+/**
+ * Display a single term in a facet with a checkbox.
+ */
+export default function FacetTerm({ field, term, isChecked, onClick }) {
+  return (
+    <li data-testid={`facetterm-${term.key}`}>
+      <Checkbox
+        checked={isChecked}
+        name={`${term.key} with ${term.doc_count} result${
+          term.doc_count > 1 ? "s" : ""
+        }`}
+        onChange={() => onClick(field, term)}
+        className="cursor-pointer rounded border border-transparent px-2 py-1 hover:border-data-border"
+      >
+        <div className="flex grow items-center justify-between gap-2 text-sm font-normal leading-[1.1]">
+          <div>{term.key}</div>
+          <div>{term.doc_count}</div>
+        </div>
+      </Checkbox>
+    </li>
+  );
+}
+
+FacetTerm.propTypes = {
+  // Facet field the term belongs to
+  field: PropTypes.string.isRequired,
+  // Term to display in the checkbox
+  term: PropTypes.shape({
+    key: PropTypes.string.isRequired,
+    doc_count: PropTypes.number.isRequired,
+  }).isRequired,
+  // True if the checkbox is checked
+  isChecked: PropTypes.bool.isRequired,
+  // Called when the checkbox is checked or unchecked
+  onClick: PropTypes.func.isRequired,
+};

--- a/components/facets/facet.js
+++ b/components/facets/facet.js
@@ -1,0 +1,37 @@
+// node_Modules
+import PropTypes from "prop-types";
+
+/**
+ * Displays a single facet with its title and terms.
+ */
+export default function Facet({ facet, children }) {
+  return (
+    <div
+      key={facet.field}
+      className="my-4 first:mt-0 last:mb-0"
+      data-testid={`facet-${facet.field}`}
+    >
+      <h2
+        className="mb-1 bg-facet-title text-center text-base font-medium text-facet-title"
+        data-testid={`facettitle-${facet.field}`}
+      >
+        {facet.title}
+      </h2>
+      <ul>{children}</ul>
+    </div>
+  );
+}
+
+Facet.propTypes = {
+  // Facet object from search results
+  facet: PropTypes.shape({
+    field: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    terms: PropTypes.arrayOf(
+      PropTypes.shape({
+        key: PropTypes.string.isRequired,
+        doc_count: PropTypes.number.isRequired,
+      })
+    ).isRequired,
+  }).isRequired,
+};

--- a/components/facets/index.js
+++ b/components/facets/index.js
@@ -1,0 +1,5 @@
+import FacetSection from "./facet-section";
+import FacetTags from "./facet-tags";
+
+export { FacetSection, FacetTags };
+/* istanbul ignore file */

--- a/components/icon.js
+++ b/components/icon.js
@@ -68,6 +68,24 @@ const Icon = {
       />
     </svg>
   ),
+  Filter: ({ className = null, testid = "icon-filter" }) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      data-testid={testid}
+    >
+      <g className="stroke-[1.5]">
+        <circle cx="10" cy="10" r="9.2" />
+        <g style={{ strokeLinecap: "round" }}>
+          <line x1="5.4" y1="8.1" x2="14.6" y2="8.1" />
+          <line x1="7" y1="10.6" x2="13" y2="10.6" />
+          <line x1="8.1" y1="13.2" x2="11.9" y2="13.2" />
+        </g>
+      </g>
+    </svg>
+  ),
   Gene: ({ className = null, testid = "icon-gene" }) => (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -191,6 +209,10 @@ Icon.Donor.propTypes = {
   testid: PropTypes.string,
 };
 Icon.FileSet.propTypes = {
+  className: PropTypes.string,
+  testid: PropTypes.string,
+};
+Icon.Filter.propTypes = {
   className: PropTypes.string,
   testid: PropTypes.string,
 };

--- a/components/modal.js
+++ b/components/modal.js
@@ -92,7 +92,7 @@ function Header({
   if (Children.count(children) === 1) {
     const childrenArray = Children.toArray(children);
     const firstChildType = typeof childrenArray[0];
-    if (firstChildType === "string" || firstChildType === "number") {
+    if (firstChildType === "string") {
       // `children` comprises a single string or number, so wrap it in an <h2>.
       headerChildren = <h2 className="text-lg font-semibold">{children}</h2>;
     }

--- a/components/navigation.js
+++ b/components/navigation.js
@@ -671,8 +671,8 @@ export default function NavigationSection() {
   }
 
   return (
-    <section className="bg-brand md:block md:h-auto md:shrink-0 md:grow-0 md:basis-1/4 md:bg-transparent">
-      <div className="flex h-14 justify-between px-4 md:block">
+    <section className="bg-brand md:sticky md:top-0 md:h-screen md:w-72 md:shrink-0 md:grow-0 md:overflow-y-auto md:border-r-2 md:border-r-gray-300 md:bg-transparent">
+      <div className="flex h-14 justify-between px-2 md:block md:px-4">
         <SiteLogo />
         <button
           data-testid="mobile-navigation-trigger"

--- a/components/report/__tests__/cell-renderers.test.js
+++ b/components/report/__tests__/cell-renderers.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import "../../__mocks__/intersectionObserverMock";
 import profiles from "../../__mocks__/profile";
 import { DataGridContainer } from "../../data-grid";
@@ -170,11 +170,9 @@ describe("Test cell renderers in search results", () => {
       const numberArrayList = cells[COLUMN_NUMBER_ARRAY];
       expect(numberArrayList).toHaveTextContent("1, 2, 3");
 
-      // Check unknown object array has JSON string and View JSON button.
+      // Check unknown object array has JSON string.
       const objectArrayList = cells[COLUMN_OBJECT_ARRAY];
       expect(objectArrayList).toHaveTextContent('[{"object":"object1"}]');
-      const viewJsonButton = objectArrayList.querySelector("button");
-      expect(viewJsonButton).toHaveTextContent("View JSON");
 
       // Check PI column has two linked paths with the correct text.
       const piLinks = within(cells[COLUMN_PI]).getAllByRole("link");
@@ -916,35 +914,6 @@ describe("Page cell-rendering tests", () => {
     expect(unknown).toHaveTextContent(
       '{"blocks":[{"@id":"#block1","body":"# Donor Help This is some help text about donors.","@type":"mark...'
     );
-
-    // Layout should have a View JSON button.
-    const viewJsonButton = within(cells[COLUMN_LAYOUT]).getByRole("button");
-    expect(viewJsonButton).toHaveTextContent("View JSON");
-
-    // Click the View JSON button to open the modal with the complete JSON.
-    fireEvent.click(viewJsonButton);
-    let previewDialog = screen.getByRole("dialog");
-    expect(previewDialog).toHaveTextContent(
-      '{ "blocks": [ { "@id": "#block1", "body": "# Donor Help This is some help text about donors.", "@type": "markdown", "direction": "ltr" } ] }'
-    );
-
-    // Close the modal.
-    const previewDialogCloseButton = within(previewDialog).getByRole("button");
-    fireEvent.click(previewDialogCloseButton);
-    previewDialog = screen.queryByRole("dialog");
-    expect(previewDialog).not.toBeInTheDocument();
-
-    // Open the modal again and close it with the ESC key.
-    fireEvent.click(viewJsonButton);
-    previewDialog = screen.getByRole("dialog");
-    fireEvent.keyDown(previewDialog, {
-      key: "Escape",
-      code: "Escape",
-      keyCode: 27,
-      charCode: 27,
-    });
-    previewDialog = screen.queryByRole("dialog");
-    expect(previewDialog).not.toBeInTheDocument();
   });
 
   it("renders nothing for `parent` when page's parent doesn't exist", () => {

--- a/components/report/cell-renderers.js
+++ b/components/report/cell-renderers.js
@@ -9,11 +9,8 @@
 import _ from "lodash";
 import Link from "next/link";
 import PropTypes from "prop-types";
-import { useState } from "react";
 // components
-import { Button } from "../form-elements";
 import ChromosomeLocations from "../chromosome-locations";
-import Modal from "../modal";
 import SeparatedList from "../separated-list";
 // lib
 import { attachmentToServerHref } from "../../lib/attachment";
@@ -235,7 +232,7 @@ function PathArray({ id, source }) {
           return (
             <Link
               key={index}
-              href={path}
+              href={resolvedPath}
               className="my-2 block first:mt-0 last:mb-0"
             >
               {resolvedPath}
@@ -283,9 +280,6 @@ SimpleArray.propTypes = {
  * modal with the whole object's formatted JSON.
  */
 function UnknownObject({ id, source }) {
-  // True if the modal showing formatted JSON is open
-  const [isJsonModalOpen, setJsonModalOpen] = useState(false);
-
   const unknownObject = source[id];
   if (unknownObject) {
     const json = JSON.stringify(unknownObject);
@@ -294,27 +288,7 @@ function UnknownObject({ id, source }) {
         ? `${json.substring(0, MAX_CELL_JSON_LENGTH)}...`
         : json;
 
-    return (
-      <div data-testid="cell-type-unknown-object">
-        {displayJson}
-        <Button size="sm" onClick={() => setJsonModalOpen(true)}>
-          View JSON
-        </Button>
-        <Modal isOpen={isJsonModalOpen} onClose={() => setJsonModalOpen(false)}>
-          <Modal.Header onClose={() => setJsonModalOpen(false)}>
-            <div>
-              Formatted JSON for <pre className="inline font-bold">{id}</pre>{" "}
-              Property
-            </div>
-          </Modal.Header>
-          <Modal.Body>
-            <pre className="overflow-x-auto text-sm">
-              {JSON.stringify(unknownObject, null, 2)}
-            </pre>
-          </Modal.Body>
-        </Modal>
-      </div>
-    );
+    return <div data-testid="cell-type-unknown-object">{displayJson}</div>;
   }
   return null;
 }

--- a/components/scroll-to-top.js
+++ b/components/scroll-to-top.js
@@ -1,0 +1,58 @@
+// node_modules
+import { ArrowUpIcon } from "@heroicons/react/20/solid";
+import { AnimatePresence, motion } from "framer-motion";
+import { useEffect, useState } from "react";
+
+export default function ScrollToTop() {
+  // True if the button to scroll to the top is visible
+  const [isScrollToTopVisible, setIsScrollToTopVisible] = useState(false);
+
+  function scrollToTop() {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }
+
+  // Detect if the user has scrolled 100px down from the top of the page.
+  useEffect(() => {
+    function handleScroll() {
+      if (window.scrollY > 100) {
+        setIsScrollToTopVisible(true);
+      } else {
+        setIsScrollToTopVisible(false);
+      }
+    }
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  // Hide the scroll-to-top button if the user hasn't scrolled in five seconds.
+  useEffect(() => {
+    let timeoutId;
+    if (isScrollToTopVisible) {
+      timeoutId = setTimeout(() => {
+        setIsScrollToTopVisible(false);
+      }, 8000);
+    }
+    return () => clearTimeout(timeoutId);
+  }, [isScrollToTopVisible]);
+
+  return (
+    <AnimatePresence>
+      {isScrollToTopVisible && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 1 }}
+        >
+          <button
+            className="fixed bottom-4 right-4 rounded-full bg-[#337788] p-2 opacity-70"
+            onClick={scrollToTop}
+          >
+            <ArrowUpIcon className="h-8 w-8 fill-white" />
+          </button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/components/search/__tests__/list-renderer.test.js
+++ b/components/search/__tests__/list-renderer.test.js
@@ -167,61 +167,22 @@ describe("Test Award component", () => {
 });
 
 describe("Test the Biosample component", () => {
-  it("renders a biosample-derived item with accessory data", () => {
+  it("renders a biosample-derived item", () => {
     const item = {
       "@id": "/primary-cells/IGVFSM0000EEEE/",
       "@type": ["PrimaryCell", "Biosample", "Sample", "Item"],
       accession: "IGVFSM0000EEEE",
-      biosample_term: "/sample-terms/CL_0011001/",
-      lab: "/labs/j-michael-cherry/",
-      status: "released",
-      taxa: "Homo sapiens",
-      uuid: "578c72a2-4f84-2c8f-96b0-ec8715e18185",
-    };
-    const accessoryData = {
-      "/sample-terms/CL_0011001/": {
-        "@id": "/sample-terms/CL_0011001/",
+      award: {
+        component: "data coordination",
+        name: "HG012012",
+        "@id": "/awards/HG012012/",
+      },
+      biosample_term: {
         term_name: "motor neuron",
       },
-      "/labs/j-michael-cherry/": {
-        "@id": "/labs/j-michael-cherry/",
+      lab: {
         title: "J. Michael Cherry, Stanford",
       },
-    };
-
-    render(
-      <SessionContext.Provider value={{ profiles }}>
-        <Biosample item={item} accessoryData={accessoryData} />
-      </SessionContext.Provider>
-    );
-
-    const uniqueId = screen.getByTestId("search-list-item-unique-id");
-    expect(uniqueId).toHaveTextContent(/^PrimaryCell/);
-    expect(uniqueId).toHaveTextContent(/IGVFSM0000EEEE$/);
-
-    const title = screen.getByTestId("search-list-item-title");
-    expect(title).toHaveTextContent("Homo sapiens motor neuron");
-
-    const meta = screen.getByTestId("search-list-item-meta");
-    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
-
-    const status = screen.getByTestId("search-list-item-status");
-    expect(status).toHaveTextContent("released");
-
-    const paths = Biosample.getAccessoryDataPaths([item]);
-    expect(paths).toEqual([
-      "/sample-terms/CL_0011001/",
-      "/labs/j-michael-cherry/",
-    ]);
-  });
-
-  it("renders a biosample-derived item without accessory data", () => {
-    const item = {
-      "@id": "/primary-cells/IGVFSM0000EEEE/",
-      "@type": ["PrimaryCell", "Biosample", "Sample", "Item"],
-      accession: "IGVFSM0000EEEE",
-      biosample_term: "/sample-terms/CL_0011001/",
-      lab: "/labs/j-michael-cherry/",
       status: "released",
       taxa: "Homo sapiens",
       uuid: "578c72a2-4f84-2c8f-96b0-ec8715e18185",
@@ -238,10 +199,10 @@ describe("Test the Biosample component", () => {
     expect(uniqueId).toHaveTextContent(/IGVFSM0000EEEE$/);
 
     const title = screen.getByTestId("search-list-item-title");
-    expect(title).toHaveTextContent(/^Homo sapiens$/);
+    expect(title).toHaveTextContent("Homo sapiens motor neuron");
 
-    const meta = screen.queryByTestId("search-list-item-meta");
-    expect(meta).toBeNull();
+    const meta = screen.getByTestId("search-list-item-meta");
+    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
 
     const status = screen.getByTestId("search-list-item-status");
     expect(status).toHaveTextContent("released");
@@ -249,7 +210,7 @@ describe("Test the Biosample component", () => {
 });
 
 describe("Test Document component", () => {
-  it("renders a document item with accessory data", () => {
+  it("renders a document item", () => {
     const item = {
       "@id": "/documents/c7870a38-4286-42fc-9551-22436306e22a/",
       "@type": ["Document", "Item"],
@@ -263,61 +224,9 @@ describe("Test Document component", () => {
       award: "/awards/1UM1HG011996-01/",
       description: "Characterization of a sample using immunofluorescence.",
       document_type: "characterization",
-      lab: "/labs/j-michael-cherry/",
-      status: "in progress",
-      submitted_by: "/users/3787a0ac-f13a-40fc-a524-69628b04cd59/",
-      uuid: "c7870a38-4286-42fc-9551-22436306e22a",
-    };
-    const accessoryData = {
-      "/labs/j-michael-cherry/": {
-        "@id": "/labs/j-michael-cherry/",
+      lab: {
         title: "J. Michael Cherry, Stanford",
       },
-    };
-
-    render(
-      <SessionContext.Provider value={{ profiles }}>
-        <Document item={item} accessoryData={accessoryData} />
-      </SessionContext.Provider>
-    );
-
-    const uniqueId = screen.getByTestId("search-list-item-unique-id");
-    expect(uniqueId).toHaveTextContent(/^Document/);
-    expect(uniqueId).toHaveTextContent(
-      /mouse_H3K4me3_07-473_validation_Hardison.pdf$/
-    );
-
-    const title = screen.getByTestId("search-list-item-title");
-    expect(title).toHaveTextContent(
-      /^Characterization of a sample using immunofluorescence.$/
-    );
-
-    const meta = screen.getByTestId("search-list-item-meta");
-    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
-    expect(meta).toHaveTextContent("characterization");
-
-    const status = screen.getByTestId("search-list-item-status");
-    expect(status).toHaveTextContent("in progress");
-
-    const paths = Document.getAccessoryDataPaths([item]);
-    expect(paths).toEqual(["/labs/j-michael-cherry/"]);
-  });
-
-  it("renders a document item without accessory data", () => {
-    const item = {
-      "@id": "/documents/c7870a38-4286-42fc-9551-22436306e22a/",
-      "@type": ["Document", "Item"],
-      aliases: ["j-michael-cherry:characterization_immunofluorescence_insert"],
-      attachment: {
-        download: "mouse_H3K4me3_07-473_validation_Hardison.pdf",
-        md5sum: "a7c2c98ff7d0f198fdbc6f0ccbfcb411",
-        href: "@@download/attachment/mouse_H3K4me3_07-473_validation_Hardison.pdf",
-        type: "application/pdf",
-      },
-      award: "/awards/1UM1HG011996-01/",
-      description: "Characterization of a sample using immunofluorescence.",
-      document_type: "characterization",
-      lab: "/labs/j-michael-cherry/",
       status: "in progress",
       submitted_by: "/users/3787a0ac-f13a-40fc-a524-69628b04cd59/",
       uuid: "c7870a38-4286-42fc-9551-22436306e22a",
@@ -341,7 +250,7 @@ describe("Test Document component", () => {
     );
 
     const meta = screen.getByTestId("search-list-item-meta");
-    expect(meta).not.toHaveTextContent("J. Michael Cherry, Stanford");
+    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
     expect(meta).toHaveTextContent("characterization");
 
     const status = screen.getByTestId("search-list-item-status");
@@ -419,7 +328,7 @@ describe("Test Gene component", () => {
 });
 
 describe("Test the HumanDonor component", () => {
-  it("renders a human donor item with accessory data", () => {
+  it("renders a human donor item", () => {
     const item = {
       "@id": "/human-donors/IGVFDO856PXB/",
       "@type": ["HumanDonor", "Donor", "Item"],
@@ -427,7 +336,7 @@ describe("Test the HumanDonor component", () => {
       aliases: ["chongyuan-luo:AA F donor of fibroblasts"],
       award: "/awards/1U01HG012079-01/",
       ethnicities: ["African American"],
-      lab: "/labs/chongyuan-luo/",
+      lab: { "@id": "/labs/chongyuan-luo/", title: "Chongyuan Luo" },
       sex: "female",
       status: "released",
       taxa: "Homo sapiens",
@@ -439,11 +348,6 @@ describe("Test the HumanDonor component", () => {
       ],
     };
     const accessoryData = {
-      "/labs/chongyuan-luo/": {
-        "@id": "/labs/chongyuan-luo/",
-        "@type": ["Lab", "Item"],
-        title: "Chongyuan Luo",
-      },
       "/phenotypic-features/123/": {
         lab: "/labs/j-michael-cherry/",
         award: "/awards/HG012012/",
@@ -505,11 +409,7 @@ describe("Test the HumanDonor component", () => {
 
     const paths = HumanDonor.getAccessoryDataPaths([item]);
     expect(paths.sort()).toEqual(
-      [
-        "/labs/chongyuan-luo/",
-        "/phenotypic-features/123/",
-        "/phenotypic-features/456/",
-      ].sort()
+      ["/phenotypic-features/123/", "/phenotypic-features/456/"].sort()
     );
   });
 
@@ -521,7 +421,7 @@ describe("Test the HumanDonor component", () => {
       aliases: ["chongyuan-luo:AA F donor of fibroblasts"],
       award: "/awards/1U01HG012079-01/",
       ethnicities: ["African American"],
-      lab: "/labs/chongyuan-luo/",
+      lab: { "@id": "/labs/chongyuan-luo/", title: "Chongyuan Luo" },
       sex: "female",
       status: "released",
       taxa: "Homo sapiens",
@@ -541,14 +441,14 @@ describe("Test the HumanDonor component", () => {
     const title = screen.getByTestId("search-list-item-title");
     expect(title).toHaveTextContent(/^African American female$/);
 
-    const meta = screen.queryByTestId("search-list-item-meta");
-    expect(meta).toBeNull();
+    const meta = screen.getByTestId("search-list-item-meta");
+    expect(meta).toHaveTextContent("Chongyuan Luo");
 
     const status = screen.getByTestId("search-list-item-status");
     expect(status).toHaveTextContent("released");
   });
 
-  it("renders a human donor item without accessory data nor ethnicities nor sex", () => {
+  it("renders a human donor item without ethnicities nor sex", () => {
     const item = {
       "@id": "/human-donors/IGVFDO856PXB/",
       "@type": ["HumanDonor", "Donor", "Item"],
@@ -574,20 +474,21 @@ describe("Test the HumanDonor component", () => {
     const title = screen.getByTestId("search-list-item-title");
     expect(title).toHaveTextContent(/^\/human-donors\/IGVFDO856PXB\/$/);
 
-    const meta = screen.queryByTestId("search-list-item-meta");
-    expect(meta).toBeNull();
-
     const status = screen.getByTestId("search-list-item-status");
     expect(status).toHaveTextContent("released");
   });
 });
 
 describe("Test the Lab component", () => {
-  it("renders a lab item with accessory data", () => {
+  it("renders a lab item", () => {
     const item = {
       "@id": "/labs/hyejung-won/",
       "@type": ["Lab", "Item"],
-      awards: ["/awards/1UM1HG012003-01/"],
+      awards: [
+        {
+          name: "1UM1HG012003-01",
+        },
+      ],
       institute_label: "UNC",
       name: "hyejung-won",
       pi: "/users/7e51864b-2e2b-40cf-9abc-5cc2dc98f35d/",
@@ -595,17 +496,10 @@ describe("Test the Lab component", () => {
       title: "Hyejung Won, UNC",
       uuid: "fe27c988-4664-4245-a1ca-bab9e1c62a00",
     };
-    const accessoryData = {
-      "/awards/1UM1HG012003-01/": {
-        "@id": "/awards/1UM1HG012003-01/",
-        "@type": ["Award", "Item"],
-        name: "1UM1HG012003-01",
-      },
-    };
 
     render(
       <SessionContext.Provider value={{ profiles }}>
-        <Lab item={item} accessoryData={accessoryData} />
+        <Lab item={item} />
       </SessionContext.Provider>
     );
 
@@ -621,16 +515,12 @@ describe("Test the Lab component", () => {
 
     const status = screen.getByTestId("search-list-item-status");
     expect(status).toHaveTextContent("current");
-
-    const paths = Lab.getAccessoryDataPaths([item]);
-    expect(paths).toEqual(["/awards/1UM1HG012003-01/"]);
   });
 
-  it("renders a lab item without accessory data", () => {
+  it("renders a lab item without the optional award", () => {
     const item = {
       "@id": "/labs/hyejung-won/",
       "@type": ["Lab", "Item"],
-      awards: ["/awards/1UM1HG012003-01/"],
       institute_label: "UNC",
       name: "hyejung-won",
       pi: "/users/7e51864b-2e2b-40cf-9abc-5cc2dc98f35d/",
@@ -692,7 +582,7 @@ describe("Test the Page component", () => {
 });
 
 describe("Test the RodentDonor component", () => {
-  it("renders a RodentDonor item with accessory data", () => {
+  it("renders a RodentDonor item", () => {
     const item = {
       "@id": "/rodent-donors/IGVFDO524ORO/",
       "@type": ["RodentDonor", "Donor", "Item"],
@@ -701,56 +591,14 @@ describe("Test the RodentDonor component", () => {
         "j-michael-cherry:alias_rodent_donor_1",
         "j-michael-cherry:rodent_donor_with_arterial_blood_pressure_trait",
       ],
-      award: "/awards/HG012012/",
-      lab: "/labs/j-michael-cherry/",
-      sex: "male",
-      status: "released",
-      strain: "some name",
-      taxa: "Mus musculus",
-      uuid: "c37934b0-4269-4470-be53-9eac7b196447",
-    };
-    const accessoryData = {
-      "/labs/j-michael-cherry/": {
-        "@id": "/labs/j-michael-cherry/",
-        "@type": ["Lab", "Item"],
+      award: {
+        component: "data coordination",
+        name: "HG012012",
+        "@id": "/awards/HG012012/",
+      },
+      lab: {
         title: "J. Michael Cherry, Stanford",
       },
-    };
-
-    render(
-      <SessionContext.Provider value={{ profiles }}>
-        <RodentDonor item={item} accessoryData={accessoryData} />
-      </SessionContext.Provider>
-    );
-
-    const uniqueId = screen.getByTestId("search-list-item-unique-id");
-    expect(uniqueId).toHaveTextContent(/^RodentDonor/);
-    expect(uniqueId).toHaveTextContent(/IGVFDO524ORO$/);
-
-    const title = screen.getByTestId("search-list-item-title");
-    expect(title).toHaveTextContent(/^some name male$/);
-
-    const meta = screen.getByTestId("search-list-item-meta");
-    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
-
-    const status = screen.getByTestId("search-list-item-status");
-    expect(status).toHaveTextContent("released");
-
-    const paths = RodentDonor.getAccessoryDataPaths([item]);
-    expect(paths).toEqual(["/labs/j-michael-cherry/"]);
-  });
-
-  it("renders a Rodent Donor item without accessory data", () => {
-    const item = {
-      "@id": "/rodent-donors/IGVFDO524ORO/",
-      "@type": ["RodentDonor", "Donor", "Item"],
-      accession: "IGVFDO524ORO",
-      aliases: [
-        "j-michael-cherry:alias_rodent_donor_1",
-        "j-michael-cherry:rodent_donor_with_arterial_blood_pressure_trait",
-      ],
-      award: "/awards/HG012012/",
-      lab: "/labs/j-michael-cherry/",
       sex: "male",
       status: "released",
       strain: "some name",
@@ -771,8 +619,8 @@ describe("Test the RodentDonor component", () => {
     const title = screen.getByTestId("search-list-item-title");
     expect(title).toHaveTextContent(/^some name male$/);
 
-    const meta = screen.queryByTestId("search-list-item-meta");
-    expect(meta).toBeNull();
+    const meta = screen.getByTestId("search-list-item-meta");
+    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
 
     const status = screen.getByTestId("search-list-item-status");
     expect(status).toHaveTextContent("released");
@@ -788,61 +636,13 @@ describe("Test the TechnicalSample component", () => {
       award: "/awards/HG012012/",
       date_obtained: "2022-04-09",
       description: "The technical sample was archived due to poor quality.",
-      lab: "/labs/j-michael-cherry/",
-      status: "archived",
-      technical_sample_term: "/sample-terms/NTR_0000637/",
-      uuid: "f12ab44c-bba8-46cc-9f3d-6a192eb09e7e",
-    };
-    const accessoryData = {
-      "/labs/j-michael-cherry/": {
-        "@id": "/labs/j-michael-cherry/",
-        "@type": ["Lab", "Item"],
+      lab: {
         title: "J. Michael Cherry, Stanford",
       },
-      "/sample-terms/NTR_0000637/": {
-        "@id": "/sample-terms/NTR_0000637/",
-        "@type": ["SampleTerm", "Item"],
-        term_id: "NTR:0000637",
-      },
-    };
-
-    render(
-      <SessionContext.Provider value={{ profiles }}>
-        <TechnicalSample item={item} accessoryData={accessoryData} />
-      </SessionContext.Provider>
-    );
-
-    const uniqueId = screen.getByTestId("search-list-item-unique-id");
-    expect(uniqueId).toHaveTextContent(/^TechnicalSample/);
-    expect(uniqueId).toHaveTextContent(/IGVFSM515BSZ$/);
-
-    const title = screen.getByTestId("search-list-item-title");
-    expect(title).toHaveTextContent(/^NTR:0000637$/);
-
-    const meta = screen.getByTestId("search-list-item-meta");
-    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
-
-    const status = screen.getByTestId("search-list-item-status");
-    expect(status).toHaveTextContent("archived");
-
-    const paths = TechnicalSample.getAccessoryDataPaths([item]);
-    expect(paths).toEqual([
-      "/sample-terms/NTR_0000637/",
-      "/labs/j-michael-cherry/",
-    ]);
-  });
-
-  it("renders a TechnicalSample item without accessory data", () => {
-    const item = {
-      "@id": "/technical-samples/IGVFSM515BSZ/",
-      "@type": ["TechnicalSample", "Sample", "Item"],
-      accession: "IGVFSM515BSZ",
-      award: "/awards/HG012012/",
-      date_obtained: "2022-04-09",
-      description: "The technical sample was archived due to poor quality.",
-      lab: "/labs/j-michael-cherry/",
       status: "archived",
-      technical_sample_term: "/sample-terms/NTR_0000637/",
+      technical_sample_term: {
+        term_name: "technical sample",
+      },
       uuid: "f12ab44c-bba8-46cc-9f3d-6a192eb09e7e",
     };
 
@@ -857,10 +657,10 @@ describe("Test the TechnicalSample component", () => {
     expect(uniqueId).toHaveTextContent(/IGVFSM515BSZ$/);
 
     const title = screen.getByTestId("search-list-item-title");
-    expect(title).toHaveTextContent(/^\/technical-samples\/IGVFSM515BSZ\/$/);
+    expect(title).toHaveTextContent(/^technical sample$/);
 
-    const meta = screen.queryByTestId("search-list-item-meta");
-    expect(meta).toBeNull();
+    const meta = screen.getByTestId("search-list-item-meta");
+    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
 
     const status = screen.getByTestId("search-list-item-status");
     expect(status).toHaveTextContent("archived");
@@ -939,22 +739,17 @@ describe("Test File component", () => {
       accession: "IGVFFI0000SQBR",
       file_format: "txt",
       content_type: "sequence barcodes",
-      lab: "/labs/christina-leslie/",
+      lab: {
+        title: "J. Michael Cherry, Stanford",
+      },
       summary: "IGVFFI0000SQBR",
       uuid: "fa9feeb4-28ba-4356-8c24-50f4e6562029",
       status: "released",
     };
-    const accessoryData = {
-      "/labs/christina-leslie/": {
-        "@id": "/labs/christina-leslie/",
-        "@type": ["Lab", "Item"],
-        title: "Christina Leslie, MSKCC",
-      },
-    };
 
     render(
       <SessionContext.Provider value={{ profiles }}>
-        <File item={item} accessoryData={accessoryData} />
+        <File item={item} />
       </SessionContext.Provider>
     );
 
@@ -966,24 +761,23 @@ describe("Test File component", () => {
     expect(title).toHaveTextContent(/^txt - sequence barcodes$/);
 
     const meta = screen.getByTestId("search-list-item-meta");
-    expect(meta).toHaveTextContent("Christina Leslie, MSKCC");
+    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
     expect(meta).toHaveTextContent("IGVFFI0000SQBR");
 
     const status = screen.getByTestId("search-list-item-status");
     expect(status).toHaveTextContent("released");
-
-    const paths = File.getAccessoryDataPaths([item]);
-    expect(paths).toEqual(["/labs/christina-leslie/"]);
   });
 
-  it("renders a File item without accessory data and summary", () => {
+  it("renders a File item without summary", () => {
     const item = {
       "@id": "/reference-data/IGVFFI0000SQBR/",
       "@type": ["ReferenceData", "File", "Item"],
       accession: "IGVFFI0000SQBR",
       file_format: "txt",
       content_type: "sequence barcodes",
-      lab: "/labs/christina-leslie/",
+      lab: {
+        title: "J. Michael Cherry, Stanford",
+      },
       uuid: "fa9feeb4-28ba-4356-8c24-50f4e6562029",
       status: "released",
     };
@@ -1002,7 +796,8 @@ describe("Test File component", () => {
     expect(title).toHaveTextContent(/^txt - sequence barcodes$/);
 
     const meta = screen.queryByTestId("search-list-item-meta");
-    expect(meta).toBeNull();
+    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
+    expect(meta).not.toHaveTextContent("IGVFFI0000SQBR");
 
     const status = screen.getByTestId("search-list-item-status");
     expect(status).toHaveTextContent("released");
@@ -1017,7 +812,9 @@ describe("Test the AnalysisSet component", () => {
       accession: "IGVFDS3099XPLN",
       aliases: ["igvf:basic_analysis_set"],
       award: "/awards/HG012012/",
-      lab: "/labs/j-michael-cherry/",
+      lab: {
+        title: "J. Michael Cherry, Stanford",
+      },
       status: "released",
       summary: "IGVFDS3099XPLN",
       input_file_sets: ["/analysis-sets/IGVFDS3099XPLN/"],
@@ -1025,11 +822,6 @@ describe("Test the AnalysisSet component", () => {
     };
 
     const accessoryData = {
-      "/labs/j-michael-cherry/": {
-        "@id": "/labs/j-michael-cherry/",
-        "@type": ["Lab", "Item"],
-        title: "J. Michael Cherry, Stanford",
-      },
       "/analysis-sets/IGVFDS3099XPLN/": {
         "@id": "/analysis-sets/IGVFDS3099XPLN/",
         "@type": ["AnalysisSet", "FileSet", "Item"],
@@ -1063,10 +855,7 @@ describe("Test the AnalysisSet component", () => {
     expect(status).toHaveTextContent("released");
 
     const paths = AnalysisSet.getAccessoryDataPaths([item]);
-    expect(paths).toEqual([
-      "/analysis-sets/IGVFDS3099XPLN/",
-      "/labs/j-michael-cherry/",
-    ]);
+    expect(paths).toEqual(["/analysis-sets/IGVFDS3099XPLN/"]);
   });
 
   it("renders an AnalysisSet item without accessory data and summary", () => {
@@ -1076,7 +865,10 @@ describe("Test the AnalysisSet component", () => {
       accession: "IGVFDS3099XPLN",
       aliases: ["igvf:basic_analysis_set"],
       award: "/awards/HG012012/",
-      lab: "/labs/j-michael-cherry/",
+      lab: {
+        "@id": "/labs/j-michael-cherry/",
+        title: "J. Michael Cherry, Stanford",
+      },
       status: "released",
       uuid: "609869e7-cbd9-4d06-9569-d3fdb4604ccd",
     };
@@ -1095,7 +887,7 @@ describe("Test the AnalysisSet component", () => {
     expect(title).toHaveTextContent(/^Analysis$/);
 
     const meta = screen.queryByTestId("search-list-item-meta");
-    expect(meta).toBeNull();
+    expect(meta).toHaveTextContent(/^J. Michael Cherry, Stanford$/);
 
     const supplement = screen.queryByTestId("search-list-item-supplement");
     expect(supplement).toBeNull();
@@ -1106,30 +898,26 @@ describe("Test the AnalysisSet component", () => {
 });
 
 describe("Test the CuratedSet component", () => {
-  it("renders a CuratedSet item with accessory data", () => {
+  it("renders a CuratedSet item", () => {
     const item = {
       "@id": "/curated-sets/IGVFDS0000AAAA/",
       "@type": ["CuratedSet", "FileSet", "Item"],
       accession: "IGVFDS0000AAAA",
       aliases: ["igvf-dacc:GRCh38.p14_assembly"],
       award: "/awards/HG012012/",
-      lab: "/labs/j-michael-cherry/",
+      lab: {
+        "@id": "/labs/tim-reddy/",
+        title: "Tim Reddy, Duke",
+      },
       status: "released",
       taxa: "Homo sapiens",
       summary: "IGVFDS0000AAAA",
       uuid: "40f1e08c-5d6d-4d19-8f69-3fd91420c09f",
     };
-    const accessoryData = {
-      "/labs/j-michael-cherry/": {
-        "@id": "/labs/j-michael-cherry/",
-        "@type": ["Lab", "Item"],
-        title: "J. Michael Cherry, Stanford",
-      },
-    };
 
     render(
       <SessionContext.Provider value={{ profiles }}>
-        <CuratedSet item={item} accessoryData={accessoryData} />
+        <CuratedSet item={item} />
       </SessionContext.Provider>
     );
 
@@ -1141,23 +929,23 @@ describe("Test the CuratedSet component", () => {
     expect(title).toHaveTextContent(/^Curated set$/);
 
     const meta = screen.getByTestId("search-list-item-meta");
-    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
+    expect(meta).toHaveTextContent("Tim Reddy, Duke");
 
     const status = screen.getByTestId("search-list-item-status");
     expect(status).toHaveTextContent("released");
-
-    const paths = CuratedSet.getAccessoryDataPaths([item]);
-    expect(paths).toEqual(["/labs/j-michael-cherry/"]);
   });
 
-  it("renders a CuratedSet item without accessory data and summary", () => {
+  it("renders a CuratedSet item without summary", () => {
     const item = {
       "@id": "/curated-sets/IGVFDS0000AAAA/",
       "@type": ["CuratedSet", "FileSet", "Item"],
       accession: "IGVFDS0000AAAA",
       aliases: ["igvf-dacc:GRCh38.p14_assembly"],
       award: "/awards/HG012012/",
-      lab: "/labs/j-michael-cherry/",
+      lab: {
+        "@id": "/labs/tim-reddy/",
+        title: "Tim Reddy, Duke",
+      },
       status: "released",
       taxa: "Homo sapiens",
       uuid: "40f1e08c-5d6d-4d19-8f69-3fd91420c09f",
@@ -1177,7 +965,7 @@ describe("Test the CuratedSet component", () => {
     expect(title).toHaveTextContent(/^Curated set$/);
 
     const meta = screen.queryByTestId("search-list-item-meta");
-    expect(meta).toBeNull();
+    expect(meta).toHaveTextContent("Tim Reddy, Duke");
 
     const status = screen.getByTestId("search-list-item-status");
     expect(status).toHaveTextContent("released");
@@ -1185,35 +973,27 @@ describe("Test the CuratedSet component", () => {
 });
 
 describe("Test the MeasurementSet component", () => {
-  it("renders a MeasurementSet item with accessory data", () => {
+  it("renders a MeasurementSet item", () => {
     const item = {
       "@id": "/measurement-sets/IGVFDS6408BFHD/",
       "@type": ["MeasurementSet", "FileSet", "Item"],
       accession: "IGVFDS6408BFHD",
       aliases: ["igvf:basic_measurement_set"],
       award: "/awards/HG012012/",
-      lab: "/labs/j-michael-cherry/",
+      lab: {
+        title: "J. Michael Cherry, Stanford",
+      },
       status: "released",
       summary: "IGVFDS6408BFHD",
       uuid: "67380d9f-06da-f9fe-9569-d31ce0607eae",
-      assay_term: "/assay-terms/OBI_0002041/",
-    };
-    const accessoryData = {
-      "/labs/j-michael-cherry/": {
-        "@id": "/labs/j-michael-cherry/",
-        "@type": ["Lab", "Item"],
-        title: "J. Michael Cherry, Stanford",
-      },
-      "/assay-terms/OBI_0002041/": {
-        "@id": "/assay-terms/OBI_0002041/",
-        "@type": ["AssayTerm", "OntologyTerm", "Item"],
+      assay_term: {
         term_name: "STARR-seq",
       },
     };
 
     render(
       <SessionContext.Provider value={{ profiles }}>
-        <MeasurementSet item={item} accessoryData={accessoryData} />
+        <MeasurementSet item={item} />
       </SessionContext.Provider>
     );
 
@@ -1229,38 +1009,28 @@ describe("Test the MeasurementSet component", () => {
 
     const status = screen.getByTestId("search-list-item-status");
     expect(status).toHaveTextContent("released");
-
-    const paths = MeasurementSet.getAccessoryDataPaths([item]);
-    expect(paths).toEqual([
-      "/assay-terms/OBI_0002041/",
-      "/labs/j-michael-cherry/",
-    ]);
   });
 
-  it("renders a MeasurementSet item without accessory data and summary", () => {
+  it("renders a MeasurementSet item without summary", () => {
     const item = {
       "@id": "/measurement-sets/IGVFDS6408BFHD/",
       "@type": ["MeasurementSet", "FileSet", "Item"],
       accession: "IGVFDS6408BFHD",
       aliases: ["igvf:basic_measurement_set"],
       award: "/awards/HG012012/",
-      lab: "/labs/j-michael-cherry/",
+      lab: {
+        title: "J. Michael Cherry, Stanford",
+      },
       status: "released",
       uuid: "67380d9f-06da-f9fe-9569-d31ce0607eae",
-      assay_term: "/assay-terms/OBI_0002041/",
-    };
-
-    const accessoryData = {
-      "/assay-terms/OBI_0002041/": {
-        "@id": "/assay-terms/OBI_0002041/",
-        "@type": ["AssayTerm", "OntologyTerm", "Item"],
+      assay_term: {
         term_name: "STARR-seq",
       },
     };
 
     render(
       <SessionContext.Provider value={{ profiles }}>
-        <MeasurementSet item={item} accessoryData={accessoryData} />
+        <MeasurementSet item={item} />
       </SessionContext.Provider>
     );
 
@@ -1272,7 +1042,7 @@ describe("Test the MeasurementSet component", () => {
     expect(title).toHaveTextContent(/^STARR-seq$/);
 
     const meta = screen.queryByTestId("search-list-item-meta");
-    expect(meta).toBeNull();
+    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
 
     const status = screen.getByTestId("search-list-item-status");
     expect(status).toHaveTextContent("released");
@@ -1314,7 +1084,7 @@ describe("Test the Software component", () => {
 });
 
 describe("Test the SoftwareVersion component", () => {
-  it("renders a SoftwareVersion item with accessory data", () => {
+  it("renders a SoftwareVersion item", () => {
     const item = {
       "@id": "/software-versions/bowtie2-v2.4.4/",
       "@type": ["SoftwareVersion", "Item"],
@@ -1322,50 +1092,9 @@ describe("Test the SoftwareVersion component", () => {
         title: "Bowtie2",
       },
       version: "2.4.4",
-      lab: "/labs/j-michael-cherry/",
-      status: "released",
-      uuid: "67380d9f-06da-f9fe-9569-d31ce0607eae",
-    };
-    const accessoryData = {
-      "/labs/j-michael-cherry/": {
-        "@id": "/labs/j-michael-cherry/",
-        "@type": ["Lab", "Item"],
+      lab: {
         title: "J. Michael Cherry, Stanford",
       },
-    };
-
-    render(
-      <SessionContext.Provider value={{ profiles }}>
-        <SoftwareVersion item={item} accessoryData={accessoryData} />
-      </SessionContext.Provider>
-    );
-
-    const uniqueId = screen.getByTestId("search-list-item-unique-id");
-    expect(uniqueId).toHaveTextContent(/^Software/);
-    expect(uniqueId).toHaveTextContent(/Bowtie2 2.4.4$/);
-
-    const title = screen.getByTestId("search-list-item-title");
-    expect(title).toHaveTextContent(/^Bowtie2 2.4.4$/);
-
-    const meta = screen.getByTestId("search-list-item-meta");
-    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
-
-    const status = screen.getByTestId("search-list-item-status");
-    expect(status).toHaveTextContent("released");
-
-    const paths = SoftwareVersion.getAccessoryDataPaths([item]);
-    expect(paths).toEqual(["/labs/j-michael-cherry/"]);
-  });
-
-  it("renders a SoftwareVersion item without accessory data", () => {
-    const item = {
-      "@id": "/software-versions/bowtie2-v2.4.4/",
-      "@type": ["SoftwareVersion", "Item"],
-      software: {
-        title: "Bowtie2",
-      },
-      version: "2.4.4",
-      lab: "/labs/j-michael-cherry/",
       status: "released",
       uuid: "67380d9f-06da-f9fe-9569-d31ce0607eae",
     };
@@ -1383,8 +1112,8 @@ describe("Test the SoftwareVersion component", () => {
     const title = screen.getByTestId("search-list-item-title");
     expect(title).toHaveTextContent(/^Bowtie2 2.4.4$/);
 
-    const meta = screen.queryByTestId("search-list-item-meta");
-    expect(meta).toBeNull();
+    const meta = screen.getByTestId("search-list-item-meta");
+    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
 
     const status = screen.getByTestId("search-list-item-status");
     expect(status).toHaveTextContent("released");
@@ -1392,7 +1121,7 @@ describe("Test the SoftwareVersion component", () => {
 });
 
 describe("Test the Source component", () => {
-  it("renders a Source item without accessory data", () => {
+  it("renders a Source item", () => {
     const item = {
       name: "aviva",
       title: "Aviva",
@@ -1426,9 +1155,11 @@ describe("Test the Source component", () => {
 });
 
 describe("Test the Publication component", () => {
-  it("renders a Publication item with accessory data", () => {
+  it("renders a Publication item", () => {
     const item = {
-      lab: "/labs/j-michael-cherry/",
+      lab: {
+        title: "J. Michael Cherry, Stanford",
+      },
       page: "57-74",
       award: "/awards/HG012012/",
       issue: "7414",
@@ -1444,17 +1175,10 @@ describe("Test the Publication component", () => {
       "@type": ["Publication", "Item"],
       uuid: "936b0798-3d6b-4b2f-a357-2bd59faae506",
     };
-    const accessoryData = {
-      "/labs/j-michael-cherry/": {
-        "@id": "/labs/j-michael-cherry/",
-        "@type": ["Lab", "Item"],
-        title: "J. Michael Cherry, Stanford",
-      },
-    };
 
     render(
       <SessionContext.Provider value={{ profiles }}>
-        <Publication item={item} accessoryData={accessoryData} />
+        <Publication item={item} />
       </SessionContext.Provider>
     );
 
@@ -1469,17 +1193,20 @@ describe("Test the Publication component", () => {
 
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
+    expect(meta).toHaveTextContent(
+      "ENCODE Project Consortium, Bernstein BE, Birney E, Dunham I, Green ED, Gunter C, Snyder M."
+    );
+    expect(meta).toHaveTextContent("Nature. 2012-09-06;489(7414):57-74.");
 
     const status = screen.getByTestId("search-list-item-status");
     expect(status).toHaveTextContent("released");
-
-    const paths = Publication.getAccessoryDataPaths([item]);
-    expect(paths).toEqual(["/labs/j-michael-cherry/"]);
   });
 
-  it("renders a Publication item without accessory data and data for meta area", () => {
+  it("renders a Publication item without data for meta area", () => {
     const item = {
-      lab: "/labs/j-michael-cherry/",
+      lab: {
+        title: "J. Michael Cherry, Stanford",
+      },
       page: "57-74",
       award: "/awards/HG012012/",
       issue: "7414",
@@ -1508,21 +1235,22 @@ describe("Test the Publication component", () => {
     );
 
     const meta = screen.queryByTestId("search-list-item-meta");
-    expect(meta).toBeNull();
+    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
+    expect(meta).not.toHaveTextContent("ENCODE Project Consortium");
+    expect(meta).not.toHaveTextContent("Nature.");
 
     const status = screen.getByTestId("search-list-item-status");
     expect(status).toHaveTextContent("released");
   });
 
-  it("renders a Publication item with publication date and without accessory data", () => {
+  it("renders a Publication item with publication date", () => {
     const item = {
-      lab: "/labs/j-michael-cherry/",
-
+      lab: {
+        title: "J. Michael Cherry, Stanford",
+      },
       award: "/awards/HG012012/",
-
       title: "An integrated encyclopedia of DNA elements in the human genome",
       status: "released",
-
       identifiers: ["PMID:22955616", "PMCID:PMC3439153"],
       "@id": "/publications/936b0798-3d6b-4b2f-a357-2bd59faae506/",
       "@type": ["Publication", "Item"],
@@ -1552,15 +1280,14 @@ describe("Test the Publication component", () => {
     expect(status).toHaveTextContent("released");
   });
 
-  it("renders a Publication item with journal and without accessory data", () => {
+  it("renders a Publication item with journal", () => {
     const item = {
-      lab: "/labs/j-michael-cherry/",
-
+      lab: {
+        title: "J. Michael Cherry, Stanford",
+      },
       award: "/awards/HG012012/",
-
       title: "An integrated encyclopedia of DNA elements in the human genome",
       status: "released",
-
       identifiers: ["PMID:22955616", "PMCID:PMC3439153"],
       "@id": "/publications/936b0798-3d6b-4b2f-a357-2bd59faae506/",
       "@type": ["Publication", "Item"],
@@ -1592,50 +1319,12 @@ describe("Test the Publication component", () => {
 });
 
 describe("Test the Biomarker component", () => {
-  it("renders a Biomarker item with accessory data", () => {
+  it("renders a Biomarker item", () => {
     const item = {
-      lab: "/labs/j-michael-cherry/",
-      gene: "/genes/ENSG00000163930/",
-      name: "BAP1",
-      award: "/awards/HG012012/",
-      classification: "marker gene",
-      quantification: "positive",
-      "@id": "/biomarkers/bdfaa822-cdbe-405c-920c-67da068c43b6/",
-      "@type": ["Biomarker", "Item"],
-      uuid: "bdfaa822-cdbe-405c-920c-67da068c43b6",
-      summary: "bdfaa822-cdbe-405c-920c-67da068c43b6",
-      name_quantification: "BAP1-positive",
-    };
-    const accessoryData = {
-      "/labs/j-michael-cherry/": {
+      lab: {
         "@id": "/labs/j-michael-cherry/",
-        "@type": ["Lab", "Item"],
         title: "J. Michael Cherry, Stanford",
       },
-    };
-
-    render(
-      <SessionContext.Provider value={{ profiles }}>
-        <Biomarker item={item} accessoryData={accessoryData} />
-      </SessionContext.Provider>
-    );
-
-    const uniqueId = screen.getByTestId("search-list-item-unique-id");
-    expect(uniqueId).toHaveTextContent(/^Biomarker/);
-    expect(uniqueId).toHaveTextContent(/bdfaa822-cdbe-405c-920c-67da068c43b6$/);
-
-    const title = screen.getByTestId("search-list-item-title");
-    expect(title).toHaveTextContent(/^BAP1 positive$/);
-
-    const meta = screen.getByTestId("search-list-item-meta");
-    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
-
-    const paths = Biomarker.getAccessoryDataPaths([item]);
-    expect(paths).toEqual(["/labs/j-michael-cherry/"]);
-  });
-
-  it("renders a Biomarker item without accessory data", () => {
-    const item = {
       gene: "/genes/ENSG00000163930/",
       name: "BAP1",
       award: "/awards/HG012012/",
@@ -1661,8 +1350,8 @@ describe("Test the Biomarker component", () => {
     const title = screen.getByTestId("search-list-item-title");
     expect(title).toHaveTextContent(/^BAP1 positive$/);
 
-    const meta = screen.queryByTestId("search-list-item-meta");
-    expect(meta).toBeNull();
+    const meta = screen.getByTestId("search-list-item-meta");
+    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
   });
 });
 

--- a/components/search/__tests__/search-list-renderer.test.js
+++ b/components/search/__tests__/search-list-renderer.test.js
@@ -38,12 +38,12 @@ describe("Test accessory data-path functions", () => {
           uuid: "860c4750-8d3c-40f5-8f2c-90c5e5d19e88",
         },
         {
-          "@id": "/technical-samples/IGVFSM632ETH/",
-          "@type": ["TechnicalSample", "Sample", "Item"],
-          accession: "IGVFSM632ETH",
-          status: "archived",
-          technical_sample_term: "/sample-terms/NTR_0000637/",
-          uuid: "f12ab44c-bba8-46cc-9f3d-6a192eb09e7e",
+          "@id": "/analysis-sets/IGVFDS9588HSLV/",
+          "@type": ["AnalysisSet", "FileSet", "Item"],
+          accession: "IGVFDS9588HSLV",
+          input_file_sets: ["/analysis-sets/IGVFDS4723JTXI/"],
+          status: "released",
+          uuid: "dd171b83-cbd9-4d06-4aa1-b77ab49569cd",
         },
         {
           "@id": "/genes/ENSG00000163930/",
@@ -94,14 +94,14 @@ describe("Test accessory data-path functions", () => {
           uuid: "3787a0ac-f13a-40fc-a524-69628b04cd59",
         },
       ],
-      TechnicalSample: [
+      AnalysisSet: [
         {
-          "@id": "/technical-samples/IGVFSM632ETH/",
-          "@type": ["TechnicalSample", "Sample", "Item"],
-          accession: "IGVFSM632ETH",
-          status: "archived",
-          technical_sample_term: "/sample-terms/NTR_0000637/",
-          uuid: "f12ab44c-bba8-46cc-9f3d-6a192eb09e7e",
+          "@id": "/analysis-sets/IGVFDS9588HSLV/",
+          "@type": ["AnalysisSet", "FileSet", "Item"],
+          accession: "IGVFDS9588HSLV",
+          input_file_sets: ["/analysis-sets/IGVFDS4723JTXI/"],
+          status: "released",
+          uuid: "dd171b83-cbd9-4d06-4aa1-b77ab49569cd",
         },
       ],
       Gene: [
@@ -135,7 +135,7 @@ describe("Test accessory data-path functions", () => {
     // results, and deduplicates them.
     const expectedAccessoryDataPaths = [
       "/labs/j-michael-cherry/",
-      "/sample-terms/NTR_0000637/",
+      "/analysis-sets/IGVFDS4723JTXI/",
     ];
     const accessoryDataPaths = getAccessoryDataPaths(itemListsByType);
     expect(accessoryDataPaths).toEqual(expectedAccessoryDataPaths);

--- a/components/search/list-renderer/analysis-set.js
+++ b/components/search/list-renderer/analysis-set.js
@@ -16,7 +16,6 @@ import {
 } from "./search-list-item";
 
 export default function AnalysisSet({ item: analysisSet, accessoryData }) {
-  const lab = accessoryData?.[analysisSet.lab];
   const summary = analysisSet.summary;
   const inputFileSetsKeys = analysisSet.input_file_sets;
   const inputFileSetsAccessions =
@@ -32,12 +31,10 @@ export default function AnalysisSet({ item: analysisSet, accessoryData }) {
           {analysisSet.accession}
         </SearchListItemUniqueId>
         <SearchListItemTitle>Analysis</SearchListItemTitle>
-        {(summary || lab) && (
-          <SearchListItemMeta>
-            {lab && <div key="lab">{lab.title}</div>}
-            {summary && <div key="summary">{summary}</div>}
-          </SearchListItemMeta>
-        )}
+        <SearchListItemMeta>
+          <div key="lab">{analysisSet.lab.title}</div>
+          {summary && <div key="summary">{summary}</div>}
+        </SearchListItemMeta>
         {inputFileSetsAccessions && (
           <SearchListItemSupplement>
             <SearchListItemSupplementSection>
@@ -67,7 +64,5 @@ AnalysisSet.getAccessoryDataPaths = (analysisSets) => {
   let fileSets = analysisSets
     .map((analysisSet) => analysisSet.input_file_sets)
     .filter(Boolean);
-  fileSets = fileSets.flat();
-  const labs = analysisSets.map((analysisSet) => analysisSet.lab);
-  return fileSets.concat(labs);
+  return fileSets.flat();
 };

--- a/components/search/list-renderer/biomarker.js
+++ b/components/search/list-renderer/biomarker.js
@@ -12,8 +12,7 @@ import {
 // lib
 import { getBiomarkerTitle } from "../../../lib/biomarker";
 
-export default function Biomarker({ item: biomarker, accessoryData }) {
-  const lab = accessoryData?.[biomarker.lab];
+export default function Biomarker({ item: biomarker }) {
   const title = getBiomarkerTitle(biomarker);
 
   return (
@@ -24,11 +23,9 @@ export default function Biomarker({ item: biomarker, accessoryData }) {
           {biomarker.uuid}
         </SearchListItemUniqueId>
         <SearchListItemTitle>{title}</SearchListItemTitle>
-        {lab && (
-          <SearchListItemMeta>
-            <div key="lab">{lab.title}</div>
-          </SearchListItemMeta>
-        )}
+        <SearchListItemMeta>
+          <div key="lab">{biomarker.lab.title}</div>
+        </SearchListItemMeta>
       </SearchListItemMain>
     </SearchListItemContent>
   );
@@ -37,10 +34,4 @@ export default function Biomarker({ item: biomarker, accessoryData }) {
 Biomarker.propTypes = {
   // Single search-result object to display on a search-result list page
   item: PropTypes.object.isRequired,
-  // Accessory data to display for all search-result objects
-  accessoryData: PropTypes.object,
-};
-
-Biomarker.getAccessoryDataPaths = (items) => {
-  return items.map((item) => item.lab);
 };

--- a/components/search/list-renderer/biosample.js
+++ b/components/search/list-renderer/biosample.js
@@ -11,13 +11,7 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function Biosample({ item: biosample, accessoryData }) {
-  const biosampleTerm = accessoryData?.[biosample.biosample_term];
-  const titleElements = [biosample.taxa, biosampleTerm?.term_name].filter(
-    Boolean
-  );
-  const lab = accessoryData?.[biosample.lab];
-
+export default function Biosample({ item: biosample }) {
   return (
     <SearchListItemContent>
       <SearchListItemMain>
@@ -25,12 +19,12 @@ export default function Biosample({ item: biosample, accessoryData }) {
           <SearchListItemType item={biosample} />
           {biosample.accession}
         </SearchListItemUniqueId>
-        <SearchListItemTitle>{titleElements.join(" ")}</SearchListItemTitle>
-        {lab && (
-          <SearchListItemMeta>
-            <div key="lab">{lab.title}</div>
-          </SearchListItemMeta>
-        )}
+        <SearchListItemTitle>
+          {biosample.taxa} {biosample.biosample_term.term_name}
+        </SearchListItemTitle>
+        <SearchListItemMeta>
+          <div key="lab">{biosample.lab.title}</div>
+        </SearchListItemMeta>
       </SearchListItemMain>
       <SearchListItemStatus item={biosample} />
     </SearchListItemContent>
@@ -40,16 +34,4 @@ export default function Biosample({ item: biosample, accessoryData }) {
 Biosample.propTypes = {
   // Single biosample-derived search-result object to display on a search-result list page
   item: PropTypes.object.isRequired,
-  // Accessory data to display for all search-result objects
-  accessoryData: PropTypes.object,
-};
-
-Biosample.getAccessoryDataPaths = (biosample) => {
-  const terms = biosample.map(
-    (differentiatedCell) => differentiatedCell.biosample_term
-  );
-  const labs = biosample
-    .map((differentiatedCell) => differentiatedCell.lab)
-    .filter(Boolean);
-  return terms.concat(labs);
 };

--- a/components/search/list-renderer/curated-set.js
+++ b/components/search/list-renderer/curated-set.js
@@ -11,8 +11,7 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function CuratedSet({ item: curatedSet, accessoryData }) {
-  const lab = accessoryData?.[curatedSet.lab];
+export default function CuratedSet({ item: curatedSet }) {
   const summary = curatedSet.summary;
 
   return (
@@ -23,12 +22,10 @@ export default function CuratedSet({ item: curatedSet, accessoryData }) {
           {curatedSet.accession}
         </SearchListItemUniqueId>
         <SearchListItemTitle>Curated set</SearchListItemTitle>
-        {(summary || lab) && (
-          <SearchListItemMeta>
-            {lab && <div key="lab">{lab.title}</div>}
-            {summary && <div key="summary">{summary}</div>}
-          </SearchListItemMeta>
-        )}
+        <SearchListItemMeta>
+          <div key="lab">{curatedSet.lab.title}</div>
+          {summary && <div key="summary">{summary}</div>}
+        </SearchListItemMeta>
       </SearchListItemMain>
       <SearchListItemStatus item={curatedSet} />
     </SearchListItemContent>
@@ -38,10 +35,4 @@ export default function CuratedSet({ item: curatedSet, accessoryData }) {
 CuratedSet.propTypes = {
   // Single curated set search-result object to display on a search-result list page
   item: PropTypes.object.isRequired,
-  // Accessory data to display for all search-result objects
-  accessoryData: PropTypes.object,
-};
-
-CuratedSet.getAccessoryDataPaths = (curatedSets) => {
-  return curatedSets.map((curatedSet) => curatedSet.lab);
 };

--- a/components/search/list-renderer/document.js
+++ b/components/search/list-renderer/document.js
@@ -11,7 +11,7 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function Document({ item: document, accessoryData }) {
+export default function Document({ item: document }) {
   return (
     <SearchListItemContent>
       <SearchListItemMain>
@@ -21,9 +21,7 @@ export default function Document({ item: document, accessoryData }) {
         </SearchListItemUniqueId>
         <SearchListItemTitle>{document.description}</SearchListItemTitle>
         <SearchListItemMeta>
-          {accessoryData && accessoryData[document.lab] && (
-            <div key="lab">{accessoryData[document.lab].title}</div>
-          )}
+          <div key="lab">{document.lab.title}</div>
           <div key="document_type">{document.document_type}</div>
         </SearchListItemMeta>
       </SearchListItemMain>
@@ -35,10 +33,4 @@ export default function Document({ item: document, accessoryData }) {
 Document.propTypes = {
   // Single document search-result object to display on a search-result list page
   item: PropTypes.object.isRequired,
-  // Accessory data to display for all search-result objects
-  accessoryData: PropTypes.object,
-};
-
-Document.getAccessoryDataPaths = (documents) => {
-  return documents.map((document) => document.lab).filter(Boolean);
 };

--- a/components/search/list-renderer/file.js
+++ b/components/search/list-renderer/file.js
@@ -11,9 +11,8 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function File({ item: file, accessoryData }) {
+export default function File({ item: file }) {
   const titleElements = [file.file_format, file.content_type];
-  const lab = accessoryData?.[file.lab];
   const summary = file.summary;
 
   return (
@@ -24,12 +23,10 @@ export default function File({ item: file, accessoryData }) {
           {file.accession}
         </SearchListItemUniqueId>
         <SearchListItemTitle>{titleElements.join(" - ")}</SearchListItemTitle>
-        {(summary || lab) && (
-          <SearchListItemMeta>
-            {lab && <div key="lab">{lab.title}</div>}
-            {summary && <div key="summary">{summary}</div>}
-          </SearchListItemMeta>
-        )}
+        <SearchListItemMeta>
+          <div key="lab">{file.lab.title}</div>
+          {summary && <div key="summary">{summary}</div>}
+        </SearchListItemMeta>
       </SearchListItemMain>
       <SearchListItemStatus item={file} />
     </SearchListItemContent>
@@ -39,11 +36,4 @@ export default function File({ item: file, accessoryData }) {
 File.propTypes = {
   // Single file search-result object to display on a search-result list page
   item: PropTypes.object.isRequired,
-  // Accessory data to display for all search-result objects
-  accessoryData: PropTypes.object,
-};
-
-File.getAccessoryDataPaths = (files) => {
-  const labs = files.map((file) => file.lab);
-  return labs;
 };

--- a/components/search/list-renderer/human-donor.js
+++ b/components/search/list-renderer/human-donor.js
@@ -16,7 +16,6 @@ export default function HumanDonor({ item: humanDonor, accessoryData }) {
     humanDonor.ethnicities?.length > 0 ? humanDonor.ethnicities.join(", ") : "";
   const sex = humanDonor.sex || "";
   const title = [ethnicities, sex].filter(Boolean);
-  const lab = accessoryData?.[humanDonor.lab];
   const collections =
     humanDonor.collections?.length > 0 ? humanDonor.collections.join(", ") : "";
   const phenotypicFeatures = humanDonor.phenotypic_features
@@ -40,13 +39,13 @@ export default function HumanDonor({ item: humanDonor, accessoryData }) {
         <SearchListItemTitle>
           {title.length > 0 ? title.join(" ") : humanDonor["@id"]}
         </SearchListItemTitle>
-        {(lab || collections || phenotypicFeatures) && (
-          <SearchListItemMeta>
-            {lab && <div key="lab">{lab.title}</div>}
-            {collections && <div>{collections}</div>}
-            {phenotypicFeatures && <div>{phenotypicFeatures}</div>}
-          </SearchListItemMeta>
-        )}
+        <SearchListItemMeta>
+          <div key="lab">{humanDonor.lab.title}</div>
+          {collections && <div key="collections">{collections}</div>}
+          {phenotypicFeatures && (
+            <div key="phenotypic-features">{phenotypicFeatures}</div>
+          )}
+        </SearchListItemMeta>
       </SearchListItemMain>
       <SearchListItemStatus item={humanDonor} />
     </SearchListItemContent>
@@ -61,11 +60,9 @@ HumanDonor.propTypes = {
 };
 
 HumanDonor.getAccessoryDataPaths = (humanDonors) => {
-  // A list lab path
-  const labs = humanDonors.map((humanDonor) => humanDonor.lab).filter(Boolean);
   // A list of list of phenotypic features paths
   const phenotypicFeatures = humanDonors
-    .map((humanDoner) => humanDoner.phenotypic_features)
+    .map((humanDonor) => humanDonor.phenotypic_features)
     .filter(Boolean);
-  return phenotypicFeatures.flat().concat(labs);
+  return phenotypicFeatures.flat();
 };

--- a/components/search/list-renderer/lab.js
+++ b/components/search/list-renderer/lab.js
@@ -11,13 +11,8 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function Lab({ item: lab, accessoryData }) {
-  const awards = (
-    accessoryData && lab.awards?.length > 0
-      ? lab.awards.map((award) => accessoryData[award])
-      : []
-  ).filter(Boolean);
-  const awardNames = awards.map((award) => award.name);
+export default function Lab({ item: lab }) {
+  const awardNames = lab.awards ? lab.awards.map((award) => award.name) : [];
 
   return (
     <SearchListItemContent>
@@ -41,10 +36,4 @@ export default function Lab({ item: lab, accessoryData }) {
 Lab.propTypes = {
   // Single lab search-result object to display on a search-result list page
   item: PropTypes.object.isRequired,
-  // Accessory data to display for all search-result objects
-  accessoryData: PropTypes.object,
-};
-
-Lab.getAccessoryDataPaths = (labs) => {
-  return labs.reduce((awardAcc, lab) => awardAcc.concat(lab.awards), []);
 };

--- a/components/search/list-renderer/measurement-set.js
+++ b/components/search/list-renderer/measurement-set.js
@@ -11,14 +11,7 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function MeasurementSet({
-  item: measurementSet,
-  accessoryData,
-}) {
-  const assayTerm = accessoryData?.[measurementSet.assay_term];
-  const lab = accessoryData?.[measurementSet.lab];
-  const summary = measurementSet.summary;
-
+export default function MeasurementSet({ item: measurementSet }) {
   return (
     <SearchListItemContent>
       <SearchListItemMain>
@@ -26,13 +19,15 @@ export default function MeasurementSet({
           <SearchListItemType item={measurementSet} />
           {measurementSet.accession}
         </SearchListItemUniqueId>
-        <SearchListItemTitle>{assayTerm.term_name}</SearchListItemTitle>
-        {(summary || lab) && (
-          <SearchListItemMeta>
-            {lab && <div key="lab">{lab.title}</div>}
-            {summary && <div key="summary">{summary}</div>}
-          </SearchListItemMeta>
-        )}
+        <SearchListItemTitle>
+          {measurementSet.assay_term.term_name}
+        </SearchListItemTitle>
+        <SearchListItemMeta>
+          <div key="lab">{measurementSet.lab.title}</div>
+          {measurementSet.summary && (
+            <div key="summary">{measurementSet.summary}</div>
+          )}
+        </SearchListItemMeta>
       </SearchListItemMain>
       <SearchListItemStatus item={measurementSet} />
     </SearchListItemContent>
@@ -42,14 +37,4 @@ export default function MeasurementSet({
 MeasurementSet.propTypes = {
   // Single measurement set search-result object to display on a search-result list page
   item: PropTypes.object.isRequired,
-  // Accessory data to display for all search-result objects
-  accessoryData: PropTypes.object,
-};
-
-MeasurementSet.getAccessoryDataPaths = (measurementSets) => {
-  const assayTerms = measurementSets
-    .map((measurementSet) => measurementSet.assay_term)
-    .filter(Boolean);
-  const labs = measurementSets.map((measurementSet) => measurementSet.lab);
-  return assayTerms.concat(labs);
 };

--- a/components/search/list-renderer/publication.js
+++ b/components/search/list-renderer/publication.js
@@ -11,8 +11,7 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function Publication({ item: publication, accessoryData }) {
-  const lab = accessoryData?.[publication.lab];
+export default function Publication({ item: publication }) {
   return (
     <SearchListItemContent>
       <SearchListItemMain>
@@ -21,34 +20,25 @@ export default function Publication({ item: publication, accessoryData }) {
           {publication.identifiers[0]}
         </SearchListItemUniqueId>
         <SearchListItemTitle>{publication.title}</SearchListItemTitle>
-        {(lab ||
-          publication.authors ||
-          publication.journal ||
-          publication.date_published) && (
-          <SearchListItemMeta>
-            {lab && <div key="lab">{lab.title}</div>}
-            {publication.authors && (
-              <div key="authors">{publication.authors}</div>
-            )}
-            {(publication.journal || publication.date_published) && (
-              <div key="citation">
-                {publication.journal ? <i>{publication.journal}. </i> : ""}
-                {publication.date_published ? (
-                  `${publication.date_published};`
-                ) : (
-                  <span>&nbsp;</span>
-                )}
-                {publication.volume ? publication.volume : ""}
-                {publication.issue ? `(${publication.issue})` : ""}
-                {publication.page ? (
-                  `:${publication.page}.`
-                ) : (
-                  <span>&nbsp;</span>
-                )}
-              </div>
-            )}
-          </SearchListItemMeta>
-        )}
+        <SearchListItemMeta>
+          <div key="lab">{publication.lab.title}</div>
+          {publication.authors && (
+            <div key="authors">{publication.authors}</div>
+          )}
+          {(publication.journal || publication.date_published) && (
+            <div key="citation">
+              {publication.journal ? <i>{publication.journal}. </i> : ""}
+              {publication.date_published ? (
+                `${publication.date_published};`
+              ) : (
+                <span>&nbsp;</span>
+              )}
+              {publication.volume ? publication.volume : ""}
+              {publication.issue ? `(${publication.issue})` : ""}
+              {publication.page ? `:${publication.page}.` : <span>&nbsp;</span>}
+            </div>
+          )}
+        </SearchListItemMeta>
       </SearchListItemMain>
       <SearchListItemStatus item={publication} />
     </SearchListItemContent>
@@ -58,10 +48,4 @@ export default function Publication({ item: publication, accessoryData }) {
 Publication.propTypes = {
   // Single publication search-result object to display on a search-result list page
   item: PropTypes.object.isRequired,
-  // Accessory data to display for all search-result objects
-  accessoryData: PropTypes.object,
-};
-
-Publication.getAccessoryDataPaths = (publications) => {
-  return publications.map((publication) => publication.lab);
 };

--- a/components/search/list-renderer/rodent-donor.js
+++ b/components/search/list-renderer/rodent-donor.js
@@ -11,9 +11,7 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function RodentDonor({ item: rodentDonor, accessoryData }) {
-  const lab = accessoryData?.[rodentDonor.lab];
-
+export default function RodentDonor({ item: rodentDonor }) {
   return (
     <SearchListItemContent>
       <SearchListItemMain>
@@ -24,11 +22,9 @@ export default function RodentDonor({ item: rodentDonor, accessoryData }) {
         <SearchListItemTitle>
           {rodentDonor.strain} {rodentDonor.sex}
         </SearchListItemTitle>
-        {lab && (
-          <SearchListItemMeta>
-            <div key="lab">{lab.title}</div>
-          </SearchListItemMeta>
-        )}
+        <SearchListItemMeta>
+          <div key="lab">{rodentDonor.lab.title}</div>
+        </SearchListItemMeta>
       </SearchListItemMain>
       <SearchListItemStatus item={rodentDonor} />
     </SearchListItemContent>
@@ -38,10 +34,4 @@ export default function RodentDonor({ item: rodentDonor, accessoryData }) {
 RodentDonor.propTypes = {
   // Single rodent-donor search-result object to display on a search-result list page
   item: PropTypes.object.isRequired,
-  // Accessory data to display for all search-result objects
-  accessoryData: PropTypes.object,
-};
-
-RodentDonor.getAccessoryDataPaths = (rodentDonors) => {
-  return rodentDonors.map((rodentDonor) => rodentDonor.lab).filter(Boolean);
 };

--- a/components/search/list-renderer/software-version.js
+++ b/components/search/list-renderer/software-version.js
@@ -11,11 +11,7 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function SoftwareVersion({
-  item: softwareVersion,
-  accessoryData,
-}) {
-  const lab = accessoryData?.[softwareVersion.lab];
+export default function SoftwareVersion({ item: softwareVersion }) {
   const titleElements = [
     softwareVersion.software?.title,
     softwareVersion.version,
@@ -29,11 +25,9 @@ export default function SoftwareVersion({
           {title}
         </SearchListItemUniqueId>
         <SearchListItemTitle>{title}</SearchListItemTitle>
-        {lab && (
-          <SearchListItemMeta>
-            <div key="lab">{lab.title}</div>
-          </SearchListItemMeta>
-        )}
+        <SearchListItemMeta>
+          <div key="lab">{softwareVersion.lab.title}</div>
+        </SearchListItemMeta>
       </SearchListItemMain>
       <SearchListItemStatus item={softwareVersion} />
     </SearchListItemContent>
@@ -43,10 +37,4 @@ export default function SoftwareVersion({
 SoftwareVersion.propTypes = {
   // Single SoftwareVersion search-result object to display on a search-result list page
   item: PropTypes.object.isRequired,
-  // Accessory data to display for all search-result objects
-  accessoryData: PropTypes.object,
-};
-
-SoftwareVersion.getAccessoryDataPaths = (softwareVersions) => {
-  return softwareVersions.map((softwareVersion) => softwareVersion.lab);
 };

--- a/components/search/list-renderer/software.js
+++ b/components/search/list-renderer/software.js
@@ -12,7 +12,6 @@ import {
 } from "./search-list-item";
 
 export default function Software({ item: software }) {
-  const lab = software.lab;
   return (
     <SearchListItemContent>
       <SearchListItemMain>
@@ -21,11 +20,9 @@ export default function Software({ item: software }) {
           {software.name}
         </SearchListItemUniqueId>
         <SearchListItemTitle>{software.title}</SearchListItemTitle>
-        {lab && (
-          <SearchListItemMeta>
-            <div key="lab">{lab.title}</div>
-          </SearchListItemMeta>
-        )}
+        <SearchListItemMeta>
+          <div key="lab">{software.lab.title}</div>
+        </SearchListItemMeta>
       </SearchListItemMain>
       <SearchListItemStatus item={software} />
     </SearchListItemContent>

--- a/components/search/list-renderer/technical-sample.js
+++ b/components/search/list-renderer/technical-sample.js
@@ -11,14 +11,7 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function TechnicalSample({
-  item: technicalSample,
-  accessoryData,
-}) {
-  const technicalSampleTerm =
-    accessoryData?.[technicalSample.technical_sample_term];
-  const lab = accessoryData?.[technicalSample.lab];
-
+export default function TechnicalSample({ item: technicalSample }) {
   return (
     <SearchListItemContent>
       <SearchListItemMain>
@@ -27,13 +20,11 @@ export default function TechnicalSample({
           {technicalSample.accession}
         </SearchListItemUniqueId>
         <SearchListItemTitle>
-          {technicalSampleTerm?.term_id || technicalSample["@id"]}
+          {technicalSample.technical_sample_term.term_name}
         </SearchListItemTitle>
-        {lab && (
-          <SearchListItemMeta>
-            <div key="lab">{lab.title}</div>
-          </SearchListItemMeta>
-        )}
+        <SearchListItemMeta>
+          <div key="lab">{technicalSample.lab.title}</div>
+        </SearchListItemMeta>
       </SearchListItemMain>
       <SearchListItemStatus item={technicalSample} />
     </SearchListItemContent>
@@ -43,14 +34,4 @@ export default function TechnicalSample({
 TechnicalSample.propTypes = {
   // Single search-result object to display on a search-result list page
   item: PropTypes.object.isRequired,
-  // Accessory data to display for all search-result objects
-  accessoryData: PropTypes.object,
-};
-
-TechnicalSample.getAccessoryDataPaths = (technicalSamples) => {
-  const terms = technicalSamples.map(
-    (technicalSample) => technicalSample.technical_sample_term
-  );
-  const labs = technicalSamples.map((technicalSample) => technicalSample.lab);
-  return terms.concat(labs);
 };

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -3,6 +3,8 @@ const { defineConfig } = require("cypress");
 module.exports = defineConfig({
   projectId: "3vpsct",
   defaultCommandTimeout: 30000,
+  viewportWidth: 1282,
+  viewportHeight: 800,
   watchForFileChanges: true,
   e2e: {
     // We've imported your old cypress plugins here.

--- a/cypress/e2e/facets.cy.js
+++ b/cypress/e2e/facets.cy.js
@@ -1,0 +1,81 @@
+/// <reference types="cypress" />
+
+describe("Facet tests", () => {
+  it("shows the correct facet components for an object type", () => {
+    cy.visit("/search?type=InVitroSystem");
+
+    // Make sure facet groups are present and the first is selected.
+    cy.get(`[data-testid="facetgroup-buttons"]`).should("exist");
+    cy.get(`[data-testid="facetgroup-buttons"]`)
+      .find("button")
+      .should("have.length", 3);
+    cy.get(`[data-testid="facetgroup-buttons"]`)
+      .find("button")
+      .first()
+      .should("have.class", "border-facet-group-button-selected");
+
+    // Make sure we have some facets appearing.
+    cy.get(`[data-testid^="facet-"]`).should("have.length.gte", 5);
+    cy.get(`[data-testid="facet-biosample_term.term_name"]`).should("exist");
+
+    // Make sure we have some search results.
+    cy.get(`[data-testid^="search-list-item-/"]`).should("have.length", 4);
+
+    // Make sure clicking a facet term has an effect.
+    cy.get(`[aria-label^="HUES8"]`).click();
+    cy.get(`[data-testid^="search-list-item-/"]`).should("have.length", 1);
+    cy.get(`[aria-label="Clear Biosample Term filter for HUES8"]`).should(
+      "exist"
+    );
+    cy.get(`[aria-label^="HUES8"]`).click();
+    cy.get(`[data-testid^="search-list-item-/"]`).should("have.length", 4);
+    cy.get(`[aria-label="Clear Biosample Term filter for HUES8"]`).should(
+      "not.exist"
+    );
+
+    // Click another facet group and make sure a new set of facets appears.
+    cy.get(`[aria-label="Provenance filter group"]`).click();
+    cy.get(`[data-testid^="facet-"]`).should("have.length.gte", 4);
+    cy.get(`[data-testid="facet-biosample_term.term_name"]`).should(
+      "not.exist"
+    );
+    cy.get(`[data-testid="facet-collections"]`).should("exist");
+
+    // Make sure we have some search results.
+    cy.get(`[data-testid^="search-list-item-/"]`).should("have.length", 4);
+
+    // Click a facet term and make sure it has an effect.
+    cy.get(`[aria-label^="Danwei Huangfu, MSKCC"]`).first().click();
+    cy.get(`[data-testid^="search-list-item-/"]`).should("have.length", 1);
+    cy.get(`[aria-label="Clear Lab filter for Danwei Huangfu, MSKCC"]`).should(
+      "exist"
+    );
+    cy.get(`[aria-label^="J. Michael Cherry, Stanford"]`).first().click();
+    cy.get(`[data-testid^="search-list-item-/"]`).should("have.length", 4);
+    cy.get(
+      `[aria-label="Clear Lab filter for J. Michael Cherry, Stanford"]`
+    ).should("exist");
+
+    // Click a facet tag to clear that term.
+    cy.get(
+      `[aria-label="Clear Lab filter for J. Michael Cherry, Stanford"]`
+    ).click();
+    cy.get(
+      `[aria-label="Clear Lab filter for J. Michael Cherry, Stanford"]`
+    ).should("not.exist");
+    cy.get(`[data-testid^="search-list-item-/"]`).should("have.length", 1);
+
+    // Check we can transition to the report view with the facets.
+    cy.get(`[label="Select report view"]`).click();
+    cy.get(`[data-testid="search-results-count"]`).should(
+      "have.text",
+      "1 item"
+    );
+    cy.get(`[aria-label="Provenance filter group"]`).click();
+    cy.get(`[aria-label^="Danwei Huangfu, MSKCC"]`).first().click();
+    cy.get(`[data-testid="search-results-count"]`).should(
+      "have.text",
+      "4 items"
+    );
+  });
+});

--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -34,13 +34,12 @@ describe("search view tests", () => {
     cy.contains("Columns").click();
     cy.get("[id^=headlessui-dialog-panel-]").should("exist");
 
-    cy.get("[role=columnheader]").contains("Award").should("exist");
-    cy.get("input[name=awards]").uncheck();
-    cy.get("[role=columnheader]").contains("Award").should("not.exist");
-    cy.get("input[name=awards]").check();
-    cy.get("[role=columnheader]").contains("Award").should("exist");
-    cy.get("input[name=aliases]").uncheck();
-    cy.get("[role=columnheader]").contains("Aliases").should("not.exist");
+    cy.get("[role=columnheader]").contains("Name").should("exist");
+    cy.get("input[aria-label=name]").uncheck();
+    cy.get("[role=columnheader]").contains("Name").should("not.exist");
+    cy.get("input[aria-label=name]").check();
+    cy.get("[role=columnheader]").contains("Name").should("exist");
+    cy.get("input[aria-label=aliases]").uncheck();
 
     cy.contains("Close").click();
     cy.get("[id^=headlessui-dialog-panel-]").should("not.exist");

--- a/lib/__tests__/facets.test.js
+++ b/lib/__tests__/facets.test.js
@@ -1,0 +1,25 @@
+import { generateFacetKey, getVisibleFacets } from "../facets";
+
+describe("Test the getVisibleFacets function", () => {
+  it("should filter out hidden facet fields", () => {
+    const facets = [
+      { field: "type", count: 1 },
+      { field: "foo", count: 1 },
+      { field: "bar", count: 1 },
+    ];
+    const expected = [
+      { field: "foo", count: 1 },
+      { field: "bar", count: 1 },
+    ];
+    expect(getVisibleFacets(facets)).toEqual(expected);
+  });
+});
+
+describe("Test the generateFacetKey function", () => {
+  it("should generate a facet key", () => {
+    const searchResults = {
+      clear_filters: "/search/?type=Dataset",
+    };
+    expect(generateFacetKey(searchResults)).toEqual("/search/?type=Dataset");
+  });
+});

--- a/lib/facets.js
+++ b/lib/facets.js
@@ -1,0 +1,26 @@
+/**
+ * Facet fields that don't get displayed as a facet.
+ */
+const HIDDEN_FACET_FIELDS = ["type"];
+
+/**
+ * Filter out the hidden facet fields from the given array of facets.
+ * @param {array} facets Property of search results
+ * @returns {array} Facets that the user can see
+ */
+export function getVisibleFacets(facets) {
+  return facets.filter((facet) => !HIDDEN_FACET_FIELDS.includes(facet.field));
+}
+
+/**
+ * Generate a string that we can use as a key to remount the `<FacetSection>` component when
+ * navigating between search results pages. This causes the currently selected facet group to reset
+ * to the first one. This string consists of the search path and the type= portion of the query
+ * string, but no other parts of the query string so that we don't remount just because the user
+ * selects a facet.
+ * @param {object} searchResults Search results from data provider
+ * @returns {string} Search path and type= portion of query string
+ */
+export function generateFacetKey(searchResults) {
+  return searchResults.clear_filters;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "lodash": "^4.17.21",
         "marked": "^4.0.17",
         "next": "^13.0.3",
+        "pretty-format": "^29.5.0",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-ace": "^10.1.0",
@@ -112,21 +113,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.0.tgz",
-      "integrity": "sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
+      "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.0",
+        "@babel/generator": "^7.21.3",
         "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-module-transforms": "^7.21.0",
+        "@babel/helper-module-transforms": "^7.21.2",
         "@babel/helpers": "^7.21.0",
-        "@babel/parser": "^7.21.0",
+        "@babel/parser": "^7.21.3",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.0",
-        "@babel/types": "^7.21.0",
+        "@babel/traverse": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -157,12 +158,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.21.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.1.tgz",
-      "integrity": "sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.3.tgz",
+      "integrity": "sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.21.0",
+        "@babel/types": "^7.21.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -438,9 +439,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
-      "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
+      "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -653,19 +654,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.2.tgz",
-      "integrity": "sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.3.tgz",
+      "integrity": "sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.1",
+        "@babel/generator": "^7.21.3",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.21.2",
-        "@babel/types": "^7.21.2",
+        "@babel/parser": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -683,9 +684,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
-      "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
+      "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -790,15 +791,39 @@
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "optional": true
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.1.tgz",
+      "integrity": "sha512-BISJ6ZE4xQsuL/FmsyRaiffpq977bMlsKfGHTQrOGFErfByxIe6iZTxPf/00Zon9b9a7iUykfQwejN3s2ZW/Bw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
-      "integrity": "sha512-fluIaaV+GyV24CCu/ggiHdV+j4RNh85yQnAYS/G2mZODZgGmmlrgCydjUcV3YvxCm9x8nMAfThsqTni4KiXT4A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
+      "integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.4.0",
+        "espree": "^9.5.0",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -832,9 +857,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
-      "integrity": "sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
+      "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1388,23 +1413,23 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.3.tgz",
-      "integrity": "sha512-FN50r/E+b8wuqyRjmGaqvqNDuWBWYWQiigfZ50KnSFH0f+AMQQyaZl+Zm2+CIpKk0fL9QxhLxOpTVA3xFHgFow=="
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.4.tgz",
+      "integrity": "sha512-+Mq3TtpkeeKFZanPturjcXt+KHfKYnLlX6jMLyCrmpq6OOs4i1GqBOAauSkii9QeKCMTYzGppar21JU57b/GEA=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.2.3.tgz",
-      "integrity": "sha512-QmMPItnU7VeojI1KnuwL9SLFWEwmaNHNlnOGpoTwdLoSiP9sc8KYiAHWEc4/44L+cAdCxcZYvn7frcRNP5l84Q==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.2.4.tgz",
+      "integrity": "sha512-ck1lI+7r1mMJpqLNa3LJ5pxCfOB1lfJncKmRJeJxcJqcngaFwylreLP7da6Rrjr6u2gVRTfmnkSkjc80IiQCwQ==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
       }
     },
     "node_modules/@next/swc-android-arm-eabi": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.3.tgz",
-      "integrity": "sha512-mykdVaAXX/gm+eFO2kPeVjnOCKwanJ9mV2U0lsUGLrEdMUifPUjiXKc6qFAIs08PvmTMOLMNnUxqhGsJlWGKSw==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
+      "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
       "cpu": [
         "arm"
       ],
@@ -1417,9 +1442,9 @@
       }
     },
     "node_modules/@next/swc-android-arm64": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.3.tgz",
-      "integrity": "sha512-8XwHPpA12gdIFtope+n9xCtJZM3U4gH4vVTpUwJ2w1kfxFmCpwQ4xmeGSkR67uOg80yRMuF0h9V1ueo05sws5w==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
+      "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
       "cpu": [
         "arm64"
       ],
@@ -1432,9 +1457,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.3.tgz",
-      "integrity": "sha512-TXOubiFdLpMfMtaRu1K5d1I9ipKbW5iS2BNbu8zJhoqrhk3Kp7aRKTxqFfWrbliAHhWVE/3fQZUYZOWSXVQi1w==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.4.tgz",
+      "integrity": "sha512-S6vBl+OrInP47TM3LlYx65betocKUUlTZDDKzTiRDbsRESeyIkBtZ6Qi5uT2zQs4imqllJznVjFd1bXLx3Aa6A==",
       "cpu": [
         "arm64"
       ],
@@ -1447,9 +1472,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.3.tgz",
-      "integrity": "sha512-GZctkN6bJbpjlFiS5pylgB2pifHvgkqLAPumJzxnxkf7kqNm6rOGuNjsROvOWVWXmKhrzQkREO/WPS2aWsr/yw==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.4.tgz",
+      "integrity": "sha512-a6LBuoYGcFOPGd4o8TPo7wmv5FnMr+Prz+vYHopEDuhDoMSHOnC+v+Ab4D7F0NMZkvQjEJQdJS3rqgFhlZmKlw==",
       "cpu": [
         "x64"
       ],
@@ -1462,9 +1487,9 @@
       }
     },
     "node_modules/@next/swc-freebsd-x64": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.3.tgz",
-      "integrity": "sha512-rK6GpmMt/mU6MPuav0/M7hJ/3t8HbKPCELw/Uqhi4732xoq2hJ2zbo2FkYs56y6w0KiXrIp4IOwNB9K8L/q62g==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
+      "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
       "cpu": [
         "x64"
       ],
@@ -1477,9 +1502,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.3.tgz",
-      "integrity": "sha512-yeiCp/Odt1UJ4KUE89XkeaaboIDiVFqKP4esvoLKGJ0fcqJXMofj4ad3tuQxAMs3F+qqrz9MclqhAHkex1aPZA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
+      "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
       "cpu": [
         "arm"
       ],
@@ -1492,9 +1517,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.3.tgz",
-      "integrity": "sha512-/miIopDOUsuNlvjBjTipvoyjjaxgkOuvlz+cIbbPcm1eFvzX2ltSfgMgty15GuOiR8Hub4FeTSiq3g2dmCkzGA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.4.tgz",
+      "integrity": "sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==",
       "cpu": [
         "arm64"
       ],
@@ -1507,9 +1532,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.3.tgz",
-      "integrity": "sha512-sujxFDhMMDjqhruup8LLGV/y+nCPi6nm5DlFoThMJFvaaKr/imhkXuk8uCTq4YJDbtRxnjydFv2y8laBSJVC2g==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.4.tgz",
+      "integrity": "sha512-8rXr3WfmqSiYkb71qzuDP6I6R2T2tpkmf83elDN8z783N9nvTJf2E7eLx86wu2OJCi4T05nuxCsh4IOU3LQ5xw==",
       "cpu": [
         "arm64"
       ],
@@ -1522,9 +1547,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.3.tgz",
-      "integrity": "sha512-w5MyxPknVvC9LVnMenAYMXMx4KxPwXuJRMQFvY71uXg68n7cvcas85U5zkdrbmuZ+JvsO5SIG8k36/6X3nUhmQ==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.4.tgz",
+      "integrity": "sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==",
       "cpu": [
         "x64"
       ],
@@ -1537,9 +1562,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.3.tgz",
-      "integrity": "sha512-CTeelh8OzSOVqpzMFMFnVRJIFAFQoTsI9RmVJWW/92S4xfECGcOzgsX37CZ8K982WHRzKU7exeh7vYdG/Eh4CA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.4.tgz",
+      "integrity": "sha512-gOvwIYoSxd+j14LOcvJr+ekd9fwYT1RyMAHOp7znA10+l40wkFiMONPLWiZuHxfRk+Dy7YdNdDh3ImumvL6VwA==",
       "cpu": [
         "x64"
       ],
@@ -1552,9 +1577,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.3.tgz",
-      "integrity": "sha512-7N1KBQP5mo4xf52cFCHgMjzbc9jizIlkTepe9tMa2WFvEIlKDfdt38QYcr9mbtny17yuaIw02FXOVEytGzqdOQ==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.4.tgz",
+      "integrity": "sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==",
       "cpu": [
         "arm64"
       ],
@@ -1567,9 +1592,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.3.tgz",
-      "integrity": "sha512-LzWD5pTSipUXTEMRjtxES/NBYktuZdo7xExJqGDMnZU8WOI+v9mQzsmQgZS/q02eIv78JOCSemqVVKZBGCgUvA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.4.tgz",
+      "integrity": "sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==",
       "cpu": [
         "ia32"
       ],
@@ -1582,9 +1607,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.3.tgz",
-      "integrity": "sha512-aLG2MaFs4y7IwaMTosz2r4mVbqRyCnMoFqOcmfTi7/mAS+G4IMH0vJp4oLdbshqiVoiVuKrAfqtXj55/m7Qu1Q==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.4.tgz",
+      "integrity": "sha512-0MffFmyv7tBLlji01qc0IaPP/LVExzvj7/R5x1Jph1bTAIj4Vu81yFQWHHQAP6r4ff9Ukj1mBK6MDNVXm7Tcvw==",
       "cpu": [
         "x64"
       ],
@@ -1705,9 +1730,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.0.1.tgz",
-      "integrity": "sha512-fTOVsMY9QLFCCXRHG3Ese6cMH5qIWwSbgxZsgeF5TNsy81HKaZ4kgehnSF8FsR3OF+numlIV2YcU79MzbnhSig==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.2.0.tgz",
+      "integrity": "sha512-xTEnpUKiV/bMyEsE5bT4oYA0x0Z/colMtxzUY8bKyPXBNLn/e0V4ZjBZkEhms0xE4pv9QsPfSRu9AWS4y5wGvA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -1867,9 +1892,9 @@
       }
     },
     "node_modules/@types/dompurify": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.4.0.tgz",
-      "integrity": "sha512-IDBwO5IZhrKvHFUl+clZxgf3hn2b/lU6H1KaBShPkQyGJUQ0xwebezIPSuiyGwfz1UzJWQl4M7BDxtHtCCPlTg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.0.tgz",
+      "integrity": "sha512-EcSqmgm/xJwH8CcJPy9AHNypp/j58CYga3nWdl93/wLxX6OH+rSD3aAj75NQazcZd1YKHJ/pjNZ9qmgVajggwQ==",
       "dependencies": {
         "@types/trusted-types": "*"
       }
@@ -1908,9 +1933,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.4.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.4.0.tgz",
-      "integrity": "sha512-VaywcGQ9tPorCX/Jkkni7RWGFfI11whqzs8dvxF41P17Z+z872thvEvlIbznjPJ02kl1HMX3LmLOonsj2n7HeQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.0.tgz",
+      "integrity": "sha512-3Emr5VOl/aoBwnWcH/EFQvlSAmjV+XtV9GGu5mwdYew5vhQh0IUZx/60x0TzHDu09Bi7HMx10t/namdJw5QIcg==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -1941,9 +1966,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.37.tgz",
-      "integrity": "sha512-7GgtHCs/QZrBrDzgIJnQtuSvhFSwhyYSI2uafSwZoNt1iOGhEN5fwNrQMjtONyHm9+/LoA4453jH0CMYcr06Pg==",
+      "version": "14.18.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.41.tgz",
+      "integrity": "sha512-2cfHr8AsUjKx6u4Q+d2eqK51z8+HueoumCQGCKVt95y/yGG4uajOuCANSnE20mbLw94h3tMcddIJ8nYkTu2mFw==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -1959,9 +1984,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.0.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
-      "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
+      "version": "18.0.30",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.30.tgz",
+      "integrity": "sha512-AnME2cHDH11Pxt/yYX6r0w448BfTwQOLEhQEjCdwB7QskEI7EKtxhGUsExTQe/MsY3D9D5rMtu62WRocw9A8FA==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -1979,9 +2004,9 @@
       }
     },
     "node_modules/@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -2029,9 +2054,9 @@
       "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.22",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -2054,14 +2079,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.54.1.tgz",
-      "integrity": "sha512-8zaIXJp/nG9Ff9vQNh7TI+C3nA6q6iIsGJ4B4L6MhZ7mHnTMR4YP5vp2xydmFXIy8rpyIVbNAG44871LMt6ujg==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
+      "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.54.1",
-        "@typescript-eslint/types": "5.54.1",
-        "@typescript-eslint/typescript-estree": "5.54.1",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2081,13 +2106,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.1.tgz",
-      "integrity": "sha512-zWKuGliXxvuxyM71UA/EcPxaviw39dB2504LqAmFDjmkpO8qNLHcmzlh6pbHs1h/7YQ9bnsO8CCcYCSA8sykUg==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.0.tgz",
+      "integrity": "sha512-NANBNOQvllPlizl9LatX8+MHi7bx7WGIWYjPHDmQe5Si/0YEYfxSljJpoTyTWFTgRy3X8gLYSE4xQ2U+aCozSw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.54.1",
-        "@typescript-eslint/visitor-keys": "5.54.1"
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2098,9 +2123,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.1.tgz",
-      "integrity": "sha512-G9+1vVazrfAfbtmCapJX8jRo2E4MDXxgm/IMOF4oGh3kq7XuK3JRkOg6y2Qu1VsTRmWETyTkWt1wxy7X7/yLkw==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.0.tgz",
+      "integrity": "sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2111,13 +2136,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.1.tgz",
-      "integrity": "sha512-bjK5t+S6ffHnVwA0qRPTZrxKSaFYocwFIkZx5k7pvWfsB1I57pO/0M0Skatzzw1sCkjJ83AfGTL0oFIFiDX3bg==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.0.tgz",
+      "integrity": "sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.54.1",
-        "@typescript-eslint/visitor-keys": "5.54.1",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2138,18 +2163,18 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.54.1.tgz",
-      "integrity": "sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.0.tgz",
+      "integrity": "sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==",
       "dev": true,
       "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.54.1",
-        "@typescript-eslint/types": "5.54.1",
-        "@typescript-eslint/typescript-estree": "5.54.1",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
@@ -2186,12 +2211,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.1.tgz",
-      "integrity": "sha512-q8iSoHTgwCfgcRJ2l2x+xCbu8nBlRAlsQ33k24Adj8eoVBE0f8dUeI+bAa8F84Mv05UGbAx57g2zrRsYIooqQg==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.0.tgz",
+      "integrity": "sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/types": "5.57.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -2213,9 +2238,9 @@
       "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ=="
     },
     "node_modules/ace-builds": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.15.3.tgz",
-      "integrity": "sha512-hq8+4DfQcUYcUyAF3vF7UoGFXwNxXST5A2IdarUOp9/Xg1thWTfxusPI2HAlTvXRTVjLDQOj9O34uPoTehEs0A=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.16.0.tgz",
+      "integrity": "sha512-EriMhoxdfhh0zKm7icSt8EXekODAOVsYh9fpnlru9ALwf0Iw7J7bpuqLjhi3QRxvVKR7P0teQdJwTvjVMcYHuw=="
     },
     "node_modules/acorn": {
       "version": "8.8.2",
@@ -2244,38 +2269,6 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-node": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
-      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^7.0.0",
-        "acorn-walk": "^7.0.0",
-        "xtend": "^4.0.2"
-      }
-    },
-    "node_modules/acorn-node/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-node/node_modules/acorn-walk": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/acorn-walk": {
@@ -2386,6 +2379,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -2441,6 +2440,19 @@
       "dev": true,
       "dependencies": {
         "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes": {
@@ -2596,9 +2608,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.13",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
+      "version": "10.4.14",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
+      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
       "dev": true,
       "funding": [
         {
@@ -2611,8 +2623,8 @@
         }
       ],
       "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001426",
+        "browserslist": "^4.21.5",
+        "caniuse-lite": "^1.0.30001464",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -2993,9 +3005,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001462",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001462.tgz",
-      "integrity": "sha512-PDd20WuOBPiasZ7KbFnmQRyuLE7cFXW2PVd7dmALzbkUXEP46upAuCDm9eY9vho8fgNMGmbAX92QBZHzcnWIqw==",
+      "version": "1.0.30001472",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
+      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3004,6 +3016,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -3269,9 +3285,9 @@
       "dev": true
     },
     "node_modules/core-js": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.0.tgz",
-      "integrity": "sha512-VG23vuEisJNkGl6XQmFJd3rEG/so/CNatqeE+7uZAwTSwFeB/qaO0be8xZYUNWprJ/GIwL8aMt9cj1kvbpTZhg==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.1.tgz",
+      "integrity": "sha512-+jwgnhg6cQxKYIIjGtAHq2nwUOolo9eoFZ4sHfUH09BLXBgxnH4gA0zEd+t+BO2cNB8idaBtZFcFTRjQJRJmAw==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -3344,23 +3360,19 @@
     "node_modules/cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true
     },
     "node_modules/cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
+      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
       "dependencies": {
-        "cssom": "~0.3.6"
+        "rrweb-cssom": "^0.6.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14"
       }
-    },
-    "node_modules/cssstyle/node_modules/cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
     },
     "node_modules/csstype": {
       "version": "3.1.1",
@@ -3369,9 +3381,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
-      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.9.0.tgz",
+      "integrity": "sha512-Ofe09LbHKgSqX89Iy1xen2WvpgbvNxDzsWx3mgU1mfILouELeXYGwIib3ItCwoRrRifoQwcBFmY54Vs0zw7QCg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3487,16 +3499,16 @@
       }
     },
     "node_modules/data-urls": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
-      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
+      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
       "dependencies": {
         "abab": "^2.0.6",
         "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0"
+        "whatwg-url": "^12.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/dayjs": {
@@ -3565,9 +3577,9 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "node_modules/deepmerge": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
-      "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3598,15 +3610,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/defined": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
-      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3622,23 +3625,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/detective": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.1.tgz",
-      "integrity": "sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==",
-      "dev": true,
-      "dependencies": {
-        "acorn-node": "^1.8.2",
-        "defined": "^1.0.0",
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "detective": "bin/detective.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/dezalgo": {
@@ -3740,9 +3726,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.324",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.324.tgz",
-      "integrity": "sha512-m+eBs/kh3TXnCuqDF6aHLLRwLK2U471JAbZ1KYigf0TM96fZglxv0/ZFBvyIxnLKsIWUoDiVnHTA2mhYz1fqdA==",
+      "version": "1.4.342",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.342.tgz",
+      "integrity": "sha512-dTei3VResi5bINDENswBxhL+N0Mw5YnfWyTqO75KGsVldurEkhC9+CelJVAse8jycWyP8pv3VSj4BSyP8wTWJA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -3826,18 +3812,18 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
-      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
       "dev": true,
       "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "get-symbol-description": "^1.0.0",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
@@ -3845,8 +3831,8 @@
         "has-property-descriptors": "^1.0.0",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.4",
-        "is-array-buffer": "^3.0.1",
+        "internal-slot": "^1.0.5",
+        "is-array-buffer": "^3.0.2",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
@@ -3854,11 +3840,12 @@
         "is-string": "^1.0.7",
         "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
+        "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "safe-regex-test": "^1.0.0",
+        "string.prototype.trim": "^1.2.7",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
         "typed-array-length": "^1.0.4",
@@ -4033,13 +4020,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.35.0.tgz",
-      "integrity": "sha512-BxAf1fVL7w+JLRQhWl2pzGeSiGqbWumV4WNvc9Rhp6tiCtm4oHnyPBSEtMGZwrQgudFQ+otqzWoPB7x+hxoWsw==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
+      "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^2.0.0",
-        "@eslint/js": "8.35.0",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.1",
+        "@eslint/js": "8.36.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -4050,9 +4039,8 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
+        "espree": "^9.5.0",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -4074,7 +4062,6 @@
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
@@ -4090,12 +4077,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.2.3.tgz",
-      "integrity": "sha512-kPulHiQEHGei9hIaaNGygHRc0UzlWM+3euOmYbxNkd2Nbhci5rrCDeMBMPSV8xgUssphDGmwDHWbk4VZz3rlZQ==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.2.4.tgz",
+      "integrity": "sha512-lunIBhsoeqw6/Lfkd6zPt25w1bn0znLA/JCL+au1HoEpSb4/PpsOYsYtgV/q+YPsoKIOzFyU5xnb04iZnXjUvg==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "13.2.3",
+        "@next/eslint-plugin-next": "13.2.4",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.42.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -4116,9 +4103,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
-      "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -4230,9 +4217,9 @@
       }
     },
     "node_modules/eslint-plugin-cypress": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz",
-      "integrity": "sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.13.1.tgz",
+      "integrity": "sha512-THjc7IT3S9H4KwmRhzAhMGQaEqy78/7W75He/gBhJEH0vIuAY16vOI4YSliDo/ZY+Wm6DtvMHR+8uVvICcI3Lw==",
       "dev": true,
       "dependencies": {
         "globals": "^11.12.0"
@@ -4456,40 +4443,16 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/argparse": {
@@ -4527,9 +4490,9 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
+      "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
@@ -5078,9 +5041,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.4.0.tgz",
-      "integrity": "sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.5.0.tgz",
+      "integrity": "sha512-MjhiaIWCJ1sAU4pIQ5i5OfOuHHxVo1oYeNsWTON7jxYkod8pHocXeh+SSbmu5OZZZK73B6cbJ2XADzXehLyovQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
@@ -5226,9 +5189,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "node_modules/grapheme-splitter": {
@@ -5992,11 +5955,11 @@
       "dev": true
     },
     "node_modules/isomorphic-dompurify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-1.1.0.tgz",
-      "integrity": "sha512-F753oJdEsnEHRPBLBqyuRkm0CpyrwBOtAh8I449gxfknQrKSvVYMY34aObe+tQ9HT7Hi47+Sn3MWjhSXQQpqWA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-1.2.0.tgz",
+      "integrity": "sha512-WAQMvW1ZGLFz3nF8byWLiuBjAakUcMYq9rs2uCDmriVEDaQ69wTZt0q0DfBIVbZtSgC/WTRHxd0A/E10Uv1JaA==",
       "dependencies": {
-        "@types/dompurify": "^2.4.0",
+        "@types/dompurify": "^3.0.0",
         "dompurify": "^3.0.1",
         "jsdom": "^21.1.0"
       }
@@ -6425,6 +6388,38 @@
         }
       }
     },
+    "node_modules/jest-environment-jsdom/node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true
+    },
+    "node_modules/jest-environment-jsdom/node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jest-environment-jsdom/node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -6499,6 +6494,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jest-environment-jsdom/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jest-environment-jsdom/node_modules/universalify": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -6506,6 +6513,19 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/jest-environment-node": {
@@ -7018,6 +7038,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jiti": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
+      "integrity": "sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==",
+      "dev": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/js-cookie": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
@@ -7025,9 +7054,9 @@
       "dev": true
     },
     "node_modules/js-sdsl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -7059,17 +7088,16 @@
       "dev": true
     },
     "node_modules/jsdom": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.0.tgz",
-      "integrity": "sha512-m0lzlP7qOtthD918nenK3hdItSd2I+V3W9IrBcB36sqDwG+KnUs66IF5GY7laGWUnlM9vTsD0W1QwSEBYWWcJg==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.1.tgz",
+      "integrity": "sha512-Jjgdmw48RKcdAIQyUD1UdBh2ecH7VqwaXPN3ehoZN6MqgVbMn+lRm1aAT1AsdJRAJpwfa4IpwgzySn61h2qu3w==",
       "dependencies": {
         "abab": "^2.0.6",
-        "acorn": "^8.8.1",
+        "acorn": "^8.8.2",
         "acorn-globals": "^7.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.2",
-        "decimal.js": "^10.4.2",
+        "cssstyle": "^3.0.0",
+        "data-urls": "^4.0.0",
+        "decimal.js": "^10.4.3",
         "domexception": "^4.0.0",
         "escodegen": "^2.0.0",
         "form-data": "^4.0.0",
@@ -7078,7 +7106,8 @@
         "https-proxy-agent": "^5.0.1",
         "is-potential-custom-element-name": "^1.0.1",
         "nwsapi": "^2.2.2",
-        "parse5": "^7.1.1",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^4.1.2",
@@ -7086,8 +7115,8 @@
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^2.0.0",
         "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0",
-        "ws": "^8.11.0",
+        "whatwg-url": "^12.0.1",
+        "ws": "^8.13.0",
         "xml-name-validator": "^4.0.0"
       },
       "engines": {
@@ -7549,9 +7578,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7671,10 +7700,27 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -7689,11 +7735,11 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.2.3.tgz",
-      "integrity": "sha512-nKFJC6upCPN7DWRx4+0S/1PIOT7vNlCT157w9AzbXEgKy6zkiPKEt5YyRUsRZkmpEqBVrGgOqNfwecTociyg+w==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.2.4.tgz",
+      "integrity": "sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==",
       "dependencies": {
-        "@next/env": "13.2.3",
+        "@next/env": "13.2.4",
         "@swc/helpers": "0.4.14",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
@@ -7706,19 +7752,19 @@
         "node": ">=14.6.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "13.2.3",
-        "@next/swc-android-arm64": "13.2.3",
-        "@next/swc-darwin-arm64": "13.2.3",
-        "@next/swc-darwin-x64": "13.2.3",
-        "@next/swc-freebsd-x64": "13.2.3",
-        "@next/swc-linux-arm-gnueabihf": "13.2.3",
-        "@next/swc-linux-arm64-gnu": "13.2.3",
-        "@next/swc-linux-arm64-musl": "13.2.3",
-        "@next/swc-linux-x64-gnu": "13.2.3",
-        "@next/swc-linux-x64-musl": "13.2.3",
-        "@next/swc-win32-arm64-msvc": "13.2.3",
-        "@next/swc-win32-ia32-msvc": "13.2.3",
-        "@next/swc-win32-x64-msvc": "13.2.3"
+        "@next/swc-android-arm-eabi": "13.2.4",
+        "@next/swc-android-arm64": "13.2.4",
+        "@next/swc-darwin-arm64": "13.2.4",
+        "@next/swc-darwin-x64": "13.2.4",
+        "@next/swc-freebsd-x64": "13.2.4",
+        "@next/swc-linux-arm-gnueabihf": "13.2.4",
+        "@next/swc-linux-arm64-gnu": "13.2.4",
+        "@next/swc-linux-arm64-musl": "13.2.4",
+        "@next/swc-linux-x64-gnu": "13.2.4",
+        "@next/swc-linux-x64-musl": "13.2.4",
+        "@next/swc-win32-arm64-msvc": "13.2.4",
+        "@next/swc-win32-ia32-msvc": "13.2.4",
+        "@next/swc-win32-x64-msvc": "13.2.4"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.4.0",
@@ -8401,9 +8447,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -8416,9 +8462,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.4.tgz",
-      "integrity": "sha512-wMyugRI2yD8gqmMpZSS8kTA0gGeKozX/R+w8iWE+yiCZL09zY0SvfiHfHabNhjGhzxlQ2S2VuTxPE3T72vppCQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.5.tgz",
+      "integrity": "sha512-vZ/iKieyCx0WTxHbkf5E1rBlv/ybFk8WTT4hL5W2jlVxum2Zbe0jMUpuQdDrpa4z2vnPiJ5KIWCqL/kd16fKYg==",
       "dev": true,
       "engines": {
         "node": ">=12.17.0"
@@ -8590,9 +8636,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.0.tgz",
-      "integrity": "sha512-rLSBxJjP+4DQOgcJAx6RZHT2he2pkhQdSnofG5VWyVl6GRq/K02ISOuOLcsMOrtKDIJb8JN2zm3FFzWNbezdPw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.1.tgz",
+      "integrity": "sha512-t+x1zEHDjBwkDGY5v5ApnZ/utcd4XYDiJsaQQoptTXgUXX95sDg1elCdJghzicm7n2mbCBJ3uYWr6M22SO19rg==",
       "dev": true,
       "funding": [
         {
@@ -8712,9 +8758,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -8771,18 +8817,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/request": {
@@ -8937,9 +8971,9 @@
       }
     },
     "node_modules/resolve.exports": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.1.tgz",
-      "integrity": "sha512-OEJWVeimw8mgQuj3HfkNl4KqRevH7lzeQNaWRPfx0PPse7Jk6ozcsG4FKVgtzDsC1KUF+YlTHh17NcgHOPykLw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -8988,6 +9022,11 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -9345,6 +9384,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
@@ -9449,6 +9505,56 @@
         }
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.31.0.tgz",
+      "integrity": "sha512-6QsHnkqyVEzYcaiHsOKkzOtOgdJcb8i54x6AV2hDwyZcY9ZyykGZVw6L/YN98xC0evwTP6utsWWrKRaa8QlfEQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^4.0.0",
+        "glob": "7.1.6",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/sucrase/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/superagent": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.5.tgz",
@@ -9531,20 +9637,20 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.7.tgz",
-      "integrity": "sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.0.tgz",
+      "integrity": "sha512-hOXlFx+YcklJ8kXiCAfk/FMyr4Pm9ck477G0m/us2344Vuj355IpoEDB5UmGAsSpTBmr+4ZhjzW04JuFXkb/fw==",
       "dev": true,
       "dependencies": {
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
         "color-name": "^1.1.4",
-        "detective": "^5.2.1",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
         "fast-glob": "^3.2.12",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
+        "jiti": "^1.17.2",
         "lilconfig": "^2.0.6",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
@@ -9558,7 +9664,8 @@
         "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
-        "resolve": "^1.22.1"
+        "resolve": "^1.22.1",
+        "sucrase": "^3.29.0"
       },
       "bin": {
         "tailwind": "lib/cli.js",
@@ -9612,6 +9719,27 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/throttleit": {
       "version": "1.0.0",
@@ -9688,15 +9816,21 @@
       }
     },
     "node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
       "dependencies": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
@@ -9823,9 +9957,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -9833,7 +9967,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/unbox-primitive": {
@@ -10021,15 +10155,15 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
       "dependencies": {
-        "tr46": "^3.0.0",
+        "tr46": "^4.1.1",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/which": {
@@ -10149,9 +10283,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
-      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10180,15 +10314,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -10319,21 +10444,21 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.0.tgz",
-      "integrity": "sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
+      "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.0",
+        "@babel/generator": "^7.21.3",
         "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-module-transforms": "^7.21.0",
+        "@babel/helper-module-transforms": "^7.21.2",
         "@babel/helpers": "^7.21.0",
-        "@babel/parser": "^7.21.0",
+        "@babel/parser": "^7.21.3",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.0",
-        "@babel/types": "^7.21.0",
+        "@babel/traverse": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -10356,12 +10481,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.21.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.1.tgz",
-      "integrity": "sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.3.tgz",
+      "integrity": "sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.21.0",
+        "@babel/types": "^7.21.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -10574,9 +10699,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
-      "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
+      "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -10726,19 +10851,19 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.2.tgz",
-      "integrity": "sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.3.tgz",
+      "integrity": "sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.1",
+        "@babel/generator": "^7.21.3",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.21.2",
-        "@babel/types": "^7.21.2",
+        "@babel/parser": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -10752,9 +10877,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
-      "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
+      "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -10848,15 +10973,30 @@
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "optional": true
     },
+    "@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "@eslint-community/regexpp": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.1.tgz",
+      "integrity": "sha512-BISJ6ZE4xQsuL/FmsyRaiffpq977bMlsKfGHTQrOGFErfByxIe6iZTxPf/00Zon9b9a7iUykfQwejN3s2ZW/Bw==",
+      "dev": true
+    },
     "@eslint/eslintrc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
-      "integrity": "sha512-fluIaaV+GyV24CCu/ggiHdV+j4RNh85yQnAYS/G2mZODZgGmmlrgCydjUcV3YvxCm9x8nMAfThsqTni4KiXT4A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
+      "integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.4.0",
+        "espree": "^9.5.0",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -10883,9 +11023,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
-      "integrity": "sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
+      "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
       "dev": true
     },
     "@headlessui/react": {
@@ -11308,95 +11448,95 @@
       }
     },
     "@next/env": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.3.tgz",
-      "integrity": "sha512-FN50r/E+b8wuqyRjmGaqvqNDuWBWYWQiigfZ50KnSFH0f+AMQQyaZl+Zm2+CIpKk0fL9QxhLxOpTVA3xFHgFow=="
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.4.tgz",
+      "integrity": "sha512-+Mq3TtpkeeKFZanPturjcXt+KHfKYnLlX6jMLyCrmpq6OOs4i1GqBOAauSkii9QeKCMTYzGppar21JU57b/GEA=="
     },
     "@next/eslint-plugin-next": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.2.3.tgz",
-      "integrity": "sha512-QmMPItnU7VeojI1KnuwL9SLFWEwmaNHNlnOGpoTwdLoSiP9sc8KYiAHWEc4/44L+cAdCxcZYvn7frcRNP5l84Q==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.2.4.tgz",
+      "integrity": "sha512-ck1lI+7r1mMJpqLNa3LJ5pxCfOB1lfJncKmRJeJxcJqcngaFwylreLP7da6Rrjr6u2gVRTfmnkSkjc80IiQCwQ==",
       "dev": true,
       "requires": {
         "glob": "7.1.7"
       }
     },
     "@next/swc-android-arm-eabi": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.3.tgz",
-      "integrity": "sha512-mykdVaAXX/gm+eFO2kPeVjnOCKwanJ9mV2U0lsUGLrEdMUifPUjiXKc6qFAIs08PvmTMOLMNnUxqhGsJlWGKSw==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
+      "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
       "optional": true
     },
     "@next/swc-android-arm64": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.3.tgz",
-      "integrity": "sha512-8XwHPpA12gdIFtope+n9xCtJZM3U4gH4vVTpUwJ2w1kfxFmCpwQ4xmeGSkR67uOg80yRMuF0h9V1ueo05sws5w==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
+      "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.3.tgz",
-      "integrity": "sha512-TXOubiFdLpMfMtaRu1K5d1I9ipKbW5iS2BNbu8zJhoqrhk3Kp7aRKTxqFfWrbliAHhWVE/3fQZUYZOWSXVQi1w==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.4.tgz",
+      "integrity": "sha512-S6vBl+OrInP47TM3LlYx65betocKUUlTZDDKzTiRDbsRESeyIkBtZ6Qi5uT2zQs4imqllJznVjFd1bXLx3Aa6A==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.3.tgz",
-      "integrity": "sha512-GZctkN6bJbpjlFiS5pylgB2pifHvgkqLAPumJzxnxkf7kqNm6rOGuNjsROvOWVWXmKhrzQkREO/WPS2aWsr/yw==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.4.tgz",
+      "integrity": "sha512-a6LBuoYGcFOPGd4o8TPo7wmv5FnMr+Prz+vYHopEDuhDoMSHOnC+v+Ab4D7F0NMZkvQjEJQdJS3rqgFhlZmKlw==",
       "optional": true
     },
     "@next/swc-freebsd-x64": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.3.tgz",
-      "integrity": "sha512-rK6GpmMt/mU6MPuav0/M7hJ/3t8HbKPCELw/Uqhi4732xoq2hJ2zbo2FkYs56y6w0KiXrIp4IOwNB9K8L/q62g==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
+      "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.3.tgz",
-      "integrity": "sha512-yeiCp/Odt1UJ4KUE89XkeaaboIDiVFqKP4esvoLKGJ0fcqJXMofj4ad3tuQxAMs3F+qqrz9MclqhAHkex1aPZA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
+      "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.3.tgz",
-      "integrity": "sha512-/miIopDOUsuNlvjBjTipvoyjjaxgkOuvlz+cIbbPcm1eFvzX2ltSfgMgty15GuOiR8Hub4FeTSiq3g2dmCkzGA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.4.tgz",
+      "integrity": "sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.3.tgz",
-      "integrity": "sha512-sujxFDhMMDjqhruup8LLGV/y+nCPi6nm5DlFoThMJFvaaKr/imhkXuk8uCTq4YJDbtRxnjydFv2y8laBSJVC2g==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.4.tgz",
+      "integrity": "sha512-8rXr3WfmqSiYkb71qzuDP6I6R2T2tpkmf83elDN8z783N9nvTJf2E7eLx86wu2OJCi4T05nuxCsh4IOU3LQ5xw==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.3.tgz",
-      "integrity": "sha512-w5MyxPknVvC9LVnMenAYMXMx4KxPwXuJRMQFvY71uXg68n7cvcas85U5zkdrbmuZ+JvsO5SIG8k36/6X3nUhmQ==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.4.tgz",
+      "integrity": "sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.3.tgz",
-      "integrity": "sha512-CTeelh8OzSOVqpzMFMFnVRJIFAFQoTsI9RmVJWW/92S4xfECGcOzgsX37CZ8K982WHRzKU7exeh7vYdG/Eh4CA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.4.tgz",
+      "integrity": "sha512-gOvwIYoSxd+j14LOcvJr+ekd9fwYT1RyMAHOp7znA10+l40wkFiMONPLWiZuHxfRk+Dy7YdNdDh3ImumvL6VwA==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.3.tgz",
-      "integrity": "sha512-7N1KBQP5mo4xf52cFCHgMjzbc9jizIlkTepe9tMa2WFvEIlKDfdt38QYcr9mbtny17yuaIw02FXOVEytGzqdOQ==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.4.tgz",
+      "integrity": "sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.3.tgz",
-      "integrity": "sha512-LzWD5pTSipUXTEMRjtxES/NBYktuZdo7xExJqGDMnZU8WOI+v9mQzsmQgZS/q02eIv78JOCSemqVVKZBGCgUvA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.4.tgz",
+      "integrity": "sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.3.tgz",
-      "integrity": "sha512-aLG2MaFs4y7IwaMTosz2r4mVbqRyCnMoFqOcmfTi7/mAS+G4IMH0vJp4oLdbshqiVoiVuKrAfqtXj55/m7Qu1Q==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.4.tgz",
+      "integrity": "sha512-0MffFmyv7tBLlji01qc0IaPP/LVExzvj7/R5x1Jph1bTAIj4Vu81yFQWHHQAP6r4ff9Ukj1mBK6MDNVXm7Tcvw==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -11490,9 +11630,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.0.1.tgz",
-      "integrity": "sha512-fTOVsMY9QLFCCXRHG3Ese6cMH5qIWwSbgxZsgeF5TNsy81HKaZ4kgehnSF8FsR3OF+numlIV2YcU79MzbnhSig==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.2.0.tgz",
+      "integrity": "sha512-xTEnpUKiV/bMyEsE5bT4oYA0x0Z/colMtxzUY8bKyPXBNLn/e0V4ZjBZkEhms0xE4pv9QsPfSRu9AWS4y5wGvA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -11623,9 +11763,9 @@
       }
     },
     "@types/dompurify": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.4.0.tgz",
-      "integrity": "sha512-IDBwO5IZhrKvHFUl+clZxgf3hn2b/lU6H1KaBShPkQyGJUQ0xwebezIPSuiyGwfz1UzJWQl4M7BDxtHtCCPlTg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.0.tgz",
+      "integrity": "sha512-EcSqmgm/xJwH8CcJPy9AHNypp/j58CYga3nWdl93/wLxX6OH+rSD3aAj75NQazcZd1YKHJ/pjNZ9qmgVajggwQ==",
       "requires": {
         "@types/trusted-types": "*"
       }
@@ -11664,9 +11804,9 @@
       }
     },
     "@types/jest": {
-      "version": "29.4.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.4.0.tgz",
-      "integrity": "sha512-VaywcGQ9tPorCX/Jkkni7RWGFfI11whqzs8dvxF41P17Z+z872thvEvlIbznjPJ02kl1HMX3LmLOonsj2n7HeQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.0.tgz",
+      "integrity": "sha512-3Emr5VOl/aoBwnWcH/EFQvlSAmjV+XtV9GGu5mwdYew5vhQh0IUZx/60x0TzHDu09Bi7HMx10t/namdJw5QIcg==",
       "dev": true,
       "requires": {
         "expect": "^29.0.0",
@@ -11697,9 +11837,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.37.tgz",
-      "integrity": "sha512-7GgtHCs/QZrBrDzgIJnQtuSvhFSwhyYSI2uafSwZoNt1iOGhEN5fwNrQMjtONyHm9+/LoA4453jH0CMYcr06Pg==",
+      "version": "14.18.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.41.tgz",
+      "integrity": "sha512-2cfHr8AsUjKx6u4Q+d2eqK51z8+HueoumCQGCKVt95y/yGG4uajOuCANSnE20mbLw94h3tMcddIJ8nYkTu2mFw==",
       "dev": true
     },
     "@types/prettier": {
@@ -11715,9 +11855,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.0.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
-      "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
+      "version": "18.0.30",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.30.tgz",
+      "integrity": "sha512-AnME2cHDH11Pxt/yYX6r0w448BfTwQOLEhQEjCdwB7QskEI7EKtxhGUsExTQe/MsY3D9D5rMtu62WRocw9A8FA==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -11735,9 +11875,9 @@
       }
     },
     "@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
       "dev": true
     },
     "@types/semver": {
@@ -11785,9 +11925,9 @@
       "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
     },
     "@types/yargs": {
-      "version": "17.0.22",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -11810,41 +11950,41 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.54.1.tgz",
-      "integrity": "sha512-8zaIXJp/nG9Ff9vQNh7TI+C3nA6q6iIsGJ4B4L6MhZ7mHnTMR4YP5vp2xydmFXIy8rpyIVbNAG44871LMt6ujg==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
+      "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.54.1",
-        "@typescript-eslint/types": "5.54.1",
-        "@typescript-eslint/typescript-estree": "5.54.1",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.1.tgz",
-      "integrity": "sha512-zWKuGliXxvuxyM71UA/EcPxaviw39dB2504LqAmFDjmkpO8qNLHcmzlh6pbHs1h/7YQ9bnsO8CCcYCSA8sykUg==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.0.tgz",
+      "integrity": "sha512-NANBNOQvllPlizl9LatX8+MHi7bx7WGIWYjPHDmQe5Si/0YEYfxSljJpoTyTWFTgRy3X8gLYSE4xQ2U+aCozSw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.54.1",
-        "@typescript-eslint/visitor-keys": "5.54.1"
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.1.tgz",
-      "integrity": "sha512-G9+1vVazrfAfbtmCapJX8jRo2E4MDXxgm/IMOF4oGh3kq7XuK3JRkOg6y2Qu1VsTRmWETyTkWt1wxy7X7/yLkw==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.0.tgz",
+      "integrity": "sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.1.tgz",
-      "integrity": "sha512-bjK5t+S6ffHnVwA0qRPTZrxKSaFYocwFIkZx5k7pvWfsB1I57pO/0M0Skatzzw1sCkjJ83AfGTL0oFIFiDX3bg==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.0.tgz",
+      "integrity": "sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.54.1",
-        "@typescript-eslint/visitor-keys": "5.54.1",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -11853,18 +11993,18 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.54.1.tgz",
-      "integrity": "sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.0.tgz",
+      "integrity": "sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==",
       "dev": true,
       "requires": {
+        "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.54.1",
-        "@typescript-eslint/types": "5.54.1",
-        "@typescript-eslint/typescript-estree": "5.54.1",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       },
       "dependencies": {
@@ -11887,12 +12027,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.1.tgz",
-      "integrity": "sha512-q8iSoHTgwCfgcRJ2l2x+xCbu8nBlRAlsQ33k24Adj8eoVBE0f8dUeI+bAa8F84Mv05UGbAx57g2zrRsYIooqQg==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.0.tgz",
+      "integrity": "sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/types": "5.57.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -11907,9 +12047,9 @@
       "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ=="
     },
     "ace-builds": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.15.3.tgz",
-      "integrity": "sha512-hq8+4DfQcUYcUyAF3vF7UoGFXwNxXST5A2IdarUOp9/Xg1thWTfxusPI2HAlTvXRTVjLDQOj9O34uPoTehEs0A=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.16.0.tgz",
+      "integrity": "sha512-EriMhoxdfhh0zKm7icSt8EXekODAOVsYh9fpnlru9ALwf0Iw7J7bpuqLjhi3QRxvVKR7P0teQdJwTvjVMcYHuw=="
     },
     "acorn": {
       "version": "8.8.2",
@@ -11931,31 +12071,6 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
-    },
-    "acorn-node": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
-      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
-      "dev": true,
-      "requires": {
-        "acorn": "^7.0.0",
-        "acorn-walk": "^7.0.0",
-        "xtend": "^4.0.2"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-          "dev": true
-        },
-        "acorn-walk": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-          "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
-          "dev": true
-        }
-      }
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -12030,6 +12145,12 @@
         "color-convert": "^2.0.1"
       }
     },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
     "anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -12068,6 +12189,16 @@
       "dev": true,
       "requires": {
         "deep-equal": "^2.0.5"
+      }
+    },
+    "array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
       }
     },
     "array-includes": {
@@ -12193,13 +12324,13 @@
       }
     },
     "autoprefixer": {
-      "version": "10.4.13",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
+      "version": "10.4.14",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
+      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001426",
+        "browserslist": "^4.21.5",
+        "caniuse-lite": "^1.0.30001464",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -12465,9 +12596,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001462",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001462.tgz",
-      "integrity": "sha512-PDd20WuOBPiasZ7KbFnmQRyuLE7cFXW2PVd7dmALzbkUXEP46upAuCDm9eY9vho8fgNMGmbAX92QBZHzcnWIqw=="
+      "version": "1.0.30001472",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
+      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -12665,9 +12796,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.0.tgz",
-      "integrity": "sha512-VG23vuEisJNkGl6XQmFJd3rEG/so/CNatqeE+7uZAwTSwFeB/qaO0be8xZYUNWprJ/GIwL8aMt9cj1kvbpTZhg=="
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.1.tgz",
+      "integrity": "sha512-+jwgnhg6cQxKYIIjGtAHq2nwUOolo9eoFZ4sHfUH09BLXBgxnH4gA0zEd+t+BO2cNB8idaBtZFcFTRjQJRJmAw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -12720,21 +12851,15 @@
     "cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true
     },
     "cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
+      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
       "requires": {
-        "cssom": "~0.3.6"
-      },
-      "dependencies": {
-        "cssom": {
-          "version": "0.3.8",
-          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-        }
+        "rrweb-cssom": "^0.6.0"
       }
     },
     "csstype": {
@@ -12744,9 +12869,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
-      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.9.0.tgz",
+      "integrity": "sha512-Ofe09LbHKgSqX89Iy1xen2WvpgbvNxDzsWx3mgU1mfILouELeXYGwIib3ItCwoRrRifoQwcBFmY54Vs0zw7QCg==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -12841,13 +12966,13 @@
       }
     },
     "data-urls": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
-      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
+      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
       "requires": {
         "abab": "^2.0.6",
         "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0"
+        "whatwg-url": "^12.0.0"
       }
     },
     "dayjs": {
@@ -12905,9 +13030,9 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "deepmerge": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
-      "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true
     },
     "define-lazy-prop": {
@@ -12926,12 +13051,6 @@
         "object-keys": "^1.1.1"
       }
     },
-    "defined": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
-      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
-      "dev": true
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -12942,17 +13061,6 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
-    },
-    "detective": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.1.tgz",
-      "integrity": "sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==",
-      "dev": true,
-      "requires": {
-        "acorn-node": "^1.8.2",
-        "defined": "^1.0.0",
-        "minimist": "^1.2.6"
-      }
     },
     "dezalgo": {
       "version": "1.0.4",
@@ -13043,9 +13151,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.324",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.324.tgz",
-      "integrity": "sha512-m+eBs/kh3TXnCuqDF6aHLLRwLK2U471JAbZ1KYigf0TM96fZglxv0/ZFBvyIxnLKsIWUoDiVnHTA2mhYz1fqdA==",
+      "version": "1.4.342",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.342.tgz",
+      "integrity": "sha512-dTei3VResi5bINDENswBxhL+N0Mw5YnfWyTqO75KGsVldurEkhC9+CelJVAse8jycWyP8pv3VSj4BSyP8wTWJA==",
       "dev": true
     },
     "emittery": {
@@ -13111,18 +13219,18 @@
       }
     },
     "es-abstract": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
-      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
       "dev": true,
       "requires": {
+        "array-buffer-byte-length": "^1.0.0",
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "get-symbol-description": "^1.0.0",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
@@ -13130,8 +13238,8 @@
         "has-property-descriptors": "^1.0.0",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.4",
-        "is-array-buffer": "^3.0.1",
+        "internal-slot": "^1.0.5",
+        "is-array-buffer": "^3.0.2",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
@@ -13139,11 +13247,12 @@
         "is-string": "^1.0.7",
         "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.2",
+        "object-inspect": "^1.12.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "safe-regex-test": "^1.0.0",
+        "string.prototype.trim": "^1.2.7",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
         "typed-array-length": "^1.0.4",
@@ -13272,13 +13381,15 @@
       }
     },
     "eslint": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.35.0.tgz",
-      "integrity": "sha512-BxAf1fVL7w+JLRQhWl2pzGeSiGqbWumV4WNvc9Rhp6tiCtm4oHnyPBSEtMGZwrQgudFQ+otqzWoPB7x+hxoWsw==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
+      "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^2.0.0",
-        "@eslint/js": "8.35.0",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.1",
+        "@eslint/js": "8.36.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -13289,9 +13400,8 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
+        "espree": "^9.5.0",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -13313,7 +13423,6 @@
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
@@ -13347,12 +13456,12 @@
       }
     },
     "eslint-config-next": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.2.3.tgz",
-      "integrity": "sha512-kPulHiQEHGei9hIaaNGygHRc0UzlWM+3euOmYbxNkd2Nbhci5rrCDeMBMPSV8xgUssphDGmwDHWbk4VZz3rlZQ==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.2.4.tgz",
+      "integrity": "sha512-lunIBhsoeqw6/Lfkd6zPt25w1bn0znLA/JCL+au1HoEpSb4/PpsOYsYtgV/q+YPsoKIOzFyU5xnb04iZnXjUvg==",
       "dev": true,
       "requires": {
-        "@next/eslint-plugin-next": "13.2.3",
+        "@next/eslint-plugin-next": "13.2.4",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.42.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -13364,9 +13473,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
-      "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
       "dev": true,
       "requires": {}
     },
@@ -13449,9 +13558,9 @@
       }
     },
     "eslint-plugin-cypress": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz",
-      "integrity": "sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.13.1.tgz",
+      "integrity": "sha512-THjc7IT3S9H4KwmRhzAhMGQaEqy78/7W75He/gBhJEH0vIuAY16vOI4YSliDo/ZY+Wm6DtvMHR+8uVvICcI3Lw==",
       "dev": true,
       "requires": {
         "globals": "^11.12.0"
@@ -13623,33 +13732,16 @@
         "estraverse": "^5.2.0"
       }
     },
-    "eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "requires": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-          "dev": true
-        }
-      }
-    },
     "eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "dev": true
     },
     "espree": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
+      "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.0",
@@ -14056,9 +14148,9 @@
       }
     },
     "get-tsconfig": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.4.0.tgz",
-      "integrity": "sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.5.0.tgz",
+      "integrity": "sha512-MjhiaIWCJ1sAU4pIQ5i5OfOuHHxVo1oYeNsWTON7jxYkod8pHocXeh+SSbmu5OZZZK73B6cbJ2XADzXehLyovQ==",
       "dev": true
     },
     "getos": {
@@ -14165,9 +14257,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "grapheme-splitter": {
@@ -14688,11 +14780,11 @@
       "dev": true
     },
     "isomorphic-dompurify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-1.1.0.tgz",
-      "integrity": "sha512-F753oJdEsnEHRPBLBqyuRkm0CpyrwBOtAh8I449gxfknQrKSvVYMY34aObe+tQ9HT7Hi47+Sn3MWjhSXQQpqWA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-1.2.0.tgz",
+      "integrity": "sha512-WAQMvW1ZGLFz3nF8byWLiuBjAakUcMYq9rs2uCDmriVEDaQ69wTZt0q0DfBIVbZtSgC/WTRHxd0A/E10Uv1JaA==",
       "requires": {
-        "@types/dompurify": "^2.4.0",
+        "@types/dompurify": "^3.0.0",
         "dompurify": "^3.0.1",
         "jsdom": "^21.1.0"
       }
@@ -15003,6 +15095,34 @@
         "jsdom": "^20.0.0"
       },
       "dependencies": {
+        "cssstyle": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+          "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+          "dev": true,
+          "requires": {
+            "cssom": "~0.3.6"
+          },
+          "dependencies": {
+            "cssom": {
+              "version": "0.3.8",
+              "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+              "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+              "dev": true
+            }
+          }
+        },
+        "data-urls": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+          "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.6",
+            "whatwg-mimetype": "^3.0.0",
+            "whatwg-url": "^11.0.0"
+          }
+        },
         "form-data": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -15060,11 +15180,30 @@
             "url-parse": "^1.5.3"
           }
         },
+        "tr46": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
         "universalify": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
           "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
           "dev": true
+        },
+        "whatwg-url": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "dev": true,
+          "requires": {
+            "tr46": "^3.0.0",
+            "webidl-conversions": "^7.0.0"
+          }
         }
       }
     },
@@ -15469,6 +15608,12 @@
         }
       }
     },
+    "jiti": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
+      "integrity": "sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==",
+      "dev": true
+    },
     "js-cookie": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
@@ -15476,9 +15621,9 @@
       "dev": true
     },
     "js-sdsl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
       "dev": true
     },
     "js-tokens": {
@@ -15503,17 +15648,16 @@
       "dev": true
     },
     "jsdom": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.0.tgz",
-      "integrity": "sha512-m0lzlP7qOtthD918nenK3hdItSd2I+V3W9IrBcB36sqDwG+KnUs66IF5GY7laGWUnlM9vTsD0W1QwSEBYWWcJg==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-21.1.1.tgz",
+      "integrity": "sha512-Jjgdmw48RKcdAIQyUD1UdBh2ecH7VqwaXPN3ehoZN6MqgVbMn+lRm1aAT1AsdJRAJpwfa4IpwgzySn61h2qu3w==",
       "requires": {
         "abab": "^2.0.6",
-        "acorn": "^8.8.1",
+        "acorn": "^8.8.2",
         "acorn-globals": "^7.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.2",
-        "decimal.js": "^10.4.2",
+        "cssstyle": "^3.0.0",
+        "data-urls": "^4.0.0",
+        "decimal.js": "^10.4.3",
         "domexception": "^4.0.0",
         "escodegen": "^2.0.0",
         "form-data": "^4.0.0",
@@ -15522,7 +15666,8 @@
         "https-proxy-agent": "^5.0.1",
         "is-potential-custom-element-name": "^1.0.1",
         "nwsapi": "^2.2.2",
-        "parse5": "^7.1.1",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^4.1.2",
@@ -15530,8 +15675,8 @@
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^2.0.0",
         "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0",
-        "ws": "^8.11.0",
+        "whatwg-url": "^12.0.1",
+        "ws": "^8.13.0",
         "xml-name-validator": "^4.0.0"
       },
       "dependencies": {
@@ -15881,9 +16026,9 @@
       }
     },
     "marked": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -15964,10 +16109,21 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -15976,24 +16132,24 @@
       "dev": true
     },
     "next": {
-      "version": "13.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.2.3.tgz",
-      "integrity": "sha512-nKFJC6upCPN7DWRx4+0S/1PIOT7vNlCT157w9AzbXEgKy6zkiPKEt5YyRUsRZkmpEqBVrGgOqNfwecTociyg+w==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.2.4.tgz",
+      "integrity": "sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==",
       "requires": {
-        "@next/env": "13.2.3",
-        "@next/swc-android-arm-eabi": "13.2.3",
-        "@next/swc-android-arm64": "13.2.3",
-        "@next/swc-darwin-arm64": "13.2.3",
-        "@next/swc-darwin-x64": "13.2.3",
-        "@next/swc-freebsd-x64": "13.2.3",
-        "@next/swc-linux-arm-gnueabihf": "13.2.3",
-        "@next/swc-linux-arm64-gnu": "13.2.3",
-        "@next/swc-linux-arm64-musl": "13.2.3",
-        "@next/swc-linux-x64-gnu": "13.2.3",
-        "@next/swc-linux-x64-musl": "13.2.3",
-        "@next/swc-win32-arm64-msvc": "13.2.3",
-        "@next/swc-win32-ia32-msvc": "13.2.3",
-        "@next/swc-win32-x64-msvc": "13.2.3",
+        "@next/env": "13.2.4",
+        "@next/swc-android-arm-eabi": "13.2.4",
+        "@next/swc-android-arm64": "13.2.4",
+        "@next/swc-darwin-arm64": "13.2.4",
+        "@next/swc-darwin-x64": "13.2.4",
+        "@next/swc-freebsd-x64": "13.2.4",
+        "@next/swc-linux-arm-gnueabihf": "13.2.4",
+        "@next/swc-linux-arm64-gnu": "13.2.4",
+        "@next/swc-linux-arm64-musl": "13.2.4",
+        "@next/swc-linux-x64-gnu": "13.2.4",
+        "@next/swc-linux-x64-musl": "13.2.4",
+        "@next/swc-win32-arm64-msvc": "13.2.4",
+        "@next/swc-win32-ia32-msvc": "13.2.4",
+        "@next/swc-win32-x64-msvc": "13.2.4",
         "@swc/helpers": "0.4.14",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
@@ -16441,15 +16597,15 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
       "dev": true
     },
     "prettier-plugin-tailwindcss": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.4.tgz",
-      "integrity": "sha512-wMyugRI2yD8gqmMpZSS8kTA0gGeKozX/R+w8iWE+yiCZL09zY0SvfiHfHabNhjGhzxlQ2S2VuTxPE3T72vppCQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.5.tgz",
+      "integrity": "sha512-vZ/iKieyCx0WTxHbkf5E1rBlv/ybFk8WTT4hL5W2jlVxum2Zbe0jMUpuQdDrpa4z2vnPiJ5KIWCqL/kd16fKYg==",
       "dev": true,
       "requires": {}
     },
@@ -16537,9 +16693,9 @@
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
     },
     "pure-rand": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.0.tgz",
-      "integrity": "sha512-rLSBxJjP+4DQOgcJAx6RZHT2he2pkhQdSnofG5VWyVl6GRq/K02ISOuOLcsMOrtKDIJb8JN2zm3FFzWNbezdPw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.1.tgz",
+      "integrity": "sha512-t+x1zEHDjBwkDGY5v5ApnZ/utcd4XYDiJsaQQoptTXgUXX95sDg1elCdJghzicm7n2mbCBJ3uYWr6M22SO19rg==",
       "dev": true
     },
     "qs": {
@@ -16613,9 +16769,9 @@
       }
     },
     "readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -16658,12 +16814,6 @@
         "define-properties": "^1.1.3",
         "functions-have-names": "^1.2.2"
       }
-    },
-    "regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true
     },
     "request": {
       "version": "2.88.2",
@@ -16785,9 +16935,9 @@
       "dev": true
     },
     "resolve.exports": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.1.tgz",
-      "integrity": "sha512-OEJWVeimw8mgQuj3HfkNl4KqRevH7lzeQNaWRPfx0PPse7Jk6ozcsG4FKVgtzDsC1KUF+YlTHh17NcgHOPykLw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
       "dev": true
     },
     "restore-cursor": {
@@ -16820,6 +16970,11 @@
       "requires": {
         "glob": "^7.1.3"
       }
+    },
+    "rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
     },
     "run-parallel": {
       "version": "1.2.0",
@@ -17095,6 +17250,17 @@
         "side-channel": "^1.0.4"
       }
     },
+    "string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
     "string.prototype.trimend": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
@@ -17161,6 +17327,42 @@
         "client-only": "0.0.1"
       }
     },
+    "sucrase": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.31.0.tgz",
+      "integrity": "sha512-6QsHnkqyVEzYcaiHsOKkzOtOgdJcb8i54x6AV2hDwyZcY9ZyykGZVw6L/YN98xC0evwTP6utsWWrKRaa8QlfEQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^4.0.0",
+        "glob": "7.1.6",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
     "superagent": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.5.tgz",
@@ -17224,20 +17426,20 @@
       }
     },
     "tailwindcss": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.7.tgz",
-      "integrity": "sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.0.tgz",
+      "integrity": "sha512-hOXlFx+YcklJ8kXiCAfk/FMyr4Pm9ck477G0m/us2344Vuj355IpoEDB5UmGAsSpTBmr+4ZhjzW04JuFXkb/fw==",
       "dev": true,
       "requires": {
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
         "color-name": "^1.1.4",
-        "detective": "^5.2.1",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
         "fast-glob": "^3.2.12",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
+        "jiti": "^1.17.2",
         "lilconfig": "^2.0.6",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
@@ -17251,7 +17453,8 @@
         "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
-        "resolve": "^1.22.1"
+        "resolve": "^1.22.1",
+        "sucrase": "^3.29.0"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -17288,6 +17491,24 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
     },
     "throttleit": {
       "version": "1.0.0",
@@ -17352,12 +17573,18 @@
       }
     },
     "tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
       "requires": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.0"
       }
+    },
+    "ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
     },
     "tsconfig-paths": {
       "version": "3.14.2",
@@ -17458,9 +17685,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
       "dev": true,
       "peer": true
     },
@@ -17605,11 +17832,11 @@
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="
     },
     "whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
       "requires": {
-        "tr46": "^3.0.0",
+        "tr46": "^4.1.1",
         "webidl-conversions": "^7.0.0"
       }
     },
@@ -17700,9 +17927,9 @@
       }
     },
     "ws": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
-      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "requires": {}
     },
     "xml-name-validator": {
@@ -17714,12 +17941,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lodash": "^4.17.21",
     "marked": "^4.0.17",
     "next": "^13.0.3",
+    "pretty-format": "^29.5.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-ace": "^10.1.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -18,6 +18,7 @@ import DarkModeManager from "../lib/dark-mode-manager";
 // components
 import GlobalContext from "../components/global-context";
 import NavigationSection from "../components/navigation";
+import ScrollToTop from "../components/scroll-to-top";
 import { Session } from "../components/session-context";
 // CSS
 import "../styles/globals.css";
@@ -94,7 +95,8 @@ export default function App({ Component, pageProps }) {
           gtag('config', 'G-E2PEXFFGYR');
         `}
       </Script>
-      <div className="pt-0 pr-2 pb-8 pl-2 md:container md:flex">
+      <div className="md:container">
+        <ScrollToTop />
         <Auth0Provider
           domain={AUTH0_ISSUER_BASE_DOMAIN}
           clientId={AUTH0_CLIENT_ID}
@@ -107,16 +109,18 @@ export default function App({ Component, pageProps }) {
           <GlobalContext.Provider value={globalContext}>
             <Session>
               <ProfileMap>
-                <NavigationSection />
-                <div className="min-w-0 shrink grow px-8 py-2 text-black dark:text-white">
-                  {pageProps.serverSideError ? (
-                    <Error
-                      statusCode={pageProps.serverSideError.code}
-                      title={pageProps.serverSideError.description}
-                    />
-                  ) : (
-                    <Component {...pageProps} />
-                  )}
+                <div className="md:flex">
+                  <NavigationSection />
+                  <div className="min-w-0 shrink grow px-3 py-2 text-black dark:text-white md:px-8">
+                    {pageProps.serverSideError ? (
+                      <Error
+                        statusCode={pageProps.serverSideError.code}
+                        title={pageProps.serverSideError.description}
+                      />
+                    ) : (
+                      <Component {...pageProps} />
+                    )}
+                  </div>
                 </div>
               </ProfileMap>
             </Session>

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -127,7 +127,7 @@ export async function getServerSideProps({ params, req }) {
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const analysisSet = await request.getObject(`/analysis-sets/${params.id}/`);
   if (FetchRequest.isResponseSuccess(analysisSet)) {
-    const award = await request.getObject(analysisSet.award, null);
+    const award = await request.getObject(analysisSet.award["@id"], null);
     const inputFileSets = analysisSet.input_file_sets
       ? await request.getMultipleObjects(analysisSet.input_file_sets, null, {
           filterErrors: true,
@@ -138,17 +138,19 @@ export async function getServerSideProps({ params, req }) {
           filterErrors: true,
         })
       : [];
-    const lab = await request.getObject(analysisSet.lab, null);
+    const lab = await request.getObject(analysisSet.lab["@id"], null);
     const samples = analysisSet.samples
       ? await request.getMultipleObjects(analysisSet.samples, null, {
           filterErrors: true,
         })
       : [];
-    const donors = analysisSet.donors
-      ? await request.getMultipleObjects(analysisSet.donors, null, {
-          filterErrors: true,
-        })
-      : [];
+    let donors = [];
+    if (analysisSet.donors) {
+      const donorPaths = analysisSet.donors.map((donor) => donor["@id"]);
+      donors = await request.getMultipleObjects(donorPaths, null, {
+        filterErrors: true,
+      });
+    }
     const breadcrumbs = await buildBreadcrumbs(
       analysisSet,
       "accession",

--- a/pages/biomarkers/[id].js
+++ b/pages/biomarkers/[id].js
@@ -93,8 +93,8 @@ export async function getServerSideProps({ params, req }) {
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const biomarker = await request.getObject(`/biomarkers/${params.id}/`);
   if (FetchRequest.isResponseSuccess(biomarker)) {
-    const award = await request.getObject(biomarker.award, null);
-    const lab = await request.getObject(biomarker.lab, null);
+    const award = await request.getObject(biomarker.award["@id"], null);
+    const lab = await request.getObject(biomarker.lab["@id"], null);
     const gene = await request.getObject(biomarker.gene, null);
     const breadcrumbs = await buildBreadcrumbs(
       biomarker,

--- a/pages/curated-sets/[id].js
+++ b/pages/curated-sets/[id].js
@@ -118,13 +118,13 @@ export async function getServerSideProps({ params, req }) {
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const curatedSet = await request.getObject(`/curated-sets/${params.id}/`);
   if (FetchRequest.isResponseSuccess(curatedSet)) {
-    const award = await request.getObject(curatedSet.award, null);
+    const award = await request.getObject(curatedSet.award["@id"], null);
     const documents = curatedSet.documents
       ? await request.getMultipleObjects(curatedSet.documents, null, {
           filterErrors: true,
         })
       : [];
-    const lab = await request.getObject(curatedSet.lab, null);
+    const lab = await request.getObject(curatedSet.lab["@id"], null);
     const samples = curatedSet.samples
       ? await request.getMultipleObjects(curatedSet.samples, null, {
           filterErrors: true,

--- a/pages/documents/[id].js
+++ b/pages/documents/[id].js
@@ -112,8 +112,8 @@ export async function getServerSideProps({ params, req }) {
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const document = await request.getObject(`/documents/${params.id}/`);
   if (FetchRequest.isResponseSuccess(document)) {
-    const award = await request.getObject(document.award, null);
-    const lab = await request.getObject(document.lab, null);
+    const award = await request.getObject(document.award["@id"], null);
+    const lab = await request.getObject(document.lab["@id"], null);
     const breadcrumbs = await buildBreadcrumbs(
       document,
       "description",

--- a/pages/human-donors/[uuid].js
+++ b/pages/human-donors/[uuid].js
@@ -78,7 +78,7 @@ HumanDonor.propTypes = {
   lab: PropTypes.object,
   // Parents of this donor
   parents: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Phenotypic Features of this donor with the feature turm embedded
+  // Phenotypic Features of this donor with the feature term embedded
   phenotypicFeatures: PropTypes.arrayOf(PropTypes.object),
   // Phenotype terms associated with the above features
   phenotypeTermsList: PropTypes.arrayOf(PropTypes.object),
@@ -88,13 +88,13 @@ export async function getServerSideProps({ params, req }) {
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const donor = await request.getObject(`/human-donors/${params.uuid}/`);
   if (FetchRequest.isResponseSuccess(donor)) {
-    const award = await request.getObject(donor.award, null);
+    const award = await request.getObject(donor.award["@id"], null);
     const documents = donor.documents
       ? await request.getMultipleObjects(donor.documents, null, {
           filterErrors: true,
         })
       : [];
-    const lab = await request.getObject(donor.lab, null);
+    const lab = await request.getObject(donor.lab["@id"], null);
     const parents = donor.parents
       ? await request.getMultipleObjects(donor.parents, null, {
           filterErrors: true,

--- a/pages/human-genomic-variants/[uuid].js
+++ b/pages/human-genomic-variants/[uuid].js
@@ -73,7 +73,7 @@ HumanGenomicVariant.propTypes = {
 export async function getServerSideProps({ params, req }) {
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const variant = await request.getObject(
-    `/human-genomic-variants/${params.uuid}`
+    `/human-genomic-variants/${params.uuid}/`
   );
   if (FetchRequest.isResponseSuccess(variant)) {
     const breadcrumbs = await buildBreadcrumbs(

--- a/pages/in-vitro-systems/[id].js
+++ b/pages/in-vitro-systems/[id].js
@@ -117,15 +117,19 @@ export async function getServerSideProps({ params, req }) {
     `/in-vitro-systems/${params.id}/`
   );
   if (FetchRequest.isResponseSuccess(inVitroSystem)) {
-    const award = await request.getObject(inVitroSystem.award, null);
+    const award = await request.getObject(inVitroSystem.award["@id"], null);
     const biosampleTerm = inVitroSystem.biosample_term
-      ? await request.getObject(inVitroSystem.biosample_term, null)
+      ? await request.getObject(inVitroSystem.biosample_term["@id"], null)
       : null;
-    const diseaseTerms = inVitroSystem.disease_terms
-      ? await request.getMultipleObjects(inVitroSystem.disease_terms, null, {
-          filterErrors: true,
-        })
-      : [];
+    let diseaseTerms = [];
+    if (inVitroSystem.disease_terms) {
+      const diseaseTermPaths = inVitroSystem.disease_terms.map(
+        (diseaseTerm) => diseaseTerm["@id"]
+      );
+      diseaseTerms = await request.getMultipleObjects(diseaseTermPaths, null, {
+        filterErrors: true,
+      });
+    }
     const documents = inVitroSystem.documents
       ? await request.getMultipleObjects(inVitroSystem.documents, null, {
           filterErrors: true,
@@ -136,13 +140,17 @@ export async function getServerSideProps({ params, req }) {
           filterErrors: true,
         })
       : [];
-    const lab = await request.getObject(inVitroSystem.lab, null);
-    const source = await request.getObject(inVitroSystem.source, null);
-    const treatments = inVitroSystem.treatments
-      ? await request.getMultipleObjects(inVitroSystem.treatments, null, {
-          filterErrors: true,
-        })
-      : [];
+    const lab = await request.getObject(inVitroSystem.lab["@id"], null);
+    const source = await request.getObject(inVitroSystem.source["@id"], null);
+    let treatments = [];
+    if (inVitroSystem.treatments) {
+      const treatmentPaths = inVitroSystem.treatments.map(
+        (treatment) => treatment["@id"]
+      );
+      treatments = await request.getMultipleObjects(treatmentPaths, null, {
+        filterErrors: true,
+      });
+    }
     const pooledFrom =
       inVitroSystem.pooled_from?.length > 0
         ? await request.getMultipleObjects(inVitroSystem.pooled_from, null, {

--- a/pages/primary-cells/[uuid].js
+++ b/pages/primary-cells/[uuid].js
@@ -113,15 +113,19 @@ export async function getServerSideProps({ params, req }) {
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const primaryCell = await request.getObject(`/primary-cells/${params.uuid}/`);
   if (FetchRequest.isResponseSuccess(primaryCell)) {
-    const award = await request.getObject(primaryCell.award, null);
+    const award = await request.getObject(primaryCell.award["@id"], null);
     const biosampleTerm = primaryCell.biosample_term
-      ? await request.getObject(primaryCell.biosample_term, null)
+      ? await request.getObject(primaryCell.biosample_term["@id"], null)
       : null;
-    const diseaseTerms = primaryCell.disease_terms
-      ? await request.getMultipleObjects(primaryCell.disease_terms, null, {
-          filterErrors: true,
-        })
-      : [];
+    let diseaseTerms = [];
+    if (primaryCell.disease_terms?.length > 0) {
+      const diseaseTermPaths = primaryCell.disease_terms.map(
+        (diseaseTerm) => diseaseTerm["@id"]
+      );
+      diseaseTerms = await request.getMultipleObjects(diseaseTermPaths, null, {
+        filterErrors: true,
+      });
+    }
     const documents = primaryCell.documents
       ? await request.getMultipleObjects(primaryCell.documents, null, {
           filterErrors: true,
@@ -132,8 +136,8 @@ export async function getServerSideProps({ params, req }) {
           filterErrors: true,
         })
       : [];
-    const lab = await request.getObject(primaryCell.lab, null);
-    const source = await request.getObject(primaryCell.source, null);
+    const lab = await request.getObject(primaryCell.lab["@id"], null);
+    const source = await request.getObject(primaryCell.source["@id"], null);
     const treatments = primaryCell.treatments
       ? await request.getMultipleObjects(primaryCell.treatments, null, {
           filterErrors: true,

--- a/pages/publications/[id].js
+++ b/pages/publications/[id].js
@@ -113,8 +113,8 @@ export async function getServerSideProps({ params, req }) {
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const publication = await request.getObject(`/publications/${params.id}/`);
   if (FetchRequest.isResponseSuccess(publication)) {
-    const award = await request.getObject(publication.award, null);
-    const lab = await request.getObject(publication.lab, null);
+    const award = await request.getObject(publication.award["@id"], null);
+    const lab = await request.getObject(publication.lab["@id"], null);
     const breadcrumbs = await buildBreadcrumbs(
       publication,
       "title",

--- a/pages/reference-data/[id].js
+++ b/pages/reference-data/[id].js
@@ -100,8 +100,8 @@ export async function getServerSideProps({ params, req }) {
     `/reference-data/${params.id}/`
   );
   if (FetchRequest.isResponseSuccess(referenceData)) {
-    const award = await request.getObject(referenceData.award, null);
-    const lab = await request.getObject(referenceData.lab, null);
+    const award = await request.getObject(referenceData.award["@id"], null);
+    const lab = await request.getObject(referenceData.lab["@id"], null);
     const fileSet = await request.getObject(referenceData.file_set, null);
     const documents = referenceData.documents
       ? await request.getMultipleObjects(referenceData.documents, null, {

--- a/pages/report.js
+++ b/pages/report.js
@@ -4,7 +4,9 @@ import { useRouter } from "next/router";
 import PropTypes from "prop-types";
 import React, { useContext, useRef } from "react";
 // components
+import Breadcrumbs from "../components/breadcrumbs";
 import { DataGridContainer } from "../components/data-grid";
+import { FacetSection, FacetTags } from "../components/facets";
 import NoCollectionData from "../components/no-collection-data";
 import PagePreamble from "../components/page-preamble";
 import {
@@ -21,6 +23,7 @@ import SortableGrid from "../components/sortable-grid";
 // lib
 import buildBreadcrumbs from "../lib/breadcrumbs";
 import errorObjectToProps from "../lib/errors";
+import { generateFacetKey } from "../lib/facets";
 import FetchRequest from "../lib/fetch-request";
 import QueryString from "../lib/query-string";
 import {
@@ -187,33 +190,41 @@ export default function Report({ searchResults }) {
 
     return (
       <>
+        <Breadcrumbs />
         {pageTitle && <PagePreamble pageTitle={pageTitle} />}
         {items.length > 0 ? (
-          <>
-            <SearchResultsHeader
+          <div className="lg:flex lg:items-start lg:gap-1">
+            <FacetSection
+              key={generateFacetKey(searchResults)}
               searchResults={searchResults}
-              columnSelectorConfig={{
-                onColumnVisibilityChange,
-                onAllColumnsVisibilityChange,
-              }}
             />
-            <SearchResultsCount count={searchResults.total} />
-            <ScrollIndicators gridRef={gridRef}>
-              <DataGridContainer ref={gridRef}>
-                <SortableGrid
-                  data={items}
-                  columns={columns}
-                  initialSort={{ isSortingSuppressed: true }}
-                  meta={{
-                    onHeaderCellClick,
-                    sortedColumnId,
-                    nonSortableColumnIds,
-                  }}
-                  CustomHeaderCell={ReportHeaderCell}
-                />
-              </DataGridContainer>
-            </ScrollIndicators>
-          </>
+            <div className="min-w-0 grow">
+              <FacetTags searchResults={searchResults} />
+              <SearchResultsHeader
+                searchResults={searchResults}
+                columnSelectorConfig={{
+                  onColumnVisibilityChange,
+                  onAllColumnsVisibilityChange,
+                }}
+              />
+              <SearchResultsCount count={searchResults.total} />
+              <ScrollIndicators gridRef={gridRef}>
+                <DataGridContainer ref={gridRef}>
+                  <SortableGrid
+                    data={items}
+                    columns={columns}
+                    initialSort={{ isSortingSuppressed: true }}
+                    meta={{
+                      onHeaderCellClick,
+                      sortedColumnId,
+                      nonSortableColumnIds,
+                    }}
+                    CustomHeaderCell={ReportHeaderCell}
+                  />
+                </DataGridContainer>
+              </ScrollIndicators>
+            </div>
+          </div>
         ) : (
           <NoCollectionData pageTitle="report items" />
         )}

--- a/pages/rodent-donors/[uuid].js
+++ b/pages/rodent-donors/[uuid].js
@@ -87,13 +87,13 @@ export async function getServerSideProps({ params, req }) {
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const donor = await request.getObject(`/rodent-donors/${params.uuid}/`);
   if (FetchRequest.isResponseSuccess(donor)) {
-    const award = await request.getObject(donor.award, null);
+    const award = await request.getObject(donor.award["@id"], null);
     const documents = donor.documents
       ? await request.getMultipleObjects(donor.documents, null, {
           filterErrors: true,
         })
       : [];
-    const lab = await request.getObject(donor.lab, null);
+    const lab = await request.getObject(donor.lab["@id"], null);
     const parents = donor.parents
       ? await request.getMultipleObjects(donor.parents, null, {
           filterErrors: true,

--- a/pages/search.js
+++ b/pages/search.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { useContext } from "react";
 // components
 import Breadcrumbs from "../components/breadcrumbs";
+import { FacetSection, FacetTags } from "../components/facets";
 import NoCollectionData from "../components/no-collection-data";
 import PagePreamble from "../components/page-preamble";
 import {
@@ -19,6 +20,7 @@ import {
 import SessionContext from "../components/session-context";
 // lib
 import buildBreadcrumbs from "../lib/breadcrumbs";
+import { generateFacetKey } from "../lib/facets";
 import errorObjectToProps from "../lib/errors";
 import FetchRequest from "../lib/fetch-request";
 import { getQueryStringFromServerQuery } from "../lib/query-utils";
@@ -40,29 +42,36 @@ export default function Search({ searchResults, accessoryData = null }) {
       <Breadcrumbs />
       {pageTitle && <PagePreamble pageTitle={pageTitle} />}
       {searchResults.total > 0 ? (
-        <>
-          <SearchResultsHeader searchResults={searchResults} />
-          <SearchResultsCount count={searchResults.total} />
-          <ul data-testid="search-list">
-            {searchResults["@graph"].map((item) => {
-              // For each item, get the appropriate search-list item renderer for it, or the
-              // fallback render if the item type doesn't have one.
-              const SearchListItemRenderer = getSearchListItemRenderer(item);
-              return (
-                <SearchListItem
-                  key={item["@id"]}
-                  testid={item["@id"]}
-                  href={item["@id"]}
-                >
-                  <SearchListItemRenderer
-                    item={item}
-                    accessoryData={accessoryData}
-                  />
-                </SearchListItem>
-              );
-            })}
-          </ul>
-        </>
+        <div className="lg:flex lg:items-start lg:gap-1">
+          <FacetSection
+            key={generateFacetKey(searchResults)}
+            searchResults={searchResults}
+          />
+          <div className="grow">
+            <FacetTags searchResults={searchResults} />
+            <SearchResultsHeader searchResults={searchResults} />
+            <SearchResultsCount count={searchResults.total} />
+            <ul data-testid="search-list">
+              {searchResults["@graph"].map((item) => {
+                // For each item, get the appropriate search-list item renderer for it, or the
+                // fallback render if the item type doesn't have one.
+                const SearchListItemRenderer = getSearchListItemRenderer(item);
+                return (
+                  <SearchListItem
+                    key={item["@id"]}
+                    testid={item["@id"]}
+                    href={item["@id"]}
+                  >
+                    <SearchListItemRenderer
+                      item={item}
+                      accessoryData={accessoryData}
+                    />
+                  </SearchListItem>
+                );
+              })}
+            </ul>
+          </div>
+        </div>
       ) : (
         <NoCollectionData pageTitle="list items" />
       )}

--- a/pages/sequence-data/[id].js
+++ b/pages/sequence-data/[id].js
@@ -92,8 +92,8 @@ export async function getServerSideProps({ params, req }) {
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const sequenceData = await request.getObject(`/sequence-data/${params.id}/`);
   if (FetchRequest.isResponseSuccess(sequenceData)) {
-    const award = await request.getObject(sequenceData.award, null);
-    const lab = await request.getObject(sequenceData.lab, null);
+    const award = await request.getObject(sequenceData.award["@id"], null);
+    const lab = await request.getObject(sequenceData.lab["@id"], null);
     const fileSet = await request.getObject(sequenceData.file_set, null);
     const documents = sequenceData.documents
       ? await request.getMultipleObjects(sequenceData.documents, null, {

--- a/pages/technical-samples/[uuid].js
+++ b/pages/technical-samples/[uuid].js
@@ -22,14 +22,7 @@ import { formatDate } from "../../lib/dates";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 
-export default function TechnicalSample({
-  sample,
-  award = null,
-  documents,
-  lab = null,
-  source = null,
-  technicalSampleTerm,
-}) {
+export default function TechnicalSample({ sample, documents }) {
   return (
     <>
       <Breadcrumbs />
@@ -41,7 +34,7 @@ export default function TechnicalSample({
             <DataItemValue>
               <Status status={sample.status} />
             </DataItemValue>
-            <SampleDataItems sample={sample} source={source}>
+            <SampleDataItems sample={sample} source={sample.source}>
               {sample.date && (
                 <>
                   <DataItemLabel>Technical Sample Date</DataItemLabel>
@@ -52,8 +45,8 @@ export default function TechnicalSample({
               <DataItemValue>{sample.sample_material}</DataItemValue>
               <DataItemLabel>Technical Sample Term</DataItemLabel>
               <DataItemValue>
-                <Link href={technicalSampleTerm["@id"]}>
-                  {technicalSampleTerm.term_name}
+                <Link href={sample.technical_sample_term["@id"]}>
+                  {sample.technical_sample_term.term_name}
                 </Link>
               </DataItemValue>
             </SampleDataItems>
@@ -65,7 +58,7 @@ export default function TechnicalSample({
             <DocumentTable documents={documents} />
           </>
         )}
-        <Attribution award={award} lab={lab} />
+        <Attribution award={sample.award} lab={sample.lab} />
       </EditableItem>
     </>
   );
@@ -74,34 +67,19 @@ export default function TechnicalSample({
 TechnicalSample.propTypes = {
   // Technical sample to display
   sample: PropTypes.object.isRequired,
-  // Award applied to this technical sample
-  award: PropTypes.object,
   // Documents associated with this technical sample
   documents: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Lab that submitted this technical sample
-  lab: PropTypes.object,
-  // Source lab or source for this technical sample
-  source: PropTypes.object,
-  // Tehnical sample ontology for the technical sample
-  technicalSampleTerm: PropTypes.object.isRequired,
 };
 
 export async function getServerSideProps({ params, req }) {
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const sample = await request.getObject(`/technical-samples/${params.uuid}/`);
   if (FetchRequest.isResponseSuccess(sample)) {
-    const award = await request.getObject(sample.award, null);
     const documents = sample.documents
       ? await request.getMultipleObjects(sample.documents, null, {
           filterErrors: true,
         })
       : [];
-    const lab = await request.getObject(sample.lab, null);
-    const source = await request.getObject(sample.source, null);
-    const technicalSampleTerm = await request.getObject(
-      sample.technical_sample_term,
-      null
-    );
     const breadcrumbs = await buildBreadcrumbs(
       sample,
       "accession",
@@ -110,15 +88,9 @@ export async function getServerSideProps({ params, req }) {
     return {
       props: {
         sample,
-        award,
         documents,
-        lab,
-        source,
-        technicalSampleTerm,
         pageContext: {
-          title: `${
-            technicalSampleTerm ? `${technicalSampleTerm.term_name} — ` : ""
-          }${sample.accession}`,
+          title: sample.accession,
         },
         breadcrumbs,
       },

--- a/pages/whole-organisms/[id].js
+++ b/pages/whole-organisms/[id].js
@@ -106,15 +106,19 @@ export async function getServerSideProps({ params, req }) {
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const sample = await request.getObject(`/whole-organisms/${params.id}/`);
   if (FetchRequest.isResponseSuccess(sample)) {
-    const award = await request.getObject(sample.award, null);
+    const award = await request.getObject(sample.award["@id"], null);
     const biosampleTerm = sample.biosample_term
-      ? await request.getObject(sample.biosample_term, null)
+      ? await request.getObject(sample.biosample_term["@id"], null)
       : null;
-    const diseaseTerms = sample.disease_terms
-      ? await request.getMultipleObjects(sample.disease_terms, null, {
-          filterErrors: true,
-        })
-      : [];
+    let diseaseTerms = [];
+    if (sample.disease_terms?.length > 0) {
+      const diseaseTermPaths = sample.disease_terms.map(
+        (diseaseTerm) => diseaseTerm["@id"]
+      );
+      diseaseTerms = await request.getMultipleObjects(diseaseTermPaths, null, {
+        filterErrors: true,
+      });
+    }
     const documents = sample.documents
       ? await request.getMultipleObjects(sample.documents, null, {
           filterErrors: true,
@@ -125,13 +129,17 @@ export async function getServerSideProps({ params, req }) {
           filterErrors: true,
         })
       : [];
-    const lab = await request.getObject(sample.lab, null);
-    const source = await request.getObject(sample.source, null);
-    const treatments = sample.treatments
-      ? await request.getMultipleObjects(sample.treatments, null, {
-          filterErrors: true,
-        })
-      : [];
+    const lab = await request.getObject(sample.lab["@id"], null);
+    const source = await request.getObject(sample.source["@id"], null);
+    let treatments = [];
+    if (sample.treatments?.length > 0) {
+      const treatmentPaths = sample.treatments.map(
+        (treatment) => treatment["@id"]
+      );
+      treatments = await request.getMultipleObjects(treatmentPaths, null, {
+        filterErrors: true,
+      });
+    }
     const pooledFrom =
       sample.pooled_from?.length > 0
         ? await request.getMultipleObjects(sample.pooled_from, null, {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -72,6 +72,19 @@
   --color-button-warning-label-disabled: #d8d8d8;
   --color-button-selected-label-disabled: #b1bad3;
 
+  --color-facet-group-button-background: #f0e7ca;
+  --color-facet-group-button-selected-background: #bfa678;
+  --color-facet-group-button-border: #998868;
+  --color-facet-group-button-selected-border: #998868;
+  --color-facet-group-icon-background: #000000;
+  --color-facet-group-icon-stroke: #000000;
+  --color-facet-group-button-selected-text: #000000;
+  --color-facet-group-button-border: #d1d5db;
+  --color-facet-group-button-text: #000000;
+
+  --color-facet-title-background: #b2d0de;
+  --color-facet-title-text: #000000;
+
   --color-form-element-background: #ffffff;
   --color-form-element-border: #384977;
   --color-form-element-label: #000000;
@@ -102,7 +115,7 @@
   --color-document-tsv: #a50104;
 
   /** Modal borders */
-  --color-modal-border: #e5e7eb;
+  --color-modal-border: #cecfd3;
 
   /** Typography */
   --color-code-background: #e0e0e0;
@@ -145,6 +158,14 @@
   --color-button-secondary-label-disabled: #606060;
   --color-button-warning-label-disabled: #808080;
   --color-button-selected-label-disabled: #606060;
+
+  --color-facet-group-button-background: #524f45;
+  --color-facet-group-button-border: #998868;
+  --color-facet-group-button-text: #ffffff;
+  --color-facet-group-button-selected-text: #ffffff;
+
+  --color-facet-title-background: #536167;
+  --color-facet-title-text: #ffffff;
 
   --color-data-header-background: #192339;
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -51,6 +51,11 @@ module.exports = {
           "var(--color-button-warning-background-disabled)",
         "button-selected-disabled":
           "var(--color-button-selected-background-disabled)",
+
+        "facet-group-button": "var(--color-facet-group-button-background)",
+        "facet-group-button-selected":
+          "var(--color-facet-group-button-selected-background)",
+        "facet-title": "var(--color-facet-title-background)",
       },
       borderColor: {
         panel: "var(--color-panel-border)",
@@ -69,6 +74,10 @@ module.exports = {
           "var(--color-button-warning-border-disabled)",
         "button-selected-disabled":
           "var(--color-button-selected-border-disabled)",
+
+        "facet-group-button": "var(--color-facet-group-button-border)",
+        "facet-group-button-selected":
+          "var(--color-facet-group-button-selected-border)",
       },
       fontSize: {
         xxs: "0.7rem",
@@ -85,6 +94,11 @@ module.exports = {
           "var(--color-button-selected-label-disabled)",
         "form-element": "var(--color-form-element-label)",
         "form-element-disabled": "var(--color-form-element-label-disabled)",
+
+        "button-facet-group": "var(--color-button-facet-group-text)",
+        "button-facet-group-selected":
+          "var(--color-button-facet-group-selected-text)",
+        "facet-title": "var(--color-facet-title-text)",
       },
       boxShadow: {
         // Status badges


### PR DESCRIPTION
I had to change the `<UnknownObject>` cell renderer to not have a modal nor a state controlling the modal’s visibility. With facets, you can change the number of rows in a report table. This causes `<UnknownObject>` to render a different number of times the next render, and React doesn’t allow a different number of `useState` calls between renders. I don’t know any way around this besides not having that `useState` call in a cell renderer. You can promote the state to `<DataGrid>`, but that means `<DataGrid>` has to have a modal boolean, which seems completely irrelevant to a generic grid-display component.

Once we merge this, I need to revert the change to the cdk config, as well as the CircleCI config to not point to different branches anymore.