### PR TITLE
IGVF-648-authentication-404

### DIFF
--- a/components/__tests__/link-reloadable.test.js
+++ b/components/__tests__/link-reloadable.test.js
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import GlobalContext from "../global-context";
+import Link from "../link-reloadable";
+
+describe("Test Link wrapper that can reload the page", () => {
+  it("renders a link that reloads the page", () => {
+    render(
+      <GlobalContext.Provider value={{ linkReload: { isEnabled: true } }}>
+        <Link href="/test">Test</Link>
+      </GlobalContext.Provider>
+    );
+
+    expect(screen.getByText("Test")).toBeInTheDocument();
+    expect(screen.getByText("Test")).toHaveAttribute("href", "/test");
+    expect(screen.getByTestId("link-reload")).toBeInTheDocument();
+  });
+
+  it("renders a link that doesn't reload the page", () => {
+    render(
+      <GlobalContext.Provider value={{ linkReload: { isEnabled: false } }}>
+        <Link href="/test">Test</Link>
+      </GlobalContext.Provider>
+    );
+
+    expect(screen.getByText("Test")).toBeInTheDocument();
+    expect(screen.getByText("Test")).toHaveAttribute("href", "/test");
+    expect(screen.getByTestId("link-normal")).toBeInTheDocument();
+  });
+});

--- a/components/link-reloadable.js
+++ b/components/link-reloadable.js
@@ -1,0 +1,26 @@
+// node_imports
+import Link from "next/link";
+import { useContext } from "react";
+// components
+import GlobalContext from "../components/global-context";
+
+/**
+ * Wrapper for the next/link <Link> component. This wrapper has the option of reloading the browser
+ * when going to the `href` page. We use this for pages (e.g. the 404 page) that don't have NextJS
+ * environment variables available to them. Reloading before going to the `href` page lets NextJS
+ * load those environment variables for the new page, allowing us to make proper requests to the
+ * data provider.
+ */
+export default function LinkReloadable(props) {
+  const { linkReload } = useContext(GlobalContext);
+
+  if (linkReload.isEnabled) {
+    // Certain static pages (e.g. the 404.js page) set `linkReload.isEnabled` to `true`, so use a
+    // regular <a> tag to reload the browser when going to the `href` page. The `linkReload` object
+    // gets cleared on reload.
+    return <a data-testid="link-reload" {...props} />;
+  }
+
+  // Normal link with no need for reload.
+  return <Link data-testid="link-normal" {...props} />;
+}

--- a/components/logo.js
+++ b/components/logo.js
@@ -1,5 +1,5 @@
-// node_modules
-import Link from "next/link";
+// components
+import Link from "./link-reloadable";
 
 export function Logo() {
   return (

--- a/components/navigation.js
+++ b/components/navigation.js
@@ -35,6 +35,7 @@ import {
 } from "./animation";
 import { useSessionStorage } from "./browser-storage";
 import { Button } from "./form-elements";
+import GlobalContext from "./global-context";
 import Icon from "./icon";
 import SiteLogo from "./logo";
 import Modal from "./modal";
@@ -46,6 +47,7 @@ import {
   logoutDataProvider,
 } from "../lib/authentication";
 import { UC } from "../lib/constants";
+import linkReloadable from "../lib/link-reloadable";
 
 /**
  * Icon for opening the sidebar navigation.
@@ -345,6 +347,7 @@ function NavigationHrefItem({
   children,
 }) {
   const router = useRouter();
+  const { linkReload } = useContext(GlobalContext);
 
   // Use different button-rendering components depending on whether the navigation is in wide mode
   // or narrow mode.
@@ -354,9 +357,10 @@ function NavigationHrefItem({
 
   function onClick() {
     // Notify the main navigation component that the user has clicked a navigation item, then
-    // navigate to the href for the navigation item.
+    // navigate to the href for the navigation item, reloading the page if NextJS hasn't loaded
+    // environment variables on the current page.
     navigationClick();
-    router.push(href);
+    linkReloadable(href, linkReload, router);
   }
 
   return (

--- a/components/page-component/page-navigation.js
+++ b/components/page-component/page-navigation.js
@@ -19,7 +19,7 @@ export default function PageNavigation(items) {
       "rounded-full border border-transparent px-4 py-1 no-underline hover:border-nav-border hover:bg-nav-highlight";
     return (
       <nav className="text-center">
-        <ul className="mt-4 mb-12 inline-flex list-none flex-wrap justify-center border-b border-gray-200 px-0 dark:border-gray-700">
+        <ul className="mb-12 mt-4 inline-flex list-none flex-wrap justify-center border-b border-gray-200 px-0 dark:border-gray-700">
           {itemTitles.map((itemTitle, index) => {
             const href = items[itemTitle];
             const isUrl = isValidUrl(href);

--- a/lib/__tests__/authentication.test.js
+++ b/lib/__tests__/authentication.test.js
@@ -1,4 +1,5 @@
 import {
+  getDataProviderUrl,
   getSession,
   getSessionProperties,
   loginDataProvider,
@@ -84,7 +85,7 @@ describe("Test authentication utility functions", () => {
       })
     );
 
-    const response = await getSession();
+    const response = await getSession("/api/path");
     expect(response).toEqual(signedOutSession);
   });
 
@@ -115,8 +116,34 @@ describe("Test authentication utility functions", () => {
       })
     );
 
-    const response = await getSessionProperties();
+    const response = await getSessionProperties("/api/path");
     expect(response).toEqual(sessionProperties);
+  });
+
+  test("getDataProviderUrl() returns the correct url", async () => {
+    const correctResponse = "http://localhost:8000";
+
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ dataProviderUrl: correctResponse }),
+      })
+    );
+
+    const response = await getDataProviderUrl();
+    expect(response).toEqual(correctResponse);
+  });
+
+  test("getDataProviderUrl() returns null on an error", async () => {
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve(),
+      })
+    );
+
+    const response = await getDataProviderUrl();
+    expect(response).toEqual(null);
   });
 });
 

--- a/lib/__tests__/fetch-request.test.js
+++ b/lib/__tests__/fetch-request.test.js
@@ -256,6 +256,107 @@ describe("Test GET requests to the data provider", () => {
   });
 });
 
+describe("Test URL-specific fetch requests", () => {
+  it("retrieves a single item from the server correctly", async () => {
+    // Mock lab collection retrieval.
+    const mockData = {
+      _csfrt_: "mock_csrf_token",
+      "auth.userid": "email@example.com",
+    };
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      })
+    );
+
+    const request = new FetchRequest();
+    const session = await request.getObjectByUrl(
+      "http://localhost:8000/session"
+    );
+    expect(session).toBeTruthy();
+    expect(_.isEqual(session, mockData)).toBeTruthy();
+  });
+
+  it("returns an error on throw", async () => {
+    window.fetch = jest.fn().mockImplementation(() => {
+      throw "Mock request error";
+    });
+
+    const request = new FetchRequest();
+    const session = await request.getObjectByUrl(
+      "http://localhost:8000/labs/j-michael-cherry/"
+    );
+    expect(session).toBeTruthy();
+    expect(session["@type"]).toContain("NetworkError");
+    expect(session.status).toEqual("error");
+    expect(session.code).toEqual("NETWORK");
+    expect(FetchRequest.isResponseSuccess(session)).toBeFalsy();
+  });
+
+  it("returns a specific error on throw", async () => {
+    window.fetch = jest.fn().mockImplementation(() => {
+      throw "Mock request error";
+    });
+
+    const request = new FetchRequest();
+    const session = await request.getObjectByUrl(
+      "http://localhost:8000/labs/j-michael-cherry/",
+      null
+    );
+    expect(session).toBeNull();
+  });
+
+  it("returns a specific error value", async () => {
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        json: () =>
+          Promise.resolve({
+            "@type": ["HTTPNotFound", "Error"],
+            status: "error",
+            code: 404,
+            title: "Not Found",
+            description: "The resource could not be found.",
+            detail: "URL",
+          }),
+      })
+    );
+
+    const request = new FetchRequest();
+    const session = await request.getObjectByUrl(
+      "http://localhost:8000/session",
+      null
+    );
+    expect(session).toBeNull();
+  });
+
+  it("returns a default error value", async () => {
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        json: () =>
+          Promise.resolve({
+            "@type": ["HTTPNotFound", "Error"],
+            status: "error",
+            code: 404,
+            title: "Not Found",
+            description: "The resource could not be found.",
+            detail: "URL",
+          }),
+      })
+    );
+
+    const request = new FetchRequest();
+    const session = await request.getObjectByUrl(
+      "http://localhost:8000/session"
+    );
+    expect(session).toBeTruthy();
+    expect(session.status).toEqual("error");
+    expect(session.code).toEqual(404);
+  });
+});
+
 describe("Text fetch requests", () => {
   it("returns text with a successful request", async () => {
     const mockData = "## Markdown";

--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -11,21 +11,35 @@ import FetchRequest from "./fetch-request";
 
 /**
  * Request the session object from the server, which contains the browser CSRF token.
+ * @param {string} dataProviderUrl URL of the data provider instance
  * @returns {object} Session object including the CSRF token
  */
-export async function getSession() {
+export async function getSession(dataProviderUrl) {
   const request = new FetchRequest();
-  return request.getObject("/session", null);
+  return request.getObjectByUrl(`${dataProviderUrl}/session`, null);
 }
 
 /**
  * Request the session-properties object from the server, which contains the current logged-in
  * user's information.
+ * @param {string} dataProviderUrl URL of the data provider instance
  * @returns {object} session-properties object
  */
-export async function getSessionProperties() {
+export async function getSessionProperties(dataProviderUrl) {
   const request = new FetchRequest();
-  return request.getObject("/session-properties", null);
+  return request.getObjectByUrl(`${dataProviderUrl}/session-properties`, null);
+}
+
+/**
+ * Request the URL of the data provider from the UI API. The FetchRequest module normally gets this
+ * from environment variables, but in some unusual cases NextJS doesn't supply them (e.g. 404
+ * pages).
+ * @returns {string} URL of the data provider; null if unavailable
+ */
+export async function getDataProviderUrl() {
+  const request = new FetchRequest({ backend: true });
+  const response = await request.getObject("/api/data-provider", null);
+  return response?.dataProviderUrl || null;
 }
 
 /**

--- a/lib/fetch-request.js
+++ b/lib/fetch-request.js
@@ -274,6 +274,30 @@ export default class FetchRequest {
   }
 
   /**
+   * Request the object with the given URL, including protocol and domain.
+   * @param {string} url Full URL to requested resource
+   * @param {*} defaultErrorValue Value to return if the request fails; error object if not given
+   * @returns {object} Requested object or error object
+   */
+  async getObjectByUrl(url, defaultErrorValue) {
+    const headerOptions = this.#buildOptions(FETCH_METHOD.GET, {
+      accept: PAYLOAD_FORMAT.JSON,
+      redirect: "follow",
+    });
+    try {
+      const response = await fetch(url, headerOptions);
+      if (!response.ok && defaultErrorValue !== undefined) {
+        return defaultErrorValue;
+      }
+      return response.json();
+    } catch (error) {
+      return defaultErrorValue === undefined
+        ? NETWORK_ERROR_RESPONSE
+        : defaultErrorValue;
+    }
+  }
+
+  /**
    * Request a number of objects with the given paths, returning each path's resource in an array
    * in the same order as their paths in the given array. If you provide `defaultErrorValue`, any
    * paths that result in a request error places this default value in that array entry,

--- a/lib/link-reloadable.js
+++ b/lib/link-reloadable.js
@@ -1,0 +1,24 @@
+/**
+ * Use this in places you would have used the NextJS router.push() function in situations where
+ * NextJS might not have loaded environment variables, e.g. 404 page. This wrapper has the option
+ * of reloading the browser before going to the `href` page. Reloading before going to the `href`
+ * page lets NextJS load those environment variables, allowing us to make proper requests to the
+ * data provider. For simplicity, only use this for navigation you can do directly from an error
+ * page, such as navigation. Other places that use router.push() only after loading a non-error
+ * page should keep using router.push().
+ * @param {string} href Link to go to on click
+ * @param {object} linkReload Object from GlobalContext
+ * @param {object} router Object from useRouter()
+ */
+export default function linkReloadable(href, linkReload, router) {
+  if (linkReload.isEnabled) {
+    // Certain static pages (e.g. the 404.js page) set `linkReload.isEnabled` to `true`. This
+    // function clears it for safety, though it gets cleared by reloading the page anyway.
+    linkReload.setIsEnabled(false);
+    window.location = href;
+  } else {
+    // For the usual case where we navigate to a new page, retrieving just the data needed to
+    // render that page.
+    router.push(href);
+  }
+}

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,9 +1,19 @@
+// node_modules
+import { useEffect, useContext } from "react";
 // components
 import Error from "../components/error";
+import GlobalContext from "../components/global-context";
 
 /**
  * Override for the default NextJS 404 error page.
  */
 export default function Error404() {
+  const { linkReload } = useContext(GlobalContext);
+
+  useEffect(() => {
+    // Any links available directly from the 404 page should reload the browser.
+    linkReload.setIsEnabled(true);
+  }, [linkReload]);
+
   return <Error statusCode={404} title="This page could not be found" />;
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -26,6 +26,8 @@ import ViewportOverlay from "../components/viewport-overlay";
 import "../styles/globals.css";
 
 function Site({ Component, pageProps, authentication }) {
+  // Flag to indicate if <Link> components should cause page reload
+  const [isLinkReloadEnabled, setIsLinkReloadEnabled] = useState(false);
   const { isLoading } = useAuth0();
 
   useEffect(() => {
@@ -49,11 +51,16 @@ function Site({ Component, pageProps, authentication }) {
         type: pageProps.pageContext?.type || "",
       },
       breadcrumbs: pageProps.breadcrumbs || [],
+      linkReload: {
+        isEnabled: isLinkReloadEnabled,
+        setIsEnabled: setIsLinkReloadEnabled,
+      },
     };
   }, [
     pageProps.breadcrumbs,
     pageProps.pageContext?.title,
     pageProps.pageContext?.type,
+    isLinkReloadEnabled,
   ]);
 
   return (

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -1,28 +1,28 @@
 // node_modules
+import Link from "next/link";
 import PropTypes from "prop-types";
 // components
+import AliasList from "../../components/alias-list";
 import Attribution from "../../components/attribution";
 import Breadcrumbs from "../../components/breadcrumbs";
 import {
   DataArea,
-  DataAreaTitle,
   DataItemLabel,
+  DataAreaTitle,
   DataItemValue,
   DataPanel,
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
+import { EditableItem } from "../../components/edit";
 import FileTable from "../../components/file-table";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import { EditableItem } from "../../components/edit";
+import SeparatedList from "../../components/separated-list";
 // lib
+import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import AliasList from "../../components/alias-list";
-import SeparatedList from "../../components/separated-list";
-import Link from "next/link";
-import buildAttribution from "../../lib/attribution";
 
 export default function AnalysisSet({
   analysisSet,

--- a/pages/api/data-provider.js
+++ b/pages/api/data-provider.js
@@ -1,0 +1,17 @@
+import { HTTP_STATUS_CODE } from "../../lib/fetch-request";
+import { API_URL } from "../../lib/constants";
+
+/**
+ * Return the URL of the data provider instance that this UI instance connects to. Normally the
+ * rest of the code can access this from environment variables, but in some cases (e.g. 404 pages)
+ * NextJS hides environment variables except from API functions like this one. This simply returns
+ * the value of the API_URL environment variable in the `dataProviderUrl` property of the response.
+ * `req` and `res` are the NextJS request and response objects.
+ * @returns {object} An object with the `dataProviderUrl` property set to data-provider URL.
+ */
+export default function dataProvider(req, res) {
+  const props = {
+    dataProviderUrl: API_URL,
+  };
+  return res.status(HTTP_STATUS_CODE.OK).json(props);
+}

--- a/pages/biomarkers/[id].js
+++ b/pages/biomarkers/[id].js
@@ -15,11 +15,11 @@ import { EditableItem } from "../../components/edit";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
+import buildAttribution from "../../lib/attribution";
+import { getBiomarkerTitle } from "../../lib/biomarker";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import { getBiomarkerTitle } from "../../lib/biomarker";
-import buildAttribution from "../../lib/attribution";
 
 export default function Biomarker({ biomarker, gene, attribution = null }) {
   return (

--- a/pages/curated-sets/[id].js
+++ b/pages/curated-sets/[id].js
@@ -1,4 +1,5 @@
 // node_modules
+import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import Attribution from "../../components/attribution";
@@ -11,18 +12,17 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
+import { EditableItem } from "../../components/edit";
 import FileTable from "../../components/file-table";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import { EditableItem } from "../../components/edit";
 // lib
+import AliasList from "../../components/alias-list";
+import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import AliasList from "../../components/alias-list";
 import SeparatedList from "../../components/separated-list";
-import Link from "next/link";
-import buildAttribution from "../../lib/attribution";
 
 export default function CuratedSet({
   curatedSet,


### PR DESCRIPTION
Error pages (e.g. 404 pages) in NextJS don’t load environment variables for reasons I can’t fathom, and this causes requests to igvfd to fail because requests for session nonsensically go to the igvf-ui instance instead of the igvfd instance. That means we can’t edit nor add objects, nor can we create access keys, until we reload the page.

This branch does three things to get around these problems:
* Adds a new `/data-provider` API endpoint that retrieves the URL the connected igvfd server. With the addition of a new `getObjectByUrl()` method to FetchRequest, we can now get the `session` and `session-properties` objects by using the entire igvfd URL instead of just the path.
* Adds a new `LinkReloadable` wrapper for `<Link>`. If a page that doesn’t load environment variables comes up, it sets a `GlobalContext` property to indicate that the next click should reload the page. `LinkReloadable` uses an `<a>` tag instead of `<Link>` so that the click causes a full page reload, so that NextJS environment variables get loaded.
* Similarly, it adds a `linkReloadable` library function that wraps `router.push` so that the page gets reloaded if the same `GlobalContext` property got set.

That means any links directly clickable from an error page should use `LinkReloadable` instead of `Link`, though you should import it as `Link` — the link-reloadable.js modules uses a default export so you can call the import anything you want, so let’s just make it `Link`. Similarly, any `router.push()` calls directly from an error page should use the `linkReloadable` function. The vast majority of the UI doesn’t have direct access from error pages, so this is mostly not an issue. Navigation is always available, so those need this treatment, as does the logo above navigation.