### PR TITLE
IGVF-644 Fix assumption that session-properties has loaded

### DIFF
--- a/components/navigation.js
+++ b/components/navigation.js
@@ -295,7 +295,7 @@ function NavigationSignOutItem({
           closeLabel="Cancel signing out"
         >
           <h2 className="text-lg font-semibold">
-            Sign Out {sessionProperties.user?.title || "User"}
+            Sign Out {sessionProperties?.user?.title || "User"}
           </h2>
         </Modal.Header>
         <Modal.Body>
@@ -311,7 +311,7 @@ function NavigationSignOutItem({
           </Button>
           <Button
             onClick={handleAuthClick}
-            label={`Sign out ${sessionProperties.user?.title || "User"}`}
+            label={`Sign out ${sessionProperties?.user?.title || "User"}`}
             id="sign-out-confirm"
           >
             Sign Out
@@ -836,7 +836,7 @@ function NavigationExpanded({ navigationClick, toggleNavCollapsed }) {
         {isAuthenticated ? (
           <NavigationGroupItem
             id="authenticate"
-            title={sessionProperties.user?.title || "User"}
+            title={sessionProperties?.user?.title || "User"}
             icon={<Icon.UserSignedIn />}
             isGroupOpened={openedParents.includes("authenticate")}
             handleGroupClick={handleParentClick}

--- a/pages/user-profile.js
+++ b/pages/user-profile.js
@@ -24,7 +24,7 @@ export default function UserProfile({ sessionUser = null }) {
   const { session, sessionProperties } = useContext(SessionContext);
   const { isLoading, user } = useAuth0();
 
-  const username = sessionProperties.user?.title || "User";
+  const username = sessionProperties?.user?.title || "User";
 
   /**
    * Called when the user adds a new access key.


### PR DESCRIPTION
The browser loads `/session-properties` after page load. I had assumed that we would at least have the empty object for session-properties, but in some cases session-properties could still have the null value when we use it to display the logged-in user name. This branch accounts for the case where `sessionProperties` could contain null.