### PR TITLE
IGVF-477 Display audits on search lists and object pages

### DIFF
--- a/components/__tests__/audit.test.js
+++ b/components/__tests__/audit.test.js
@@ -1,0 +1,389 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { useAuth0 } from "@auth0/auth0-react";
+import { AuditDetail, AuditStatus, useAudit } from "../audit";
+
+/**
+ * Method to mock the useAuth0 hook comes from:
+ * https://stackoverflow.com/questions/45758366/how-to-change-jest-mock-function-return-value-in-each-testanswer-45758767
+ * This method lets you change the return values of the hook between tests.
+ */
+jest.mock("@auth0/auth0-react", () => ({
+  useAuth0: jest.fn(),
+}));
+
+// Needed because of animations.
+global.scrollTo = jest.fn();
+
+/**
+ * Mimics a full audit object within an item object.
+ */
+const demoAudit = {
+  ERROR: [
+    {
+      category: "extremely low read depth",
+      detail:
+        "Alignment file {ENCFF557RSA|/files/ENCFF557RSA/} processed by ATAC-seq ENCODE4 v2.1.1 GRCh38 pipeline has 8585759 usable fragments. According to ENCODE4 standards, ATAC-seq assays processed by the uniform processing pipeline should have > 25 million usable fragments. 20-25 million is acceptable and < 15 million is not compliant.",
+      level: 60,
+      level_name: "ERROR",
+      path: "/analyses/ENCAN615CMZ/",
+      name: "audit_analysis",
+    },
+  ],
+  WARNING: [
+    {
+      category: "mixed read lengths",
+      detail:
+        "Biological replicate 1 in experiment {ENCSR859USB|/experiments/ENCSR859USB/} has mixed sequencing read lengths (33, 36).",
+      level: 40,
+      level_name: "WARNING",
+      path: "/experiments/ENCSR859USB/",
+      name: "audit_experiment",
+    },
+    {
+      category: "moderate number of reproducible peaks",
+      detail:
+        "According to ENCODE4 standards, ATAC-seq assays processed by the uniform processing pipeline should have either >150k reproducible peaks in an overlap peaks file, or >70k in an IDR thresholded peaks file. 100-150k or 50-70k peaks respectively is acceptable, and <100k or <50k respectively is not compliant. File(s) {ENCFF055NNT|/files/ENCFF055NNT/} (overlap peaks) and {ENCFF926KTI|/files/ENCFF926KTI/} (IDR thresholded peaks) processed by ATAC-seq ENCODE4 v2.1.1 GRCh38 pipeline have 99862 and 55575 peaks.",
+      level: 40,
+      level_name: "WARNING",
+      path: "/analyses/ENCAN615CMZ/",
+      name: "audit_analysis",
+    },
+  ],
+  NOT_COMPLIANT: [
+    {
+      category: "insufficient read depth",
+      detail:
+        "Alignment file processed by ATAC-seq ENCODE4 v2.1.1 GRCh38 pipeline has 15065125 usable fragments. According to ENCODE4 standards, ATAC-seq assays processed by the uniform processing pipeline should have > 25 million usable fragments. 20-25 million is acceptable and < 15 million is not compliant.",
+      level: 50,
+      level_name: "NOT_COMPLIANT",
+      path: "/analyses/ENCAN615CMZ/",
+      name: "audit_analysis",
+    },
+  ],
+  INTERNAL_ACTION: [
+    {
+      category: "mismatched status",
+      detail:
+        "{ENCAN615CMZ|/analyses/ENCAN615CMZ/} has in progress subobject quality standard {encode4-atac-seq|/quality-standards/encode4-atac-seq/}",
+      level: 30,
+      level_name: "INTERNAL_ACTION",
+      path: "/analyses/ENCAN615CMZ/",
+      name: "audit_item_status",
+    },
+  ],
+  FAKE: [
+    {
+      category:
+        "fake level to make sure we can deal with a new level without crashing",
+      detail: "Stuff",
+      level: 0,
+      level_name: "FAKE",
+      path: "/analyses/ENCAN615CMZ/",
+      name: "audit_item_status",
+    },
+  ],
+};
+
+describe("Test the AuditStatus and AuditDetail components together", () => {
+  it("renders the AuditStatus button and the AuditDetail panel if the button is clicked", async () => {
+    useAuth0.mockReturnValue({ isLoading: false, isAuthenticated: false });
+
+    function AuditTestComponent() {
+      const auditState = useAudit();
+      const item = {
+        "@id": "/path/item",
+        audit: demoAudit,
+      };
+
+      return (
+        <>
+          <AuditStatus item={item} auditState={auditState} />
+          <AuditDetail item={item} auditState={auditState} />
+        </>
+      );
+    }
+
+    render(<AuditTestComponent />);
+
+    // Make sure the button has the correct Tailwind CSS class for open audit details.
+    let auditStatusButton = screen.getByTestId("audit-status-button");
+    expect(auditStatusButton).toHaveClass("bg-button-audit-closed");
+
+    // Click on the button to open the audit details.
+    fireEvent.click(auditStatusButton);
+
+    // Make sure the button has the correct Tailwind CSS class for closed audit details.
+    auditStatusButton = screen.getByTestId("audit-status-button");
+    expect(auditStatusButton).toHaveClass("bg-button-audit-open");
+
+    // Make sure the audit detail panel appears.
+    expect(screen.getByTestId("audit-detail-panel")).toBeInTheDocument();
+  });
+});
+
+describe("Test the AuditStatus button", () => {
+  it("renders all four possible audits while signed in, and it reacts to clicks", () => {
+    useAuth0.mockReturnValueOnce({ isLoading: false, isAuthenticated: true });
+
+    const item = {
+      "@id": "/path/item",
+      audit: demoAudit,
+    };
+    const auditState = {
+      isDetailOpen: false,
+      toggleDetailsOpen: jest.fn(),
+    };
+
+    render(<AuditStatus item={item} auditState={auditState} />);
+
+    const auditStatusButton = screen.getByTestId("audit-status-button");
+    expect(auditStatusButton).toBeInTheDocument();
+
+    // Make sure it an icon for each of the four audit levels.
+    let auditStatusIcon =
+      within(auditStatusButton).getByTestId("audit-error-icon");
+    expect(auditStatusIcon).toBeInTheDocument();
+    auditStatusIcon =
+      within(auditStatusButton).getByTestId("audit-warning-icon");
+    expect(auditStatusIcon).toBeInTheDocument();
+    auditStatusIcon = within(auditStatusButton).getByTestId(
+      "audit-not-compliant-icon"
+    );
+    expect(auditStatusIcon).toBeInTheDocument();
+    auditStatusIcon = within(auditStatusButton).getByTestId(
+      "audit-internal-action-icon"
+    );
+    expect(auditStatusIcon).toBeInTheDocument();
+
+    // Make sure the button has the correct Tailwind CSS class for closed audit details.
+    expect(auditStatusButton).toHaveClass("bg-button-audit-closed");
+  });
+
+  it("renders three of the possible four audits while signed out", () => {
+    useAuth0.mockReturnValueOnce({ isLoading: false, isAuthenticated: false });
+
+    const item = {
+      "@id": "/path/item",
+      audit: demoAudit,
+    };
+    const auditState = {
+      isDetailOpen: false,
+      toggleDetailsOpen: jest.fn(),
+    };
+
+    render(<AuditStatus item={item} auditState={auditState} />);
+
+    const auditStatusButton = screen.getByTestId("audit-status-button");
+    expect(auditStatusButton).toBeInTheDocument();
+
+    // Make sure it an icon for each of the four audit levels.
+    let auditStatusIcon =
+      within(auditStatusButton).getByTestId("audit-error-icon");
+    expect(auditStatusIcon).toBeInTheDocument();
+    auditStatusIcon =
+      within(auditStatusButton).getByTestId("audit-warning-icon");
+    expect(auditStatusIcon).toBeInTheDocument();
+    auditStatusIcon = within(auditStatusButton).getByTestId(
+      "audit-not-compliant-icon"
+    );
+    expect(auditStatusIcon).toBeInTheDocument();
+    auditStatusIcon = within(auditStatusButton).queryByTestId(
+      "audit-internal-action-icon"
+    );
+    expect(auditStatusIcon).toBeNull();
+  });
+
+  it("renders a highlighted status button if audit details are open", () => {
+    useAuth0.mockReturnValueOnce({ isLoading: false, isAuthenticated: false });
+
+    const item = {
+      "@id": "/path/item",
+      audit: demoAudit,
+    };
+    const auditState = {
+      isDetailOpen: true,
+      toggleDetailsOpen: jest.fn(),
+    };
+
+    render(<AuditStatus item={item} auditState={auditState} />);
+
+    // Make sure the button has the correct Tailwind CSS class for open audit details.
+    expect(screen.getByTestId("audit-status-button")).toHaveClass(
+      "bg-button-audit-open"
+    );
+  });
+
+  it("renders no audit status button if no audits exist in an item", () => {
+    useAuth0.mockReturnValueOnce({ isLoading: false, isAuthenticated: false });
+
+    const item = {
+      "@id": "/path/item",
+    };
+    const auditState = {
+      isDetailOpen: false,
+      toggleDetailsOpen: jest.fn(),
+    };
+
+    render(<AuditStatus item={item} auditState={auditState} />);
+    expect(screen.queryByTestId("audit-status-button")).toBeNull();
+  });
+
+  it("renders no audit status button if the item has empty audits", () => {
+    useAuth0.mockReturnValueOnce({ isLoading: false, isAuthenticated: false });
+
+    const item = {
+      "@id": "/path/item",
+      audit: {},
+    };
+    const auditState = {
+      isDetailOpen: false,
+      toggleDetailsOpen: jest.fn(),
+    };
+
+    render(<AuditStatus item={item} auditState={auditState} />);
+    expect(screen.queryByTestId("audit-status-button")).toBeNull();
+  });
+});
+
+describe("Test the AuditDetail panel", () => {
+  it("renders the audit detail panel and all four levels if it's open and signed in", () => {
+    useAuth0.mockReturnValueOnce({ isLoading: false, isAuthenticated: true });
+
+    const item = {
+      "@id": "/path/item",
+      audit: demoAudit,
+    };
+    const auditState = {
+      isDetailOpen: true,
+      toggleDetailsOpen: jest.fn(),
+    };
+
+    render(<AuditDetail item={item} auditState={auditState} />);
+
+    expect(screen.getByTestId("audit-detail-panel")).toBeInTheDocument();
+
+    // Make sure all four of the level panels appear.
+    expect(screen.getByTestId("audit-level-detail-ERROR")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("audit-level-detail-WARNING")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("audit-level-detail-NOT_COMPLIANT")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("audit-level-detail-INTERNAL_ACTION")
+    ).toBeInTheDocument();
+  });
+
+  it("renders the audit detail panel and three levels if it's open and signed out", () => {
+    useAuth0.mockReturnValueOnce({ isLoading: false, isAuthenticated: false });
+
+    const item = {
+      "@id": "/path/item",
+      audit: demoAudit,
+    };
+    const auditState = {
+      isDetailOpen: true,
+      toggleDetailsOpen: jest.fn(),
+    };
+
+    render(<AuditDetail item={item} auditState={auditState} />);
+
+    expect(screen.getByTestId("audit-detail-panel")).toBeInTheDocument();
+
+    // Make sure all four of the level panels appear.
+    expect(screen.getByTestId("audit-level-detail-ERROR")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("audit-level-detail-WARNING")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("audit-level-detail-NOT_COMPLIANT")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("audit-level-detail-INTERNAL_ACTION")
+    ).toBeNull();
+  });
+
+  it("reacts to clicks in a detail button to render the detail text", async () => {
+    useAuth0.mockReturnValueOnce({ isLoading: false, isAuthenticated: true });
+
+    const item = {
+      "@id": "/path/item",
+      audit: demoAudit,
+    };
+    const auditState = {
+      isDetailOpen: true,
+      toggleDetailsOpen: jest.fn(),
+    };
+
+    render(<AuditDetail item={item} auditState={auditState} />);
+
+    expect(screen.getByTestId("audit-detail-panel")).toBeInTheDocument();
+
+    // Click on the button for the ERROR level that includes a link.
+    const errorDetail = screen.getByTestId("audit-level-detail-ERROR");
+    expect(errorDetail).toBeInTheDocument();
+    const errorDetailButton = within(errorDetail).getByRole("button");
+    fireEvent.click(errorDetailButton);
+    await waitFor(() =>
+      screen.queryByTestId("audit-level-detail-narrative-ERROR")
+    );
+
+    let narrative = screen.queryByTestId("audit-level-detail-narrative-ERROR");
+    expect(within(narrative).getByRole("link")).toHaveAttribute(
+      "href",
+      "/files/ENCFF557RSA"
+    );
+
+    // Click on the button for the NOT_COMPLIANT level that doesn't include a link.
+    const notCompliantDetail = screen.getByTestId(
+      "audit-level-detail-NOT_COMPLIANT"
+    );
+    expect(notCompliantDetail).toBeInTheDocument();
+    const internalActionButton = within(notCompliantDetail).getByRole("button");
+    fireEvent.click(internalActionButton);
+    await waitFor(() =>
+      screen.queryByTestId("audit-level-detail-narrative-NOT_COMPLIANT")
+    );
+
+    narrative = screen.queryByTestId(
+      "audit-level-detail-narrative-NOT_COMPLIANT"
+    );
+    expect(within(narrative).queryByRole("link")).toBeNull();
+
+    // Click on the button for the INTERNAL_ACTION level that begins with a link.
+    const internalActionDetail = screen.getByTestId(
+      "audit-level-detail-INTERNAL_ACTION"
+    );
+    expect(internalActionDetail).toBeInTheDocument();
+    const internalActionDetailButton =
+      within(internalActionDetail).getByRole("button");
+    fireEvent.click(internalActionDetailButton);
+    await waitFor(() =>
+      screen.queryByTestId("audit-level-detail-narrative-INTERNAL_ACTION")
+    );
+  });
+
+  it("doesn't render the audit detail panel if it's closed", () => {
+    useAuth0.mockReturnValueOnce({ isLoading: false, isAuthenticated: false });
+
+    const item = {
+      "@id": "/path/item",
+      audit: demoAudit,
+    };
+    const auditState = {
+      isDetailOpen: false,
+      toggleDetailsOpen: jest.fn(),
+    };
+
+    render(<AuditDetail item={item} auditState={auditState} />);
+
+    expect(screen.queryByTestId("audit-detail-panel")).toBeNull();
+  });
+});

--- a/components/animation.js
+++ b/components/animation.js
@@ -1,0 +1,8 @@
+/**
+ * Framer Motion animation variants and transition for height=0 to height=auto animations.
+ */
+export const standardAnimationTransition = { duration: 0.2, ease: "easeInOut" };
+export const standardAnimationVariants = {
+  open: { height: "auto" },
+  collapsed: { height: 0 },
+};

--- a/components/audit.js
+++ b/components/audit.js
@@ -1,0 +1,375 @@
+// node_modules
+import { AnimatePresence, motion } from "framer-motion";
+import Link from "next/link";
+import PropTypes from "prop-types";
+import { useState } from "react";
+// components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
+import { useAuthenticated } from "./authentication";
+import Icon from "./icon";
+
+/**
+ * The following small components render the custom icons for each audit level.
+ */
+function ErrorIcon({ className }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      data-testid="audit-error-icon"
+    >
+      <path d="M18.9,16L11.2,2.7c-0.5-0.9-1.9-0.9-2.4,0L1.1,16C0.6,16.9,1.3,18,2.3,18h15.4C18.7,18,19.4,16.9,18.9,16z" />
+    </svg>
+  );
+}
+
+ErrorIcon.propTypes = {
+  // Tailwind CSS classes to add to the icon
+  className: PropTypes.string.isRequired,
+};
+
+function WarningIcon({ className }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      data-testid="audit-warning-icon"
+    >
+      <circle cx="10" cy="10" r="8" />
+    </svg>
+  );
+}
+
+WarningIcon.propTypes = {
+  // Tailwind CSS classes to add to the icon
+  className: PropTypes.string.isRequired,
+};
+
+function NotCompliantIcon({ className }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      data-testid="audit-not-compliant-icon"
+    >
+      <path d="M18,4.2C18,3,17,2,15.8,2H4.2C3,2,2,3,2,4.2v11.5C2,17,3,18,4.2,18h11.5c1.2,0,2.3-1,2.3-2.3" />
+    </svg>
+  );
+}
+
+NotCompliantIcon.propTypes = {
+  // Tailwind CSS classes to add to the icon
+  className: PropTypes.string.isRequired,
+};
+
+function InternalActionIcon({ className }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      data-testid="audit-internal-action-icon"
+    >
+      <path d="M18.9,4l-7.7,13.3c-0.5,0.9-1.9,0.9-2.4,0L1.1,4C0.6,3.1,1.3,2,2.3,2h15.4C18.7,2,19.4,3.1,18.9,4z" />
+    </svg>
+  );
+}
+
+InternalActionIcon.propTypes = {
+  // Tailwind CSS classes to add to the icon
+  className: PropTypes.string.isRequired,
+};
+
+/**
+ * Maps an audit level to an icon and color.
+ */
+const auditMap = {
+  ERROR: {
+    Icon: ErrorIcon,
+    color: "fill-red-500",
+    humanReadable: "Error",
+  },
+  WARNING: {
+    Icon: WarningIcon,
+    color: "fill-orange-500",
+    humanReadable: "Warning",
+  },
+  NOT_COMPLIANT: {
+    Icon: NotCompliantIcon,
+    color: "fill-fuchsia-500",
+    humanReadable: "Not Compliant",
+  },
+  INTERNAL_ACTION: {
+    Icon: InternalActionIcon,
+    color: "fill-blue-600",
+    humanReadable: "Internal Action",
+  },
+};
+
+/**
+ * For convenience, a list of all audit levels.
+ */
+const allLevels = Object.keys(auditMap);
+
+/**
+ * List of audit levels viewable without authentication.
+ */
+const publicLevels = allLevels.filter((level) => level !== "INTERNAL_ACTION");
+
+// Regex to find a simplified markdown in the form "{link text|path}"
+const markdownRegex = /{(.+?)\|(.+?)}/g;
+
+/**
+ * Display the audit narrative with embedded links. This gets displayed in each row of the audit
+ * details. Links, if they exist in the `narrative` text, must be formatted in this form:
+ * {link text|URI}
+ */
+function NarrativeWithLinks({ narrative }) {
+  let linkMatches = markdownRegex.exec(narrative);
+  if (linkMatches) {
+    // `narrative` has at least one "markdown" sequence, so treat the whole thing as marked-down
+    // text. Each loop iteration finds each markdown sequence. That gets broken into the non-link
+    // text before the link and then the link itself.
+    const renderedDetail = [];
+    let segmentIndex = 0;
+    while (linkMatches) {
+      const linkText = linkMatches[1];
+      const linkPath = linkMatches[2];
+      const preText = narrative.substring(segmentIndex, linkMatches.index);
+      renderedDetail.push(
+        preText ? <span key={segmentIndex}>{preText}</span> : null,
+        <Link href={linkPath} key={linkMatches.index}>
+          {linkText}
+        </Link>
+      );
+      segmentIndex = linkMatches.index + linkMatches[0].length;
+      linkMatches = markdownRegex.exec(narrative);
+    }
+
+    // Lastly, render any non-link text after the last link.
+    const postText = narrative.substring(segmentIndex, narrative.length);
+    return renderedDetail.concat(
+      postText ? <span key={segmentIndex}>{postText}</span> : null
+    );
+  }
+  return narrative;
+}
+
+NarrativeWithLinks.propTypes = {
+  // Audit narrative text containing formatted links
+  narrative: PropTypes.string.isRequired,
+};
+
+/**
+ * Custom hook to allow components that display audits to manage the audit status button and
+ * details without needing to know the audit implementation.
+ * @returns {object} Audit status and functions
+ */
+export function useAudit() {
+  const [isDetailOpen, setIsPanelOpen] = useState(false);
+
+  function toggleDetailsOpen() {
+    setIsPanelOpen(!isDetailOpen);
+  }
+
+  return {
+    // states
+    isDetailOpen,
+    // functions
+    toggleDetailsOpen,
+  };
+}
+
+/**
+ * Displays the details for one level of audits. The user can click a button here to open the audit
+ * narrative for each audit at this level.
+ */
+function AuditLevelDetail({ level, children }) {
+  // True if the narratives for an audit level are open
+  const [areNarrativesOpen, setAreNarrativesOpen] = useState(false);
+
+  return (
+    <div
+      className={`my-0.5 bg-audit-level-detail p-px`}
+      data-testid={`audit-level-detail-${level}`}
+    >
+      <button
+        className="mx-auto block rounded-full p-0.5 hover:bg-button-audit-level-detail"
+        onClick={() => setAreNarrativesOpen(!areNarrativesOpen)}
+        aria-label={`${areNarrativesOpen ? "Open" : "Closed"} narratives for ${
+          auditMap[level]?.humanReadable || "Unknown"
+        } audits`}
+      >
+        <Icon.EllipsisHorizontal className="w-6" />
+      </button>
+      {children(areNarrativesOpen)}
+    </div>
+  );
+}
+
+AuditLevelDetail.propTypes = {
+  // Audit level
+  level: PropTypes.string.isRequired,
+};
+
+/**
+ * Displays the details of an audit, including all audit levels. The user can open audit details,
+ * and then can also open the audit narratives for each audit level.
+ */
+export function AuditDetail({ item, auditState, className = null }) {
+  const isAuthenticated = useAuthenticated();
+  const hasAudits = item.audit && Object.keys(item.audit).length > 0;
+
+  return (
+    <AnimatePresence>
+      {hasAudits && auditState.isDetailOpen && (
+        <motion.div
+          className="overflow-hidden"
+          initial="collapsed"
+          animate="open"
+          exit="collapsed"
+          transition={standardAnimationTransition}
+          variants={standardAnimationVariants}
+          data-testid="audit-detail-panel"
+        >
+          <div className={className}>
+            {Object.keys(item.audit).map((level) => {
+              if (isAuthenticated || publicLevels.includes(level)) {
+                const levelAudits = item.audit[level];
+                const AuditIcon = auditMap[level]?.Icon || null;
+                return (
+                  <AuditLevelDetail key={level} level={level}>
+                    {(areNarrativesOpen) => {
+                      return levelAudits.map((audit) => {
+                        return (
+                          <div
+                            className={`my-px bg-panel p-1 first:mt-0 last:mb-0`}
+                            key={`${audit.category}-${audit.detail}`}
+                          >
+                            <div className="flex items-center text-sm font-semibold">
+                              {AuditIcon && (
+                                <AuditIcon
+                                  className={`mr-1 h-5 w-5 ${auditMap[level].color}`}
+                                />
+                              )}
+                              <div>{audit.category}</div>
+                            </div>
+                            <AnimatePresence>
+                              {areNarrativesOpen && (
+                                <motion.div
+                                  className="overflow-hidden text-sm leading-relaxed"
+                                  initial="collapsed"
+                                  animate="open"
+                                  exit="collapsed"
+                                  transition={standardAnimationTransition}
+                                  variants={standardAnimationVariants}
+                                >
+                                  <div
+                                    className="mt-2"
+                                    data-testid={`audit-level-detail-narrative-${audit.level_name}`}
+                                  >
+                                    <NarrativeWithLinks
+                                      narrative={audit.detail}
+                                    />
+                                  </div>
+                                </motion.div>
+                              )}
+                            </AnimatePresence>
+                          </div>
+                        );
+                      });
+                    }}
+                  </AuditLevelDetail>
+                );
+              }
+              return null;
+            })}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+AuditDetail.propTypes = {
+  // Item with audits to display
+  item: PropTypes.object.isRequired,
+  auditState: PropTypes.shape({
+    // True if the audit details are open
+    isDetailOpen: PropTypes.bool.isRequired,
+    // Function to toggle the audit details open or closed
+    toggleDetailsOpen: PropTypes.func.isRequired,
+  }).isRequired,
+  // Tailwind CSS classes to add to the wrapper around the audit details
+  className: PropTypes.string,
+};
+
+/**
+ * Displays the audit status button for an item.
+ */
+export function AuditStatus({ item, auditState }) {
+  const isAuthenticated = useAuthenticated();
+  const hasAudits = item.audit && Object.keys(item.audit).length > 0;
+
+  if (hasAudits) {
+    // Make an array of the human-readable audit levels for screen readers.
+    const auditLevelTexts = Object.keys(item.audit).map(
+      (level) => auditMap[level]?.humanReadable || "Unknown"
+    );
+
+    return (
+      <button
+        onClick={auditState.toggleDetailsOpen}
+        className={`flex h-[22px] items-center rounded-full border border-button-audit px-1 ${
+          auditState.isDetailOpen
+            ? "bg-button-audit-open"
+            : "bg-button-audit-closed"
+        }`}
+        aria-label={`${
+          auditState.isDetailOpen ? "Opened" : "Closed"
+        } audits for ${auditLevelTexts.join(", ")}`}
+        data-testid="audit-status-button"
+      >
+        {Object.keys(item.audit).map((level) => {
+          if (isAuthenticated || publicLevels.includes(level)) {
+            const Icon = auditMap[level]?.Icon;
+            if (Icon) {
+              return (
+                <Icon
+                  className={`h-3 w-3 ${auditMap[level].color}`}
+                  key={level}
+                />
+              );
+            }
+            return null;
+          }
+        })}
+      </button>
+    );
+  }
+
+  // Item does not have audits.
+  return null;
+}
+
+AuditStatus.propTypes = {
+  // Item with audits to display
+  item: PropTypes.object.isRequired,
+  // Audit state from `useAudits`
+  auditState: PropTypes.shape({
+    // True if the audit panel is open
+    isDetailOpen: PropTypes.bool.isRequired,
+    // Function to toggle the audit panel open/closed
+    toggleDetailsOpen: PropTypes.func.isRequired,
+  }).isRequired,
+};

--- a/components/edit-func.js
+++ b/components/edit-func.js
@@ -130,15 +130,17 @@ export function EditLink({ item }) {
   const editPath = `${removeTrailingSlash(item["@id"])}/#!edit`;
   if (canEdit(item)) {
     return (
-      <ButtonLink
-        label="Edit"
-        href={editPath}
-        type="secondary"
-        size="sm"
-        hasIconOnly
-      >
-        <PencilSquareIcon title="Edit" />
-      </ButtonLink>
+      <div className="mb-1 flex justify-end">
+        <ButtonLink
+          label="Edit"
+          href={editPath}
+          type="secondary"
+          size="sm"
+          hasIconOnly
+        >
+          <PencilSquareIcon title="Edit" />
+        </ButtonLink>
+      </div>
     );
   }
   return null;

--- a/components/edit.js
+++ b/components/edit.js
@@ -5,7 +5,7 @@ import React, { useContext, useRef, useState, useEffect } from "react";
 // components
 import { Button, ButtonLink } from "./form-elements";
 import FlashMessage from "./flash-message";
-import EditJson, { EditLink, canEdit } from "./edit-func";
+import EditJson, { canEdit } from "./edit-func";
 import SessionContext from "./session-context";
 import { useAuthenticated } from "./authentication";
 import PagePreamble from "./page-preamble";
@@ -42,16 +42,7 @@ export function useEditor(action) {
 
 export function EditableItem({ item, children }) {
   const editing = useEditor("edit");
-  return editing ? (
-    <EditPage item={item} />
-  ) : (
-    <>
-      <div className="mb-1 flex justify-end">
-        <EditLink item={item} />
-      </div>
-      {children}
-    </>
-  );
+  return editing ? <EditPage item={item} /> : <>{children}</>;
 }
 
 EditableItem.propTypes = {

--- a/components/icon.js
+++ b/components/icon.js
@@ -95,16 +95,30 @@ const Icon = {
       fill="none"
       data-testid={testid}
     >
-      <g className="stroke-2">
-        <path
-          d="M14.2,1
+      <path
+        d="M14.2,1
 	c-2.2,2.2,2.6,7,0.4,9.2c-2.2,2.2-7-2.6-9.2-0.4s2.6,7,0.4,9.2"
-        />
-        <path
-          d="M1,14.2
+      />
+      <path
+        d="M1,14.2
 	c2.2-2.2,7,2.6,9.2,0.4c2.2-2.2-2.6-7-0.4-9.2s7,2.6,9.2,0.4"
-        />
-      </g>
+      />
+    </svg>
+  ),
+  EllipsisHorizontal: ({
+    className = null,
+    testid = "icon-ellipsis-horizontal",
+  }) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      viewBox="0 0 36 8"
+      fill="currentColor"
+      data-testid={testid}
+    >
+      <circle cx="18" cy="4" r="3.4" />
+      <circle cx="31.6" cy="4" r="3.4" />
+      <circle cx="4.4" cy="4" r="3.4" />
     </svg>
   ),
   Sample: ({ className = null, testid = "icon-sample" }) => (
@@ -205,6 +219,10 @@ Icon.Circle.propTypes = {
   testid: PropTypes.string,
 };
 Icon.Donor.propTypes = {
+  className: PropTypes.string,
+  testid: PropTypes.string,
+};
+Icon.EllipsisHorizontal.propTypes = {
   className: PropTypes.string,
   testid: PropTypes.string,
 };

--- a/components/navigation.js
+++ b/components/navigation.js
@@ -23,20 +23,15 @@ import { useRouter } from "next/router";
 import PropTypes from "prop-types";
 import React, { Children, isValidElement, useContext, useState } from "react";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import Icon from "./icon";
 import SiteLogo from "./logo";
 import SessionContext from "./session-context";
 // lib
 import { AUTH_ERROR_URI } from "../lib/constants";
-
-/**
- * Animation configurations for mobile and hierarchical navigation.
- */
-const navigationTransition = { duration: 0.2, ease: "easeInOut" };
-const navigationVariants = {
-  open: { height: "auto" },
-  collapsed: { height: 0 },
-};
 
 /**
  * Renders collapsable navigation items, both for the mobile menu and for collapsable children of
@@ -52,8 +47,8 @@ function NavigationCollapsableArea({ isOpen, testid = "", children }) {
           initial="collapsed"
           animate="open"
           exit="collapsed"
-          transition={navigationTransition}
-          variants={navigationVariants}
+          transition={standardAnimationTransition}
+          variants={standardAnimationVariants}
         >
           {children}
         </motion.div>

--- a/components/object-page-header.js
+++ b/components/object-page-header.js
@@ -1,0 +1,28 @@
+// node_modules
+import PropTypes from "prop-types";
+// components
+import { AuditDetail, useAudit } from "./audit";
+import { EditLink } from "./edit-func";
+import QualitySection from "./quality-section";
+
+/**
+ * Display the header above the data areas of an object page.
+ */
+export default function ObjectPageHeader({ item }) {
+  const auditState = useAudit();
+
+  return (
+    <>
+      <div className="flex justify-between">
+        <QualitySection item={item} auditState={auditState} />
+        <EditLink item={item} />
+      </div>
+      <AuditDetail item={item} auditState={auditState} className="mb-2" />
+    </>
+  );
+}
+
+ObjectPageHeader.propTypes = {
+  // Single object from data provider
+  item: PropTypes.object.isRequired,
+};

--- a/components/quality-section.js
+++ b/components/quality-section.js
@@ -1,0 +1,28 @@
+// node_modules
+import PropTypes from "prop-types";
+// components
+import { AuditStatus } from "./audit";
+import Status from "./status";
+
+/**
+ * Display the quality properties of an item object. This includes the status badge and the audit
+ * status button and panel.
+ */
+export default function QualitySection({ item, auditState }) {
+  return (
+    <section className="mb-1 flex items-center gap-1">
+      {item.status && <Status status={item.status} />}
+      <AuditStatus item={item} auditState={auditState} />
+    </section>
+  );
+}
+
+QualitySection.propTypes = {
+  // Item object to display the quality section for.
+  item: PropTypes.shape({
+    status: PropTypes.string,
+    audit: PropTypes.object,
+  }),
+  // State of the audit detail panel.
+  auditState: PropTypes.object.isRequired,
+};

--- a/components/search/__tests__/item.test.js
+++ b/components/search/__tests__/item.test.js
@@ -3,7 +3,7 @@ import {
   SearchListItemContent,
   SearchListItemMain,
   SearchListItemMeta,
-  SearchListItemStatus,
+  SearchListItemQuality,
   SearchListItemSupplement,
   SearchListItemSupplementContent,
   SearchListItemSupplementLabel,
@@ -38,7 +38,6 @@ describe("Test a search-list item", () => {
               <div>{term.synonyms.join(", ")}</div>
             </SearchListItemMeta>
           </SearchListItemMain>
-          <SearchListItemStatus item={term} />
           <SearchListItemSupplement>
             <SearchListItemSupplementSection>
               <SearchListItemSupplementLabel>
@@ -49,6 +48,7 @@ describe("Test a search-list item", () => {
               </SearchListItemSupplementContent>
             </SearchListItemSupplementSection>
           </SearchListItemSupplement>
+          <SearchListItemQuality item={term} />
         </SearchListItemContent>
       </SearchListItem>
     );
@@ -62,9 +62,6 @@ describe("Test a search-list item", () => {
 
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("Metadata");
-
-    const status = screen.getByTestId("search-list-item-status");
-    expect(status).toHaveTextContent("current");
 
     const supplement = screen.getByTestId("search-list-item-supplement");
     expect(supplement).toHaveTextContent("Term Supplement");

--- a/components/search/__tests__/list-renderer.test.js
+++ b/components/search/__tests__/list-renderer.test.js
@@ -22,9 +22,7 @@ import User from "../list-renderer/user";
 import Biomarker from "../list-renderer/biomarker";
 import Source from "../list-renderer/source";
 import Treatment from "../list-renderer/treatment";
-import HumanGenomicVariant, {
-  humanGenomicVariantTitle,
-} from "../list-renderer/human-genomic-variant";
+import HumanGenomicVariant from "../list-renderer/human-genomic-variant";
 
 /**
  * For objects in the profiles mock, the displayed item type is the human-readable title of the
@@ -59,7 +57,7 @@ describe("Test OntologyTerm component", () => {
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("MPRA");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 
@@ -90,7 +88,7 @@ describe("Test OntologyTerm component", () => {
     const meta = screen.queryByTestId("search-list-item-meta");
     expect(meta).toBeNull();
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 });
@@ -127,7 +125,7 @@ describe("Test Award component", () => {
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("predictive modeling");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("current");
   });
 
@@ -161,7 +159,7 @@ describe("Test Award component", () => {
     const meta = screen.queryByTestId("search-list-item-meta");
     expect(meta).toBeNull();
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("current");
   });
 
@@ -211,7 +209,7 @@ describe("Test Award component", () => {
     expect(meta).toHaveTextContent("Lea Starit");
     expect(meta).toHaveTextContent("predictive modeling");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("current");
 
     const paths = Award.getAccessoryDataPaths([item]);
@@ -257,7 +255,7 @@ describe("Test the Biosample component", () => {
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 });
@@ -306,7 +304,7 @@ describe("Test Document component", () => {
     expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
     expect(meta).toHaveTextContent("characterization");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("in progress");
   });
 });
@@ -342,7 +340,7 @@ describe("Test Gene component", () => {
     expect(meta).toHaveTextContent("BAP1");
     expect(meta).toHaveTextContent("UCHL2, HUCEP-13, KIAA0272, hucep-6");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 
@@ -375,7 +373,7 @@ describe("Test Gene component", () => {
     expect(meta).toHaveTextContent("BAP1");
     expect(meta).not.toHaveTextContent("UCHL2");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 });
@@ -457,7 +455,7 @@ describe("Test the HumanDonor component", () => {
     expect(meta).toHaveTextContent("Amount");
     expect(meta).toHaveTextContent("ENCODE");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
 
     const paths = HumanDonor.getAccessoryDataPaths([item]);
@@ -497,7 +495,7 @@ describe("Test the HumanDonor component", () => {
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("Chongyuan Luo");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 
@@ -527,7 +525,7 @@ describe("Test the HumanDonor component", () => {
     const title = screen.getByTestId("search-list-item-title");
     expect(title).toHaveTextContent(/^\/human-donors\/IGVFDO856PXB\/$/);
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 });
@@ -566,7 +564,7 @@ describe("Test the Lab component", () => {
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("1UM1HG012003-01");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("current");
   });
 
@@ -598,7 +596,7 @@ describe("Test the Lab component", () => {
     const meta = screen.queryByTestId("search-list-item-meta");
     expect(meta).toBeNull();
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("current");
   });
 });
@@ -629,7 +627,7 @@ describe("Test the Page component", () => {
     const title = screen.getByTestId("search-list-item-title");
     expect(title).toHaveTextContent(/^Human Donors$/);
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 });
@@ -675,7 +673,7 @@ describe("Test the RodentDonor component", () => {
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 });
@@ -715,7 +713,7 @@ describe("Test the TechnicalSample component", () => {
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("archived");
   });
 });
@@ -817,7 +815,7 @@ describe("Test File component", () => {
     expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
     expect(meta).toHaveTextContent("IGVFFI0000SQBR");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 
@@ -852,7 +850,7 @@ describe("Test File component", () => {
     expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
     expect(meta).not.toHaveTextContent("IGVFFI0000SQBR");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 });
@@ -904,7 +902,7 @@ describe("Test the AnalysisSet component", () => {
     );
     expect(supplement).toHaveTextContent("IGVFDS3099XPLN");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
 
     const paths = AnalysisSet.getAccessoryDataPaths([item]);
@@ -945,7 +943,7 @@ describe("Test the AnalysisSet component", () => {
     const supplement = screen.queryByTestId("search-list-item-supplement");
     expect(supplement).toBeNull();
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 });
@@ -984,7 +982,7 @@ describe("Test the CuratedSet component", () => {
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("Tim Reddy, Duke");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 
@@ -1020,7 +1018,7 @@ describe("Test the CuratedSet component", () => {
     const meta = screen.queryByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("Tim Reddy, Duke");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 });
@@ -1060,7 +1058,7 @@ describe("Test the MeasurementSet component", () => {
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 
@@ -1097,7 +1095,7 @@ describe("Test the MeasurementSet component", () => {
     const meta = screen.queryByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 });
@@ -1131,7 +1129,7 @@ describe("Test the Software component", () => {
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 });
@@ -1168,7 +1166,7 @@ describe("Test the SoftwareVersion component", () => {
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 });
@@ -1202,7 +1200,7 @@ describe("Test the Source component", () => {
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("Aviva Systems Biology");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 });
@@ -1251,7 +1249,7 @@ describe("Test the Publication component", () => {
     );
     expect(meta).toHaveTextContent("Nature. 2012-09-06;489(7414):57-74.");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 
@@ -1292,7 +1290,7 @@ describe("Test the Publication component", () => {
     expect(meta).not.toHaveTextContent("ENCODE Project Consortium");
     expect(meta).not.toHaveTextContent("Nature.");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 
@@ -1329,7 +1327,7 @@ describe("Test the Publication component", () => {
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("2012-09-06;");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 
@@ -1366,7 +1364,7 @@ describe("Test the Publication component", () => {
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("Nature.");
 
-    const status = screen.getByTestId("search-list-item-status");
+    const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
 });
@@ -1502,48 +1500,5 @@ describe("Test the Human Genomic Variant component", () => {
 
     const title = screen.getByTestId("search-list-item-title");
     expect(title.textContent).toBe("chr1:100000000:TG:GC");
-  });
-  it("Human Genomic Variant title is correct", () => {
-    const itemWithRefSeqId = {
-      "@id": "/human-genomic-variants/8138364d-f96b-42b9-a719-42199818c6fc/",
-      "@type": ["HumanGenomicVariant", "Variant", "Item"],
-      alt: "GC",
-      ref: "TG",
-      status: "in progress",
-      assembly: "GRCh38",
-      position: 100000000,
-      refseq_id: "NC_000001.1",
-      schema_version: "1",
-      creation_timestamp: "2023-03-28T05:59:17.412294+00:00",
-      selection_criteria:
-        "The variant was selected by another lab due to its frequency in an understudied population",
-      uuid: "8138364d-f96b-42b9-a719-42199818c6fc",
-      summary: "8138364d-f96b-42b9-a719-42199818c6fc",
-    };
-
-    expect(humanGenomicVariantTitle(itemWithRefSeqId)).toBe(
-      "NC_000001.1:100000000:TG:GC"
-    );
-
-    const itemWithReferenceSeq = {
-      "@id": "/human-genomic-variants/8138364d-f96b-42b9-a719-42199818c6fc/",
-      "@type": ["HumanGenomicVariant", "Variant", "Item"],
-      alt: "GC",
-      ref: "TG",
-      status: "in progress",
-      assembly: "GRCh38",
-      position: 100000000,
-      reference_sequence: "AAATCGGG",
-      schema_version: "1",
-      creation_timestamp: "2023-03-28T05:59:17.412294+00:00",
-      selection_criteria:
-        "The variant was selected by another lab due to its frequency in an understudied population",
-      uuid: "8138364d-f96b-42b9-a719-42199818c6fc",
-      summary: "8138364d-f96b-42b9-a719-42199818c6fc",
-    };
-
-    expect(humanGenomicVariantTitle(itemWithReferenceSeq)).toBe(
-      "AAATCGGG:100000000:TG:GC"
-    );
   });
 });

--- a/components/search/list-renderer/analysis-set.js
+++ b/components/search/list-renderer/analysis-set.js
@@ -1,18 +1,18 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
-  SearchListItemTitle,
-  SearchListItemType,
-  SearchListItemUniqueId,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemSupplement,
   SearchListItemSupplementSection,
   SearchListItemSupplementLabel,
   SearchListItemSupplementContent,
+  SearchListItemTitle,
+  SearchListItemType,
+  SearchListItemUniqueId,
 } from "./search-list-item";
 
 export default function AnalysisSet({ item: analysisSet, accessoryData }) {
@@ -48,7 +48,7 @@ export default function AnalysisSet({ item: analysisSet, accessoryData }) {
           </SearchListItemSupplement>
         )}
       </SearchListItemMain>
-      <SearchListItemStatus item={analysisSet} />
+      <SearchListItemQuality item={analysisSet} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/award.js
+++ b/components/search/list-renderer/award.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
   SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -28,7 +28,7 @@ export default function Award({ item: award, accessoryData }) {
           </SearchListItemMeta>
         )}
       </SearchListItemMain>
-      <SearchListItemStatus item={award} />
+      <SearchListItemQuality item={award} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/biomarker.js
+++ b/components/search/list-renderer/biomarker.js
@@ -1,10 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -27,6 +28,7 @@ export default function Biomarker({ item: biomarker }) {
           <div key="lab">{biomarker.lab.title}</div>
         </SearchListItemMeta>
       </SearchListItemMain>
+      <SearchListItemQuality item={biomarker} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/biosample.js
+++ b/components/search/list-renderer/biosample.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -26,7 +26,7 @@ export default function Biosample({ item: biosample }) {
           <div key="lab">{biosample.lab.title}</div>
         </SearchListItemMeta>
       </SearchListItemMain>
-      <SearchListItemStatus item={biosample} />
+      <SearchListItemQuality item={biosample} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/curated-set.js
+++ b/components/search/list-renderer/curated-set.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -27,7 +27,7 @@ export default function CuratedSet({ item: curatedSet }) {
           {summary && <div key="summary">{summary}</div>}
         </SearchListItemMeta>
       </SearchListItemMain>
-      <SearchListItemStatus item={curatedSet} />
+      <SearchListItemQuality item={curatedSet} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/document.js
+++ b/components/search/list-renderer/document.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -25,7 +25,7 @@ export default function Document({ item: document }) {
           <div key="document_type">{document.document_type}</div>
         </SearchListItemMeta>
       </SearchListItemMain>
-      <SearchListItemStatus item={document} />
+      <SearchListItemQuality item={document} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/file.js
+++ b/components/search/list-renderer/file.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -28,7 +28,7 @@ export default function File({ item: file }) {
           {summary && <div key="summary">{summary}</div>}
         </SearchListItemMeta>
       </SearchListItemMain>
-      <SearchListItemStatus item={file} />
+      <SearchListItemQuality item={file} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/gene.js
+++ b/components/search/list-renderer/gene.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -27,7 +27,7 @@ export default function Gene({ item: gene }) {
           )}
         </SearchListItemMeta>
       </SearchListItemMain>
-      <SearchListItemStatus item={gene} />
+      <SearchListItemQuality item={gene} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/human-donor.js
+++ b/components/search/list-renderer/human-donor.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -47,7 +47,7 @@ export default function HumanDonor({ item: humanDonor, accessoryData }) {
           )}
         </SearchListItemMeta>
       </SearchListItemMain>
-      <SearchListItemStatus item={humanDonor} />
+      <SearchListItemQuality item={humanDonor} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/human-genomic-variant.js
+++ b/components/search/list-renderer/human-genomic-variant.js
@@ -1,20 +1,17 @@
+// node_modules
+import { PropTypes } from "prop-types";
+// components/search/list-renderer
 import {
   SearchListItemContent,
   SearchListItemMain,
   SearchListItemMeta,
-  SearchListItemStatus,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
 } from "./search-list-item";
-import { PropTypes } from "prop-types";
-
-export function humanGenomicVariantTitle(variant) {
-  const first =
-    variant.chromosome || variant.refseq_id || variant.reference_sequence;
-  const titleSeq = [first, variant.position, variant.ref, variant.alt];
-  return titleSeq.join(":");
-}
+// lib
+import humanGenomicVariantTitle from "../../../lib/human-genomic-variant-title";
 
 export default function HumanGenomicVariant({ item: variant }) {
   return (
@@ -33,7 +30,7 @@ export default function HumanGenomicVariant({ item: variant }) {
           </SearchListItemMeta>
         )}
       </SearchListItemMain>
-      <SearchListItemStatus item={variant} />
+      <SearchListItemQuality item={variant} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/lab.js
+++ b/components/search/list-renderer/lab.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -28,7 +28,7 @@ export default function Lab({ item: lab }) {
           </SearchListItemMeta>
         )}
       </SearchListItemMain>
-      <SearchListItemStatus item={lab} />
+      <SearchListItemQuality item={lab} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/measurement-set.js
+++ b/components/search/list-renderer/measurement-set.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -29,7 +29,7 @@ export default function MeasurementSet({ item: measurementSet }) {
           )}
         </SearchListItemMeta>
       </SearchListItemMain>
-      <SearchListItemStatus item={measurementSet} />
+      <SearchListItemQuality item={measurementSet} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/ontology-term.js
+++ b/components/search/list-renderer/ontology-term.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -26,7 +26,7 @@ export default function OntologyTerm({ item: ontologyTerm }) {
           </SearchListItemMeta>
         )}
       </SearchListItemMain>
-      <SearchListItemStatus item={ontologyTerm} />
+      <SearchListItemQuality item={ontologyTerm} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/page.js
+++ b/components/search/list-renderer/page.js
@@ -1,10 +1,10 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -20,7 +20,7 @@ export default function Page({ item: page }) {
         </SearchListItemUniqueId>
         <SearchListItemTitle>{page.title}</SearchListItemTitle>
       </SearchListItemMain>
-      <SearchListItemStatus item={page} />
+      <SearchListItemQuality item={page} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/publication.js
+++ b/components/search/list-renderer/publication.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
   SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -40,7 +40,7 @@ export default function Publication({ item: publication }) {
           )}
         </SearchListItemMeta>
       </SearchListItemMain>
-      <SearchListItemStatus item={publication} />
+      <SearchListItemQuality item={publication} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/rodent-donor.js
+++ b/components/search/list-renderer/rodent-donor.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -26,7 +26,7 @@ export default function RodentDonor({ item: rodentDonor }) {
           <div key="lab">{rodentDonor.lab.title}</div>
         </SearchListItemMeta>
       </SearchListItemMain>
-      <SearchListItemStatus item={rodentDonor} />
+      <SearchListItemQuality item={rodentDonor} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/search-list-item.js
+++ b/components/search/list-renderer/search-list-item.js
@@ -2,10 +2,11 @@
 import PropTypes from "prop-types";
 import { useContext } from "react";
 // components
+import { AuditDetail, useAudit } from "../../audit";
 import Icon from "../../icon";
+import QualitySection from "../../quality-section";
 import SeparatedList from "../../separated-list";
 import SessionContext from "../../session-context";
-import Status from "../../status";
 
 /**
  * Display the main contents of a search-list item including the unique identifier, title, and
@@ -110,7 +111,7 @@ export function SearchListItemSupplement({ children }) {
  */
 export function SearchListItemSupplementSection({ children }) {
   return (
-    <div className="my-1.5" data-testid="search-list-item-supplement-section">
+    <div className="mt-1.5" data-testid="search-list-item-supplement-section">
       {children}
     </div>
   );
@@ -149,32 +150,24 @@ export function SearchListItemSupplementContent({ children }) {
  * object page.
  */
 export function SearchListItemContent({ children }) {
+  return <div data-testid="search-list-item-content">{children}</div>;
+}
+
+/**
+ * Wrapper for the status and audit information of a search-list item.
+ */
+export function SearchListItemQuality({ item }) {
+  const auditState = useAudit();
+
   return (
-    <div className="sm:flex sm:gap-2" data-testid="search-list-item-content">
-      {children}
+    <div className="mt-2" data-testid="search-list-item-quality">
+      <QualitySection item={item} auditState={auditState} />
+      <AuditDetail item={item} auditState={auditState} />
     </div>
   );
 }
 
-/**
- * Display the status of a search-list item.
- */
-export function SearchListItemStatus({ item }) {
-  return (
-    <>
-      {item.status && (
-        <div
-          className="mt-2 self-center sm:mt-0"
-          data-testid="search-list-item-status"
-        >
-          <Status status={item.status} />
-        </div>
-      )}
-    </>
-  );
-}
-
-SearchListItemStatus.propTypes = {
-  // Item to display status for
+SearchListItemQuality.propTypes = {
+  // Search-result item to to display the status and audits for
   item: PropTypes.object.isRequired,
 };

--- a/components/search/list-renderer/software-version.js
+++ b/components/search/list-renderer/software-version.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -29,7 +29,7 @@ export default function SoftwareVersion({ item: softwareVersion }) {
           <div key="lab">{softwareVersion.lab.title}</div>
         </SearchListItemMeta>
       </SearchListItemMain>
-      <SearchListItemStatus item={softwareVersion} />
+      <SearchListItemQuality item={softwareVersion} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/software.js
+++ b/components/search/list-renderer/software.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -24,7 +24,7 @@ export default function Software({ item: software }) {
           <div key="lab">{software.lab.title}</div>
         </SearchListItemMeta>
       </SearchListItemMain>
-      <SearchListItemStatus item={software} />
+      <SearchListItemQuality item={software} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/source.js
+++ b/components/search/list-renderer/source.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -27,7 +27,7 @@ export default function Source({ item: source }) {
           </SearchListItemMeta>
         )}
       </SearchListItemMain>
-      <SearchListItemStatus item={source} />
+      <SearchListItemQuality item={source} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/technical-sample.js
+++ b/components/search/list-renderer/technical-sample.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -26,7 +26,7 @@ export default function TechnicalSample({ item: technicalSample }) {
           <div key="lab">{technicalSample.lab.title}</div>
         </SearchListItemMeta>
       </SearchListItemMain>
-      <SearchListItemStatus item={technicalSample} />
+      <SearchListItemQuality item={technicalSample} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/treatment.js
+++ b/components/search/list-renderer/treatment.js
@@ -1,10 +1,10 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -35,7 +35,7 @@ export default function Treatment({ item: treatment }) {
           </SearchListItemTitle>
         )}
       </SearchListItemMain>
-      <SearchListItemStatus item={treatment} />
+      <SearchListItemQuality item={treatment} />
     </SearchListItemContent>
   );
 }

--- a/components/search/list-renderer/user.js
+++ b/components/search/list-renderer/user.js
@@ -1,11 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
-// components
+// components/search/list-renderer
 import {
   SearchListItemContent,
-  SearchListItemMeta,
   SearchListItemMain,
-  SearchListItemStatus,
+  SearchListItemMeta,
+  SearchListItemQuality,
   SearchListItemTitle,
   SearchListItemType,
   SearchListItemUniqueId,
@@ -28,7 +28,7 @@ export default function User({ item: user, accessoryData }) {
           </SearchListItemMeta>
         )}
       </SearchListItemMain>
-      <SearchListItemStatus item={user} />
+      <SearchListItemQuality item={user} />
     </SearchListItemContent>
   );
 }

--- a/components/status.js
+++ b/components/status.js
@@ -25,7 +25,8 @@ export default function Status({ status }) {
   const statusClass = statusStyles[status] || statusStyles.fallback;
   return (
     <div
-      className={`my-0.5 mx-px w-fit whitespace-nowrap rounded-full border border-white px-2 py-0 text-xs font-semibold uppercase shadow-status ${statusClass}`}
+      className={`h-5 w-fit whitespace-nowrap rounded-full border border-white px-2 pt-px text-xs font-semibold uppercase shadow-status ${statusClass}`}
+      data-testid={`status-pill-${status.replace(/\s/g, "-")}`}
     >
       {status}
     </div>

--- a/cypress/e2e/audit.cy.js
+++ b/cypress/e2e/audit.cy.js
@@ -1,0 +1,39 @@
+/// <reference types="cypress" />
+
+describe("Audit tests", () => {
+  it("shows audit status buttons on a search-list page which open audit details when clicked", () => {
+    cy.visit("/search?type=InVitroSystem");
+    cy.get(`[data-testid="audit-status-button"]`).should("have.length.gte", 2);
+
+    // Click the first status button to open a details panel.
+    cy.get(`[data-testid="audit-status-button"]`).first().click();
+    cy.get(`[data-testid="audit-detail-panel"]`).should("exist");
+
+    // Click the details narrative button to open a narrative for the audit.
+    cy.get(`[aria-label="Closed narratives for Error audits"]`).click();
+    cy.get(`[data-testid^="audit-level-detail-narrative"]`).should("exist");
+
+    // Click the status button to close the narrative and details panel.
+    cy.get(`[data-testid="audit-status-button"]`).first().click();
+    cy.get(`[data-testid="audit-detail-panel"]`).should("not.exist");
+    cy.get(`[data-testid^="audit-level-detail-narrative"]`).should("not.exist");
+  });
+
+  it("shows an audit status button on an object page that opens audit details when clicked", () => {
+    cy.visit("/in-vitro-systems/IGVFSM0002AAAZ");
+    cy.get(`[data-testid="audit-status-button"]`).should("exist");
+
+    // Click the status button to open the details panel.
+    cy.get(`[data-testid="audit-status-button"]`).click();
+    cy.get(`[data-testid="audit-detail-panel"]`).should("exist");
+
+    // Click the details narrative button to open the narrative for the audit.
+    cy.get(`[aria-label="Closed narratives for Error audits"]`).click();
+    cy.get(`[data-testid^="audit-level-detail-narrative"]`).should("exist");
+
+    // Click the status button to close the narrative and details panel.
+    cy.get(`[data-testid="audit-status-button"]`).click();
+    cy.get(`[data-testid="audit-detail-panel"]`).should("not.exist");
+    cy.get(`[data-testid^="audit-level-detail-narrative"]`).should("not.exist");
+  });
+});

--- a/lib/__tests__/human-genomic-variant-title.test.js
+++ b/lib/__tests__/human-genomic-variant-title.test.js
@@ -1,0 +1,47 @@
+import humanGenomicVariantTitle from "../human-genomic-variant-title";
+
+describe("test the humanGenomicVariableTitle function", () => {
+  it("Human Genomic Variant title is correct", () => {
+    const itemWithRefSeqId = {
+      "@id": "/human-genomic-variants/8138364d-f96b-42b9-a719-42199818c6fc/",
+      "@type": ["HumanGenomicVariant", "Variant", "Item"],
+      alt: "GC",
+      ref: "TG",
+      status: "in progress",
+      assembly: "GRCh38",
+      position: 100000000,
+      refseq_id: "NC_000001.1",
+      schema_version: "1",
+      creation_timestamp: "2023-03-28T05:59:17.412294+00:00",
+      selection_criteria:
+        "The variant was selected by another lab due to its frequency in an understudied population",
+      uuid: "8138364d-f96b-42b9-a719-42199818c6fc",
+      summary: "8138364d-f96b-42b9-a719-42199818c6fc",
+    };
+
+    expect(humanGenomicVariantTitle(itemWithRefSeqId)).toBe(
+      "NC_000001.1:100000000:TG:GC"
+    );
+
+    const itemWithReferenceSeq = {
+      "@id": "/human-genomic-variants/8138364d-f96b-42b9-a719-42199818c6fc/",
+      "@type": ["HumanGenomicVariant", "Variant", "Item"],
+      alt: "GC",
+      ref: "TG",
+      status: "in progress",
+      assembly: "GRCh38",
+      position: 100000000,
+      reference_sequence: "AAATCGGG",
+      schema_version: "1",
+      creation_timestamp: "2023-03-28T05:59:17.412294+00:00",
+      selection_criteria:
+        "The variant was selected by another lab due to its frequency in an understudied population",
+      uuid: "8138364d-f96b-42b9-a719-42199818c6fc",
+      summary: "8138364d-f96b-42b9-a719-42199818c6fc",
+    };
+
+    expect(humanGenomicVariantTitle(itemWithReferenceSeq)).toBe(
+      "AAATCGGG:100000000:TG:GC"
+    );
+  });
+});

--- a/lib/human-genomic-variant-title.js
+++ b/lib/human-genomic-variant-title.js
@@ -1,0 +1,11 @@
+/**
+ * Compose the title of a human genomic variant.
+ * @param {object} variant Human genomic variant object
+ * @returns {string} Title of the human genomic variant
+ */
+export default function humanGenomicVariantTitle(variant) {
+  const first =
+    variant.chromosome || variant.refseq_id || variant.reference_sequence;
+  const titleSeq = [first, variant.position, variant.ref, variant.alt];
+  return titleSeq.join(":");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1916,9 +1916,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.0.35",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.35.tgz",
-      "integrity": "sha512-6Laome31HpetaIUGFWl1VQ3mdSImwxtFZ39rh059a1MNnKGqBpC88J6NJ8n/Is3Qx7CefDGLgf/KhN/sYCf7ag==",
+      "version": "18.0.37",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.37.tgz",
+      "integrity": "sha512-4yaZZtkRN3ZIQD3KSEwkfcik8s0SWV+82dlJot1AbGYHCzJkWP3ENBY6wYeDRmKZ6HkrgoGAmR2HqdwYGp6OEw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -2010,14 +2010,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.58.0.tgz",
-      "integrity": "sha512-ixaM3gRtlfrKzP8N6lRhBbjTow1t6ztfBvQNGuRM8qH1bjFFXIJ35XY+FC0RRBKn3C6cT+7VW1y8tNm7DwPHDQ==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.0.tgz",
+      "integrity": "sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/typescript-estree": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/typescript-estree": "5.59.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2037,13 +2037,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.58.0.tgz",
-      "integrity": "sha512-b+w8ypN5CFvrXWQb9Ow9T4/6LC2MikNf1viLkYTiTbkQl46CnR69w7lajz1icW0TBsYmlpg+mRzFJ4LEJ8X9NA==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz",
+      "integrity": "sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0"
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/visitor-keys": "5.59.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2054,9 +2054,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.58.0.tgz",
-      "integrity": "sha512-JYV4eITHPzVQMnHZcYJXl2ZloC7thuUHrcUmxtzvItyKPvQ50kb9QXBkgNAt90OYMqwaodQh2kHutWZl1fc+1g==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.0.tgz",
+      "integrity": "sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2067,13 +2067,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.58.0.tgz",
-      "integrity": "sha512-cRACvGTodA+UxnYM2uwA2KCwRL7VAzo45syNysqlMyNyjw0Z35Icc9ihPJZjIYuA5bXJYiJ2YGUB59BqlOZT1Q==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz",
+      "integrity": "sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/visitor-keys": "5.59.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2094,17 +2094,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.58.0.tgz",
-      "integrity": "sha512-gAmLOTFXMXOC+zP1fsqm3VceKSBQJNzV385Ok3+yzlavNHZoedajjS4UyS21gabJYcobuigQPs/z71A9MdJFqQ==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.0.tgz",
+      "integrity": "sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/typescript-estree": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/typescript-estree": "5.59.0",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -2142,12 +2142,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.58.0.tgz",
-      "integrity": "sha512-/fBraTlPj0jwdyTwLyrRTxv/3lnU2H96pNTVM6z3esTWLtA5MZ9ghSMJ7Rb+TtUAdtEw9EyJzJ0EydIMKxQ9gA==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz",
+      "integrity": "sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.58.0",
+        "@typescript-eslint/types": "5.59.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -2599,9 +2599,9 @@
       "dev": true
     },
     "node_modules/axe-core": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
-      "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz",
+      "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -3185,9 +3185,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
       "dev": true,
       "engines": {
         "node": ">= 6"
@@ -3323,9 +3323,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.9.0.tgz",
-      "integrity": "sha512-Ofe09LbHKgSqX89Iy1xen2WvpgbvNxDzsWx3mgU1mfILouELeXYGwIib3ItCwoRrRifoQwcBFmY54Vs0zw7QCg==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
+      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3343,7 +3343,7 @@
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
         "cli-table3": "~0.6.1",
-        "commander": "^5.1.0",
+        "commander": "^6.2.1",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
         "debug": "^4.3.4",
@@ -3361,7 +3361,7 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
@@ -3668,9 +3668,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.365",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.365.tgz",
-      "integrity": "sha512-FRHZO+1tUNO4TOPXmlxetkoaIY8uwHzd1kKopK/Gx2SKn1L47wJXWD44wxP5CGRyyP98z/c8e1eBzJrgPeiBOg==",
+      "version": "1.4.366",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.366.tgz",
+      "integrity": "sha512-XjC4pyf1no8kJe24nUfyexpWwiGRbZWXU/KbprSEvXcTXUlr3Zr5vK3lQt2to0ttpMhAc3iENccwPSKbnEW2Fg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -8861,12 +8861,12 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
-      "integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.12.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -9056,9 +9056,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -11805,9 +11805,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.0.35",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.35.tgz",
-      "integrity": "sha512-6Laome31HpetaIUGFWl1VQ3mdSImwxtFZ39rh059a1MNnKGqBpC88J6NJ8n/Is3Qx7CefDGLgf/KhN/sYCf7ag==",
+      "version": "18.0.37",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.37.tgz",
+      "integrity": "sha512-4yaZZtkRN3ZIQD3KSEwkfcik8s0SWV+82dlJot1AbGYHCzJkWP3ENBY6wYeDRmKZ6HkrgoGAmR2HqdwYGp6OEw==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -11899,41 +11899,41 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.58.0.tgz",
-      "integrity": "sha512-ixaM3gRtlfrKzP8N6lRhBbjTow1t6ztfBvQNGuRM8qH1bjFFXIJ35XY+FC0RRBKn3C6cT+7VW1y8tNm7DwPHDQ==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.0.tgz",
+      "integrity": "sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/typescript-estree": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/typescript-estree": "5.59.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.58.0.tgz",
-      "integrity": "sha512-b+w8ypN5CFvrXWQb9Ow9T4/6LC2MikNf1viLkYTiTbkQl46CnR69w7lajz1icW0TBsYmlpg+mRzFJ4LEJ8X9NA==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz",
+      "integrity": "sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0"
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/visitor-keys": "5.59.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.58.0.tgz",
-      "integrity": "sha512-JYV4eITHPzVQMnHZcYJXl2ZloC7thuUHrcUmxtzvItyKPvQ50kb9QXBkgNAt90OYMqwaodQh2kHutWZl1fc+1g==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.0.tgz",
+      "integrity": "sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.58.0.tgz",
-      "integrity": "sha512-cRACvGTodA+UxnYM2uwA2KCwRL7VAzo45syNysqlMyNyjw0Z35Icc9ihPJZjIYuA5bXJYiJ2YGUB59BqlOZT1Q==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz",
+      "integrity": "sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/visitor-keys": "5.59.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -11942,17 +11942,17 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.58.0.tgz",
-      "integrity": "sha512-gAmLOTFXMXOC+zP1fsqm3VceKSBQJNzV385Ok3+yzlavNHZoedajjS4UyS21gabJYcobuigQPs/z71A9MdJFqQ==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.0.tgz",
+      "integrity": "sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/typescript-estree": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/typescript-estree": "5.59.0",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -11976,12 +11976,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.58.0.tgz",
-      "integrity": "sha512-/fBraTlPj0jwdyTwLyrRTxv/3lnU2H96pNTVM6z3esTWLtA5MZ9ghSMJ7Rb+TtUAdtEw9EyJzJ0EydIMKxQ9gA==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz",
+      "integrity": "sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.58.0",
+        "@typescript-eslint/types": "5.59.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -12305,9 +12305,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
-      "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz",
+      "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
       "dev": true
     },
     "axobject-query": {
@@ -12717,9 +12717,9 @@
       }
     },
     "commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
       "dev": true
     },
     "common-tags": {
@@ -12826,9 +12826,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.9.0.tgz",
-      "integrity": "sha512-Ofe09LbHKgSqX89Iy1xen2WvpgbvNxDzsWx3mgU1mfILouELeXYGwIib3ItCwoRrRifoQwcBFmY54Vs0zw7QCg==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
+      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -12845,7 +12845,7 @@
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
         "cli-table3": "~0.6.1",
-        "commander": "^5.1.0",
+        "commander": "^6.2.1",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
         "debug": "^4.3.4",
@@ -12863,7 +12863,7 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
@@ -13108,9 +13108,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.365",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.365.tgz",
-      "integrity": "sha512-FRHZO+1tUNO4TOPXmlxetkoaIY8uwHzd1kKopK/Gx2SKn1L47wJXWD44wxP5CGRyyP98z/c8e1eBzJrgPeiBOg==",
+      "version": "1.4.366",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.366.tgz",
+      "integrity": "sha512-XjC4pyf1no8kJe24nUfyexpWwiGRbZWXU/KbprSEvXcTXUlr3Zr5vK3lQt2to0ttpMhAc3iENccwPSKbnEW2Fg==",
       "dev": true
     },
     "emittery": {
@@ -16857,12 +16857,12 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "resolve": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
-      "integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.12.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -16989,9 +16989,9 @@
       }
     },
     "semver": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -11,8 +11,8 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 import { EditableItem } from "../../components/edit";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -36,12 +36,9 @@ export default function AnalysisSet({
       <Breadcrumbs />
       <EditableItem item={analysisSet}>
         <PagePreamble />
+        <ObjectPageHeader item={analysisSet} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={analysisSet.status} />
-            </DataItemValue>
             {analysisSet.aliases?.length > 0 && (
               <>
                 <DataItemLabel>Aliases</DataItemLabel>
@@ -100,7 +97,6 @@ export default function AnalysisSet({
             <DocumentTable documents={documents} />
           </>
         )}
-
         <Attribution attribution={attribution} />
       </EditableItem>
     </>

--- a/pages/assay-terms/[name].js
+++ b/pages/assay-terms/[name].js
@@ -10,8 +10,8 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
@@ -23,12 +23,9 @@ export default function AssayOntologyTerm({ assayOntologyTerm, isA }) {
       <Breadcrumbs />
       <EditableItem item={assayOntologyTerm}>
         <PagePreamble />
+        <ObjectPageHeader item={assayOntologyTerm} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={assayOntologyTerm.status} />
-            </DataItemValue>
             <OntologyTermDataItems ontologyTerm={assayOntologyTerm} isA={isA}>
               {assayOntologyTerm.category_slims.length > 0 && (
                 <>

--- a/pages/awards/[name].js
+++ b/pages/awards/[name].js
@@ -9,8 +9,8 @@ import {
   DataItemValue,
   DataPanel,
 } from "../../components/data-area";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 import { EditableItem } from "../../components/edit";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -23,14 +23,11 @@ export default function Award({ award, pis, contactPi }) {
   return (
     <>
       <Breadcrumbs />
-      <PagePreamble />
       <EditableItem item={award}>
+        <PagePreamble />
+        <ObjectPageHeader item={award} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={award.status} />
-            </DataItemValue>
             <DataItemLabel>Title</DataItemLabel>
             <DataItemValue>{award.title}</DataItemValue>
             {award.description && (

--- a/pages/biomarkers/[id].js
+++ b/pages/biomarkers/[id].js
@@ -12,6 +12,7 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -26,6 +27,7 @@ export default function Biomarker({ biomarker, gene, attribution = null }) {
       <Breadcrumbs />
       <EditableItem item={biomarker}>
         <PagePreamble />
+        <ObjectPageHeader item={biomarker} />
         <DataPanel>
           <DataArea>
             <DataItemLabel>Name</DataItemLabel>

--- a/pages/curated-sets/[id].js
+++ b/pages/curated-sets/[id].js
@@ -11,8 +11,8 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 import { EditableItem } from "../../components/edit";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -35,12 +35,9 @@ export default function CuratedSet({
       <Breadcrumbs />
       <EditableItem item={curatedSet}>
         <PagePreamble />
+        <ObjectPageHeader item={curatedSet} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={curatedSet.status} />
-            </DataItemValue>
             <DataItemLabel>Curated Set Type</DataItemLabel>
             <DataItemValue>{curatedSet.curated_set_type}</DataItemValue>
             {curatedSet.taxa && (

--- a/pages/documents/[id].js
+++ b/pages/documents/[id].js
@@ -13,8 +13,8 @@ import {
 } from "../../components/data-area";
 import DocumentAttachmentLink from "../../components/document-link";
 import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
@@ -27,12 +27,9 @@ export default function Document({ document, attribution = null }) {
       <Breadcrumbs />
       <EditableItem item={document}>
         <PagePreamble />
+        <ObjectPageHeader item={document} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={document.status} />
-            </DataItemValue>
             <DataItemLabel>Type</DataItemLabel>
             <DataItemValue>{document.document_type}</DataItemValue>
             <DataItemLabel>Description</DataItemLabel>

--- a/pages/genes/[id].js
+++ b/pages/genes/[id].js
@@ -10,9 +10,10 @@ import {
 } from "../../components/data-area";
 import DbxrefList from "../../components/dbxref-list";
 import ChromosomeLocations from "../../components/chromosome-locations";
+import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import Status from "../../components/status";
-import { EditableItem } from "../../components/edit";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
@@ -40,6 +41,7 @@ export default function Gene({ gene }) {
       <Breadcrumbs />
       <EditableItem item={gene}>
         <PagePreamble />
+        <ObjectPageHeader item={gene} />
         <DataPanel>
           <DataArea>
             <DataItemLabel>Status</DataItemLabel>

--- a/pages/human-donors/[uuid].js
+++ b/pages/human-donors/[uuid].js
@@ -4,18 +4,12 @@ import PropTypes from "prop-types";
 import Attribution from "../../components/attribution";
 import Breadcrumbs from "../../components/breadcrumbs";
 import { DonorDataItems } from "../../components/common-data-items";
-import {
-  DataArea,
-  DataAreaTitle,
-  DataItemLabel,
-  DataItemValue,
-  DataPanel,
-} from "../../components/data-area";
+import { DataArea, DataAreaTitle, DataPanel } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
-import ExternalResources from "../../components/external-resources";
-import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 import { EditableItem } from "../../components/edit";
+import ExternalResources from "../../components/external-resources";
+import ObjectPageHeader from "../../components/object-page-header";
+import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
@@ -36,12 +30,9 @@ export default function HumanDonor({
       <Breadcrumbs />
       <EditableItem item={donor}>
         <PagePreamble />
+        <ObjectPageHeader item={donor} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={donor.status} />
-            </DataItemValue>
             <DonorDataItems donor={donor} parents={parents} />
           </DataArea>
         </DataPanel>

--- a/pages/human-genomic-variants/[uuid].js
+++ b/pages/human-genomic-variants/[uuid].js
@@ -1,3 +1,6 @@
+// node_modules
+import { PropTypes } from "prop-types";
+// components
 import Breadcrumbs from "../../components/breadcrumbs";
 import {
   DataArea,
@@ -6,13 +9,13 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
-import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
-import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import { PropTypes } from "prop-types";
-import { humanGenomicVariantTitle } from "../../components/search/list-renderer/human-genomic-variant";
+import ObjectPageHeader from "../../components/object-page-header";
+import PagePreamble from "../../components/page-preamble";
+// lib
+import buildBreadcrumbs from "../../lib/breadcrumbs";
+import humanGenomicVariantTitle from "../../lib/human-genomic-variant-title";
 
 export default function HumanGenomicVariant({ variant }) {
   // reference_sequence/refseq_id
@@ -24,12 +27,9 @@ export default function HumanGenomicVariant({ variant }) {
       <Breadcrumbs />
       <EditableItem item={variant}>
         <PagePreamble pageTitle={humanGenomicVariantTitle(variant)} />
+        <ObjectPageHeader item={variant} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={variant.status} />
-            </DataItemValue>
             <DataItemLabel>Assembly</DataItemLabel>
             <DataItemValue>{variant.assembly}</DataItemValue>
             <DataItemLabel>{label}</DataItemLabel>

--- a/pages/in-vitro-systems/[id].js
+++ b/pages/in-vitro-systems/[id].js
@@ -13,15 +13,15 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
-import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
-import TreatmentTable from "../../components/treatment-table";
 import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
+import PagePreamble from "../../components/page-preamble";
+import TreatmentTable from "../../components/treatment-table";
 // lib
+import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import buildAttribution from "../../lib/attribution";
 
 export default function InVitroSystem({
   inVitroSystem,
@@ -41,12 +41,9 @@ export default function InVitroSystem({
       <Breadcrumbs />
       <EditableItem item={inVitroSystem}>
         <PagePreamble />
+        <ObjectPageHeader item={inVitroSystem} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={inVitroSystem.status} />
-            </DataItemValue>
             <BiosampleDataItems
               biosample={inVitroSystem}
               source={source}

--- a/pages/labs/[name].js
+++ b/pages/labs/[name].js
@@ -9,10 +9,10 @@ import {
   DataItemValue,
   DataPanel,
 } from "../../components/data-area";
+import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SeparatedList from "../../components/separated-list";
-import Status from "../../components/status";
-import { EditableItem } from "../../components/edit";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
@@ -24,12 +24,9 @@ export default function Lab({ lab, awards = null, pi = null }) {
       <Breadcrumbs />
       <EditableItem item={lab}>
         <PagePreamble />
+        <ObjectPageHeader item={lab} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={lab.status} />
-            </DataItemValue>
             <DataItemLabel>Institute</DataItemLabel>
             <DataItemValue>{lab.institute_label}</DataItemValue>
             {pi && (

--- a/pages/measurement-sets/[id].js
+++ b/pages/measurement-sets/[id].js
@@ -1,4 +1,5 @@
 // node_modules
+import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import Attribution from "../../components/attribution";
@@ -11,17 +12,16 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
-import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
+import PagePreamble from "../../components/page-preamble";
 // lib
+import AliasList from "../../components/alias-list";
+import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import AliasList from "../../components/alias-list";
 import SeparatedList from "../../components/separated-list";
-import Link from "next/link";
-import buildAttribution from "../../lib/attribution";
 
 export default function MeasurementSet({
   measurementSet,
@@ -36,12 +36,9 @@ export default function MeasurementSet({
       <Breadcrumbs />
       <EditableItem item={measurementSet}>
         <PagePreamble />
+        <ObjectPageHeader item={measurementSet} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={measurementSet.status} />
-            </DataItemValue>
             <DataItemLabel>Assay Term</DataItemLabel>
             {assayTerm && (
               <DataItemValue>

--- a/pages/phenotype-terms/[name].js
+++ b/pages/phenotype-terms/[name].js
@@ -2,16 +2,11 @@
 import PropTypes from "prop-types";
 // components
 import Breadcrumbs from "../../components/breadcrumbs";
-import {
-  DataArea,
-  DataItemLabel,
-  DataItemValue,
-  DataPanel,
-} from "../../components/data-area";
+import { DataArea, DataPanel } from "../../components/data-area";
 import { OntologyTermDataItems } from "../../components/common-data-items";
 import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
@@ -23,12 +18,9 @@ export default function PhenotypeOntologyTerm({ phenotypeOntologyTerm }) {
       <Breadcrumbs />
       <EditableItem item={phenotypeOntologyTerm}>
         <PagePreamble />
+        <ObjectPageHeader item={phenotypeOntologyTerm} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={phenotypeOntologyTerm.status} />
-            </DataItemValue>
             <OntologyTermDataItems ontologyTerm={phenotypeOntologyTerm} />
           </DataArea>
         </DataPanel>

--- a/pages/primary-cells/[uuid].js
+++ b/pages/primary-cells/[uuid].js
@@ -12,15 +12,15 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
-import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
-import TreatmentTable from "../../components/treatment-table";
 import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
+import PagePreamble from "../../components/page-preamble";
+import TreatmentTable from "../../components/treatment-table";
 // lib
+import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import buildAttribution from "../../lib/attribution";
 
 export default function PrimaryCell({
   primaryCell,
@@ -39,12 +39,9 @@ export default function PrimaryCell({
       <Breadcrumbs />
       <EditableItem item={primaryCell}>
         <PagePreamble />
+        <ObjectPageHeader item={primaryCell} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={primaryCell.status} />
-            </DataItemValue>
             <BiosampleDataItems
               biosample={primaryCell}
               source={source}

--- a/pages/publications/[id].js
+++ b/pages/publications/[id].js
@@ -4,22 +4,22 @@ import PropTypes from "prop-types";
 import AttachmentThumbnail from "../../components/attachment-thumbnail";
 import Attribution from "../../components/attribution";
 import Breadcrumbs from "../../components/breadcrumbs";
-import DbxrefList from "../../components/dbxref-list";
 import {
   DataArea,
   DataItemLabel,
   DataItemValue,
   DataPanel,
 } from "../../components/data-area";
+import DbxrefList from "../../components/dbxref-list";
 import DocumentAttachmentLink from "../../components/document-link";
 import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 // lib
+import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import buildAttribution from "../../lib/attribution";
 
 export default function Publication({ publication, attribution = null }) {
   return (
@@ -27,12 +27,9 @@ export default function Publication({ publication, attribution = null }) {
       <Breadcrumbs />
       <EditableItem item={publication}>
         <PagePreamble />
+        <ObjectPageHeader item={publication} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={publication.status} />
-            </DataItemValue>
             <DataItemLabel>Title</DataItemLabel>
             <DataItemValue>{publication.title}</DataItemValue>
             {publication.authors && (

--- a/pages/reference-data/[id].js
+++ b/pages/reference-data/[id].js
@@ -4,23 +4,23 @@ import PropTypes from "prop-types";
 // components
 import Attribution from "../../components/attribution";
 import Breadcrumbs from "../../components/breadcrumbs";
+import { FileDataItems } from "../../components/common-data-items";
 import {
   DataArea,
+  DataAreaTitle,
   DataItemLabel,
   DataItemValue,
   DataPanel,
 } from "../../components/data-area";
+import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 // lib
+import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import { DataAreaTitle } from "../../components/data-area";
-import DocumentTable from "../../components/document-table";
-import { FileDataItems } from "../../components/common-data-items";
-import buildAttribution from "../../lib/attribution";
 
 export default function ReferenceData({
   referenceData,
@@ -34,12 +34,9 @@ export default function ReferenceData({
       <Breadcrumbs />
       <EditableItem item={referenceData}>
         <PagePreamble />
+        <ObjectPageHeader item={referenceData} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={referenceData.status} />
-            </DataItemValue>
             <FileDataItems
               file={referenceData}
               fileSet={fileSet}

--- a/pages/rodent-donors/[uuid].js
+++ b/pages/rodent-donors/[uuid].js
@@ -12,10 +12,10 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
-import ExternalResources from "../../components/external-resources";
-import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 import { EditableItem } from "../../components/edit";
+import ExternalResources from "../../components/external-resources";
+import ObjectPageHeader from "../../components/object-page-header";
+import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
@@ -33,12 +33,9 @@ export default function RodentDonor({
       <Breadcrumbs />
       <EditableItem item={donor}>
         <PagePreamble />
+        <ObjectPageHeader item={donor} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={donor.status} />
-            </DataItemValue>
             <DonorDataItems donor={donor} parents={parents}>
               <DataItemLabel>Strain</DataItemLabel>
               <DataItemValue>{donor.strain}</DataItemValue>

--- a/pages/sample-terms/[name].js
+++ b/pages/sample-terms/[name].js
@@ -11,8 +11,8 @@ import {
 } from "../../components/data-area";
 import DbxrefList from "../../components/dbxref-list";
 import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
@@ -24,12 +24,9 @@ export default function SampleOntologyTerm({ sampleOntologyTerm }) {
       <Breadcrumbs />
       <EditableItem item={sampleOntologyTerm}>
         <PagePreamble />
+        <ObjectPageHeader item={sampleOntologyTerm} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={sampleOntologyTerm.status} />
-            </DataItemValue>
             {sampleOntologyTerm.dbxrefs?.length > 0 && (
               <>
                 <DataItemLabel>External Resources</DataItemLabel>

--- a/pages/sequence-data/[id].js
+++ b/pages/sequence-data/[id].js
@@ -10,8 +10,8 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
@@ -33,12 +33,9 @@ export default function SequenceData({
       <Breadcrumbs />
       <EditableItem item={sequenceData}>
         <PagePreamble />
+        <ObjectPageHeader item={sequenceData} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={sequenceData.status} />
-            </DataItemValue>
             <FileDataItems
               file={sequenceData}
               fileSet={fileSet}

--- a/pages/software/[id].js
+++ b/pages/software/[id].js
@@ -10,9 +10,9 @@ import {
   DataItemValue,
   DataPanel,
 } from "../../components/data-area";
-import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
+import PagePreamble from "../../components/page-preamble";
 import SoftwareVersionTable from "../../components/software-version-table";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -27,12 +27,9 @@ export default function Software({ software, versions, attribution = null }) {
       <Breadcrumbs />
       <EditableItem item={software}>
         <PagePreamble />
+        <ObjectPageHeader item={software} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={software.status} />
-            </DataItemValue>
             <DataItemLabel>Title</DataItemLabel>
             <DataItemValue>{software.title}</DataItemValue>
             <DataItemLabel>Description</DataItemLabel>

--- a/pages/sources/[id].js
+++ b/pages/sources/[id].js
@@ -8,8 +8,8 @@ import {
   DataItemValue,
   DataPanel,
 } from "../../components/data-area";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 import { EditableItem } from "../../components/edit";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -23,12 +23,9 @@ export default function Source({ source }) {
       <Breadcrumbs />
       <EditableItem item={source}>
         <PagePreamble />
+        <ObjectPageHeader item={source} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={source.status} />
-            </DataItemValue>
             <DataItemLabel>Title</DataItemLabel>
             <DataItemValue>{source.title}</DataItemValue>
             {source.description && (

--- a/pages/technical-samples/[uuid].js
+++ b/pages/technical-samples/[uuid].js
@@ -13,15 +13,15 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
-import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
+import PagePreamble from "../../components/page-preamble";
 // lib
+import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import { formatDate } from "../../lib/dates";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import buildAttribution from "../../lib/attribution";
 
 export default function TechnicalSample({
   sample,
@@ -33,12 +33,9 @@ export default function TechnicalSample({
       <Breadcrumbs />
       <EditableItem item={sample}>
         <PagePreamble />
+        <ObjectPageHeader item={sample} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={sample.status} />
-            </DataItemValue>
             <SampleDataItems sample={sample} source={sample.source}>
               {sample.date && (
                 <>

--- a/pages/tissues/[uuid].js
+++ b/pages/tissues/[uuid].js
@@ -12,15 +12,15 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 import TreatmentTable from "../../components/treatment-table";
 import { EditableItem } from "../../components/edit";
 // lib
+import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import buildAttribution from "../../lib/attribution";
 
 export default function Tissue({
   tissue,
@@ -39,12 +39,9 @@ export default function Tissue({
       <Breadcrumbs />
       <EditableItem item={tissue}>
         <PagePreamble />
+        <ObjectPageHeader item={tissue} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={tissue.status} />
-            </DataItemValue>
             <BiosampleDataItems
               biosample={tissue}
               source={source}

--- a/pages/treatments/[uuid].js
+++ b/pages/treatments/[uuid].js
@@ -11,9 +11,9 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
-import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
+import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import { UC } from "../../lib/constants";
@@ -26,12 +26,9 @@ export default function Treatment({ treatment, documents }) {
       <Breadcrumbs />
       <EditableItem item={treatment}>
         <PagePreamble />
+        <ObjectPageHeader item={treatment} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={treatment.status} />
-            </DataItemValue>
             <DataItemLabel>Treatment Term Name</DataItemLabel>
             <DataItemValue>{treatment.treatment_term_name}</DataItemValue>
             <DataItemLabel>Treatment Type</DataItemLabel>

--- a/pages/users/[uuid].js
+++ b/pages/users/[uuid].js
@@ -11,8 +11,8 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import NoContent from "../../components/no-content";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
@@ -24,17 +24,10 @@ export default function User({ user, lab = null }) {
       <Breadcrumbs />
       <EditableItem item={user}>
         <PagePreamble />
+        <ObjectPageHeader item={user} />
         {user.status || user.job_title || lab || user.email ? (
           <DataPanel>
             <DataArea>
-              {user.status && (
-                <>
-                  <DataItemLabel>Status</DataItemLabel>
-                  <DataItemValue>
-                    <Status status={user.status} />
-                  </DataItemValue>
-                </>
-              )}
               {user.job_title && (
                 <>
                   <DataItemLabel>Job Title</DataItemLabel>

--- a/pages/whole-organisms/[id].js
+++ b/pages/whole-organisms/[id].js
@@ -4,23 +4,17 @@ import PropTypes from "prop-types";
 import Attribution from "../../components/attribution";
 import Breadcrumbs from "../../components/breadcrumbs";
 import { BiosampleDataItems } from "../../components/common-data-items";
-import {
-  DataArea,
-  DataAreaTitle,
-  DataItemLabel,
-  DataItemValue,
-  DataPanel,
-} from "../../components/data-area";
+import { DataArea, DataAreaTitle, DataPanel } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
-import PagePreamble from "../../components/page-preamble";
-import Status from "../../components/status";
-import TreatmentTable from "../../components/treatment-table";
 import { EditableItem } from "../../components/edit";
+import ObjectPageHeader from "../../components/object-page-header";
+import PagePreamble from "../../components/page-preamble";
+import TreatmentTable from "../../components/treatment-table";
 // lib
+import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import buildAttribution from "../../lib/attribution";
 
 export default function WholeOrganism({
   sample,
@@ -39,12 +33,9 @@ export default function WholeOrganism({
       <Breadcrumbs />
       <EditableItem item={sample}>
         <PagePreamble />
+        <ObjectPageHeader item={sample} />
         <DataPanel>
           <DataArea>
-            <DataItemLabel>Status</DataItemLabel>
-            <DataItemValue>
-              <Status status={sample.status} />
-            </DataItemValue>
             <BiosampleDataItems
               biosample={sample}
               source={source}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -72,6 +72,12 @@
   --color-button-warning-label-disabled: #d8d8d8;
   --color-button-selected-label-disabled: #b1bad3;
 
+  --color-button-audit-open-background: #d3dfff;
+  --color-button-audit-closed-background: transparet;
+  --color-button-audit-border: #384977;
+  --color-button-audit-level-detail: #f0f0f0;
+  --color-audit-level-detail-background: #d0d0d0;
+
   --color-facet-group-button-background: #f0e7ca;
   --color-facet-group-button-selected-background: #bfa678;
   --color-facet-group-button-border: #998868;
@@ -163,6 +169,12 @@
   --color-facet-group-button-border: #998868;
   --color-facet-group-button-text: #ffffff;
   --color-facet-group-button-selected-text: #ffffff;
+
+  --color-button-audit-open-background: #384977;
+  --color-button-audit-border: #8facff;
+  --color-button-audit-level: #4e5b75;
+  --color-audit-level-detail-background: #4e5b75;
+  --color-button-audit-level-detail: #111827;
 
   --color-facet-title-background: #536167;
   --color-facet-title-text: #ffffff;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -52,6 +52,11 @@ module.exports = {
         "button-selected-disabled":
           "var(--color-button-selected-background-disabled)",
 
+        "button-audit-open": "var(--color-button-audit-open-background)",
+        "button-audit-closed": "var(--color-button-audit-closed-background)",
+        "button-audit-level-detail": "var(--color-button-audit-level-detail)",
+        "audit-level-detail": "var(--color-audit-level-detail-background)",
+
         "facet-group-button": "var(--color-facet-group-button-background)",
         "facet-group-button-selected":
           "var(--color-facet-group-button-selected-background)",
@@ -74,6 +79,8 @@ module.exports = {
           "var(--color-button-warning-border-disabled)",
         "button-selected-disabled":
           "var(--color-button-selected-border-disabled)",
+
+        "button-audit": "var(--color-button-audit-border)",
 
         "facet-group-button": "var(--color-facet-group-button-border)",
         "facet-group-button-selected":


### PR DESCRIPTION
I sorted some imports that I found out of module-name order, and in that process decided to move the `humanGenomicVariantTitle()` function to its own file under `/lib` so that we can just import from `/lib` instead of a special-case path. I also moved its Jest test to its own file under `/lib`.

I moved the object edit button within the new `<ObjectPageHeader>` component so that it can share a row with the status and audits. Before, the edit button seemed to float on the page without relation to anything. That means refactoring the `<EditableItem>` component so that the edit icon can get displayed separately.

You’ll see some code in audit.js that allows for an audit level this code doesn’t know about, so it can handle that without crashing, though its display has no icon.

If the user isn’t logged in, the INTERNAL_ACTION audit gets hidden. It still shows up in public JSON, but this is what we decided to do in ENCODE, and why you see the use of the `publicLevels` constant.

I use the new `<StatusListItemQuality>` components even for objects that don’t have a status because they might have an audit in the future.