### PR TITLE
IGVF-374 Search output page

### DIFF
--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,7 +52,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-dev.demo.igvf.org',
+            'backend_url': 'https://igvfd-igvf-650-add-ids-fuzzysearch.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,7 +52,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-dev.demo.igvf.org',
+            'backend_url': 'https://igvfd-igvf-650-add-ids-fuzzysearch.demo.igvf.org/',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,7 +52,6 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-igvf-650-add-ids-fuzzysearch.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,7 +52,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-igvf-650-add-ids-fuzzysearch.demo.igvf.org',
+            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,6 +52,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
+            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,7 +52,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-igvf-650-add-ids-fuzzysearch.demo.igvf.org/',
+            'backend_url': 'https://igvfd-igvf-650-add-ids-fuzzysearch.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/components/navigation.js
+++ b/components/navigation.js
@@ -40,6 +40,7 @@ import Icon from "./icon";
 import SiteLogo from "./logo";
 import Modal from "./modal";
 import SessionContext from "./session-context";
+import SiteSearchTrigger from "./site-search-trigger";
 // lib
 import {
   loginAuthProvider,
@@ -386,6 +387,13 @@ NavigationHrefItem.propTypes = {
 };
 
 /**
+ * Wrapper for the site search icon while navigation is collapsed.
+ */
+function NavigationSearchItem({ children }) {
+  return <li>{children}</li>;
+}
+
+/**
  * Icon for expanding or collapsing a navigation group item.
  */
 function NavigationGroupExpandIcon({ isGroupOpened }) {
@@ -534,6 +542,7 @@ function NavigationExpanded({ navigationClick, toggleNavCollapsed }) {
           isNavCollapsed={false}
         />
       )}
+      <SiteSearchTrigger isExpanded />
       <NavigationList className="p-4">
         <NavigationHrefItem
           id="awards"
@@ -926,6 +935,9 @@ function NavigationCollapsed({ navigationClick, toggleNavCollapsed }) {
           <Icon.Brand />
         </NavigationIcon>
       </NavigationHrefItem>
+      <NavigationSearchItem>
+        <SiteSearchTrigger />
+      </NavigationSearchItem>
       {isAuthenticated ? (
         <NavigationSignOutItem id="sign-out" isNarrowNav>
           <Icon.UserSignedIn className="h-8 w-8" />

--- a/components/search/index.js
+++ b/components/search/index.js
@@ -10,6 +10,7 @@ import ItemLink from "../item-link";
 
 import {
   generateAccessoryDataPropertyMap,
+  getAccessoryData,
   getAccessoryDataPaths,
   getItemListsByType,
   getSearchListItemRenderer,
@@ -25,7 +26,7 @@ function SearchListItem({ href, testid, children }) {
       data-testid={`search-list-item-${testid}`}
     >
       <ItemLink href={href} label={`View details for ${testid}`} />
-      <div className="grow py-4 px-2 sm:px-4">{children}</div>
+      <div className="grow px-2 py-4 sm:px-4">{children}</div>
     </li>
   );
 }
@@ -39,6 +40,7 @@ SearchListItem.propTypes = {
 
 export {
   generateAccessoryDataPropertyMap,
+  getAccessoryData,
   getAccessoryDataPaths,
   getItemListsByType,
   getSearchListItemRenderer,

--- a/components/search/list-renderer/analysis-set.js
+++ b/components/search/list-renderer/analysis-set.js
@@ -15,7 +15,10 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function AnalysisSet({ item: analysisSet, accessoryData }) {
+export default function AnalysisSet({
+  item: analysisSet,
+  accessoryData = null,
+}) {
   const summary = analysisSet.summary;
   const inputFileSetsKeys = analysisSet.input_file_sets;
   const inputFileSetsAccessions =

--- a/components/search/list-renderer/award.js
+++ b/components/search/list-renderer/award.js
@@ -11,7 +11,7 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function Award({ item: award, accessoryData }) {
+export default function Award({ item: award, accessoryData = null }) {
   const contactPi = accessoryData?.[award.contact_pi];
   return (
     <SearchListItemContent>

--- a/components/search/list-renderer/human-donor.js
+++ b/components/search/list-renderer/human-donor.js
@@ -11,7 +11,7 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function HumanDonor({ item: humanDonor, accessoryData }) {
+export default function HumanDonor({ item: humanDonor, accessoryData = null }) {
   const ethnicities =
     humanDonor.ethnicities?.length > 0 ? humanDonor.ethnicities.join(", ") : "";
   const sex = humanDonor.sex || "";
@@ -19,21 +19,23 @@ export default function HumanDonor({ item: humanDonor, accessoryData }) {
   const collections =
     humanDonor.collections?.length > 0 ? humanDonor.collections.join(", ") : "";
 
-  const phenotypicFeatures = humanDonor.phenotypic_features
-    ?.filter((path) => {
-      const keys = Object.keys(accessoryData);
-      return keys.includes(path);
-    })
-    .map((path) => {
-      const feature = accessoryData[path];
-      if (feature.quantity) {
-        return `${feature.feature.term_name} ${feature.quantity} ${
-          feature.quantity_units
-        }${feature.quantity === 1 ? "" : "s"}`;
-      }
-      return feature.feature.term_name;
-    })
-    .join(", ");
+  const phenotypicFeatures = accessoryData
+    ? humanDonor.phenotypic_features
+        ?.filter((path) => {
+          const keys = Object.keys(accessoryData);
+          return keys.includes(path);
+        })
+        .map((path) => {
+          const feature = accessoryData[path];
+          if (feature.quantity) {
+            return `${feature.feature.term_name} ${feature.quantity} ${
+              feature.quantity_units
+            }${feature.quantity === 1 ? "" : "s"}`;
+          }
+          return feature.feature.term_name;
+        })
+        .join(", ")
+    : "";
 
   return (
     <SearchListItemContent>

--- a/components/search/list-renderer/index.js
+++ b/components/search/list-renderer/index.js
@@ -7,6 +7,8 @@ import {
   SearchListItemType,
   SearchListItemUniqueId,
 } from "./search-list-item";
+// lib
+import FetchRequest from "../../../lib/fetch-request";
 
 /**
  * When you add a new renderer for a search-list item `@type`, likely in its own file in this
@@ -258,4 +260,28 @@ export function getItemListsByType(searchResults) {
     );
     return itemListsByTypeAcc;
   }, {});
+}
+
+/**
+ * Retrieve all needed accessory data for search results. Each search result item type might have
+ * an accessory data path retrieval function. If so, call it and return the results. Remember that
+ * the search results can contain a mix of item types, so this could get different accessory data
+ * for each search result. null gets returned if no accessory data is needed.
+ * @param {object} itemListsByType Search-result items keyed by item type
+ * @param {string} cookie Browser cookie for request authentication
+ */
+export async function getAccessoryData(itemListsByType, cookie) {
+  const accessoryDataPaths = getAccessoryDataPaths(itemListsByType);
+  if (accessoryDataPaths.length > 0) {
+    const request = new FetchRequest({ cookie });
+    const accessoryDataList = await request.getMultipleObjects(
+      accessoryDataPaths,
+      null,
+      {
+        filterErrors: true,
+      }
+    );
+    return generateAccessoryDataPropertyMap(accessoryDataList);
+  }
+  return null;
 }

--- a/components/search/list-renderer/rodent-donor.js
+++ b/components/search/list-renderer/rodent-donor.js
@@ -11,27 +11,32 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function RodentDonor({ item: rodentDonor, accessoryData }) {
+export default function RodentDonor({
+  item: rodentDonor,
+  accessoryData = null,
+}) {
   const lab = rodentDonor.lab;
   const collections =
     rodentDonor.collections?.length > 0
       ? rodentDonor.collections.join(", ")
       : "";
-  const phenotypicFeatures = rodentDonor.phenotypic_features
-    ?.filter((path) => {
-      const keys = Object.keys(accessoryData);
-      return keys.includes(path);
-    })
-    .map((path) => {
-      const feature = accessoryData[path];
-      if (feature.quantity) {
-        return `${feature.feature.term_name} ${feature.quantity} ${
-          feature.quantity_units
-        }${feature.quantity === 1 ? "" : "s"}`;
-      }
-      return feature.feature.term_name;
-    })
-    .join(", ");
+  const phenotypicFeatures = accessoryData
+    ? rodentDonor.phenotypic_features
+        ?.filter((path) => {
+          const keys = Object.keys(accessoryData);
+          return keys.includes(path);
+        })
+        .map((path) => {
+          const feature = accessoryData[path];
+          if (feature.quantity) {
+            return `${feature.feature.term_name} ${feature.quantity} ${
+              feature.quantity_units
+            }${feature.quantity === 1 ? "" : "s"}`;
+          }
+          return feature.feature.term_name;
+        })
+        .join(", ")
+    : "";
   return (
     <SearchListItemContent>
       <SearchListItemMain>

--- a/components/search/list-renderer/user.js
+++ b/components/search/list-renderer/user.js
@@ -11,7 +11,7 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function User({ item: user, accessoryData }) {
+export default function User({ item: user, accessoryData = null }) {
   const lab = accessoryData?.[user.lab];
 
   return (

--- a/components/session-context.js
+++ b/components/session-context.js
@@ -22,6 +22,7 @@ import {
   loginDataProvider,
   logoutAuthProvider,
 } from "../lib/authentication";
+import getCollectionTitles from "../lib/collection-titles";
 import getProfiles from "../lib/profiles";
 /* istanbul ignore file */
 
@@ -46,6 +47,8 @@ export function Session({ authentication, children }) {
   const [sessionProperties, setSessionProperties] = useState(null);
   // Caches the /profiles schemas
   const [profiles, setProfiles] = useState(null);
+  // Caches the /collection-titles map
+  const [collectionTitles, setCollectionTitles] = useState(null);
   // Caches the data provider URL
   const [dataProviderUrl, setDataProviderUrl] = useState(null);
   // Set to true once we start the process of signing into igvfd
@@ -92,11 +95,21 @@ export function Session({ authentication, children }) {
   // them from this context instead of doing a request to /profiles.
   useEffect(() => {
     if (!profiles && session) {
-      getProfiles(session).then((profiles) => {
-        setProfiles(profiles);
+      getProfiles(session).then((response) => {
+        setProfiles(response);
       });
     }
   }, [profiles, session]);
+
+  // Get the mapping of @type, collection name, and schema name to corresponding human-readable
+  // names.
+  useEffect(() => {
+    if (!collectionTitles && session) {
+      getCollectionTitles(session).then((response) => {
+        setCollectionTitles(response);
+      });
+    }
+  });
 
   // If we detect a transition from Auth0's logged-out state to logged-in state, log the user into
   // igvfd. The callback that auth0-react calls after a successful Auth0 login exists outside the
@@ -166,7 +179,9 @@ export function Session({ authentication, children }) {
   ]);
 
   return (
-    <SessionContext.Provider value={{ session, sessionProperties, profiles }}>
+    <SessionContext.Provider
+      value={{ session, sessionProperties, profiles, collectionTitles }}
+    >
       {children}
     </SessionContext.Provider>
   );

--- a/components/site-search-trigger.js
+++ b/components/site-search-trigger.js
@@ -1,0 +1,250 @@
+// node_modules
+import { MagnifyingGlassIcon, XCircleIcon } from "@heroicons/react/20/solid";
+import { Dialog } from "@headlessui/react";
+import { useRouter } from "next/router";
+import PropTypes from "prop-types";
+import { useEffect, useRef, useState } from "react";
+// components
+import { useSessionStorage } from "./browser-storage";
+// lib
+import { KC, UC } from "../lib/constants";
+import { encodeUriElement } from "../lib/query-encoding";
+
+// Maximum number of recent terms to keep track of.
+const MAX_RECENT_TERMS = 5;
+
+/**
+ * Hook to process the array of recently searched terms stored in sessionStorage. The most recent
+ * term gets stored first in the array.
+ */
+function useRecentSearches() {
+  const [recentTermsJson, setRecentTermsJson] = useSessionStorage(
+    "recent-site-search",
+    JSON.stringify([])
+  );
+  const recentTerms = JSON.parse(recentTermsJson);
+
+  function saveRecentTerm(recentTerm) {
+    // If the new search term is already in the list, remove it so we can then move it to the
+    // front of the list.
+    const updatedRecentTerms = recentTerms.includes(recentTerm)
+      ? recentTerms.filter((term) => term !== recentTerm)
+      : recentTerms;
+
+    // Add the new term to the front of the list, and limit the length of the list -- older items
+    // fall off the bottom of the list.
+    updatedRecentTerms.unshift(recentTerm);
+    const limitedRecentTerms = JSON.stringify(
+      updatedRecentTerms.slice(0, MAX_RECENT_TERMS)
+    );
+
+    // Save the new array of recent terms to sessionStorage.
+    setRecentTermsJson(limitedRecentTerms);
+  }
+
+  return {
+    // Array of recent terms, most recent first
+    recentTerms,
+    // Called to add a new term to the list of recent terms
+    saveRecentTerm,
+  };
+}
+
+/**
+ * Displays the search trigger for when the navigation is expanded.
+ */
+function SearchTriggerExpanded({ onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex h-8 w-full items-center gap-2 rounded border border-panel bg-form-element p-2 text-form-element"
+      label="Search the site for a word or phrase"
+    >
+      <MagnifyingGlassIcon className="h-4 w-4" />
+      <div className="text-sm text-gray-400">{`Search (${UC.cmd}K or ${UC.ctrl}K)`}</div>
+    </button>
+  );
+}
+
+SearchTriggerExpanded.propTypes = {
+  // Function to call when the user clicks the search trigger
+  onClick: PropTypes.func.isRequired,
+};
+
+/**
+ * Displays the search trigger for when the navigation is collapsed.
+ */
+function SearchTriggerCollapsed({ onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      className="block"
+      label="Search the site for a word or phrase"
+    >
+      <MagnifyingGlassIcon className="h-8 w-8" />
+    </button>
+  );
+}
+
+SearchTriggerCollapsed.propTypes = {
+  // Function to call when the user clicks the search trigger
+  onClick: PropTypes.func.isRequired,
+};
+
+/**
+ * Displays the site-search modal as an overlay on whatever page the user viewed when they
+ * triggered this box. This also displays the trigger for the box, which appears like a text edit
+ * field though it's actually a button.
+ */
+export default function SiteSearchTrigger({ isExpanded }) {
+  // True if the search input modal is open
+  const [isInputOpen, setIsInputOpen] = useState(false);
+  // Holds the currently typed search term
+  const [searchTerm, setSearchTerm] = useState("");
+  // Recently searched terms from sessionStorage
+  const { recentTerms, saveRecentTerm } = useRecentSearches();
+
+  const inputRef = useRef(null);
+  const router = useRouter();
+
+  // Called to change the search text input value.
+  function onChange(event) {
+    setSearchTerm(event.target.value);
+  }
+
+  // Called to close the search input modal and clear its value for next time.
+  function closeModal() {
+    setSearchTerm("");
+    setIsInputOpen(false);
+  }
+
+  // Navigates to the site-search page with the current search term to show the results. The search
+  // term gets saved to sessionStorage.
+  function closeModalAndExecuteSearch() {
+    closeModal();
+    const trimmedTerm = searchTerm.trim();
+    if (trimmedTerm) {
+      saveRecentTerm(trimmedTerm);
+      router.push(`/site-search?term=${encodeUriElement(trimmedTerm)}`);
+    }
+  }
+
+  // Called when the user types a key while the search input is open, allowing ESC to close the
+  // modal, or RETURN to close the modal and trigger the search.
+  function onKeyDown(event) {
+    if (event.keyCode === KC.ESC) {
+      // ESC just closes the modal and forgets what the user typed.
+      event.preventDefault();
+      closeModal();
+    } else if (event.keyCode === KC.RETURN) {
+      // RETURN closes the modal and performs the search.
+      event.preventDefault();
+      closeModalAndExecuteSearch();
+    }
+  }
+
+  // Called when the user clicks on a recent search term. This overwrites any text in the search
+  // input with the clicked term, and focuses the input so the user can continue typing.
+  function onRecentSearch(recentTerm) {
+    setSearchTerm(recentTerm);
+    inputRef.current.focus();
+  }
+
+  // Set up the command-key equivalent for triggering the search modal regardless of the current
+  // page.
+  useEffect(() => {
+    function onSearchKeypress(event) {
+      if (
+        (event.key === "k" || event.key === "K") &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        setIsInputOpen(true);
+        return false;
+      }
+      return true;
+    }
+
+    document.addEventListener("keydown", onSearchKeypress);
+    return () => {
+      document.removeEventListener("keydown", onSearchKeypress);
+    };
+  });
+
+  // Once the search input modal opens, focus the input field so the user can start typing.
+  useEffect(() => {
+    if (isInputOpen) {
+      inputRef.current.focus();
+    }
+  }, [isInputOpen]);
+
+  return (
+    <>
+      {isExpanded ? (
+        <SearchTriggerExpanded onClick={() => setIsInputOpen(true)} />
+      ) : (
+        <SearchTriggerCollapsed onClick={() => setIsInputOpen(true)} />
+      )}
+
+      <Dialog open={isInputOpen} onClose={closeModal} className="relative z-50">
+        <div
+          className="fixed inset-0 bg-black/30 dark:bg-black/60"
+          aria-hidden="true"
+        />
+        <div className="fixed inset-0 overflow-y-auto">
+          <Dialog.Panel className="mx-auto w-4/5 max-w-4xl overflow-hidden rounded-lg border border-modal-border bg-white drop-shadow-lg dark:bg-gray-900 xl:my-20">
+            <div className="flex items-center gap-2 px-2 py-1">
+              <button
+                onClick={closeModalAndExecuteSearch}
+                aria-label={`Search for ${searchTerm}`}
+              >
+                <MagnifyingGlassIcon className="h-6 w-6 fill-black dark:fill-white" />
+              </button>
+              <input
+                type="text"
+                ref={inputRef}
+                placeholder="Search"
+                value={searchTerm}
+                onChange={onChange}
+                onKeyDown={onKeyDown}
+                className="block w-full border-none bg-transparent py-3 text-black outline-none dark:text-white"
+              />
+              <button
+                onClick={closeModal}
+                aria-label="Close search box without searching"
+              >
+                <XCircleIcon className="h-6 w-6 fill-gray-500" />
+              </button>
+            </div>
+
+            {recentTerms.length > 0 && (
+              <>
+                <div className="border-t border-panel px-4 py-2 text-base font-semibold text-gray-500 dark:text-gray-300">
+                  Recent Searches
+                </div>
+                {recentTerms.map((recentTerm) => {
+                  return (
+                    <button
+                      className="block w-full border-t border-gray-100 px-4 py-2 text-left text-sm text-gray-800 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700"
+                      key={recentTerm}
+                      onClick={() => onRecentSearch(recentTerm)}
+                      aria-label={`Enter the recent search, ${recentTerm}, into the search box`}
+                    >
+                      {recentTerm}
+                    </button>
+                  );
+                })}
+              </>
+            )}
+          </Dialog.Panel>
+        </div>
+      </Dialog>
+    </>
+  );
+}
+
+SiteSearchTrigger.propTypes = {
+  // True if the navigation area is expanded
+  isExpanded: PropTypes.bool,
+};

--- a/components/site-search-trigger.js
+++ b/components/site-search-trigger.js
@@ -81,7 +81,7 @@ function SearchTriggerCollapsed({ onClick }) {
       className="block"
       label="Search the site for a word or phrase"
     >
-      <MagnifyingGlassIcon className="h-8 w-8" />
+      <MagnifyingGlassIcon className="h-8 w-8 fill-black dark:fill-white" />
     </button>
   );
 }

--- a/lib/__tests__/collection-titles.test.js
+++ b/lib/__tests__/collection-titles.test.js
@@ -1,0 +1,30 @@
+import getCollectionTitles from "../collection-titles";
+
+describe("Test the getCollectionTitles function", () => {
+  it("returns the collection-titles object", async () => {
+    const expectedCollectionTitles = {
+      awards: "Awards (Grants)",
+      Award: "Awards (Grants)",
+      award: "Awards (Grants)",
+      biomarkers: "Biomarkers",
+      Biomarker: "Biomarkers",
+      biomarker: "Biomarkers",
+      "human-donors": "Human Donors",
+      HumanDonor: "Human Donors",
+      human_donor: "Human Donors",
+      "rodent-donors": "Rodent Donors",
+      RodentDonor: "Rodent Donors",
+      rodent_donor: "Rodent Donors",
+    };
+
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(expectedCollectionTitles),
+      })
+    );
+
+    const collectionTitles = await getCollectionTitles("SESSIONCSFRTOKEN");
+    expect(collectionTitles).toEqual(expectedCollectionTitles);
+  });
+});

--- a/lib/collection-titles.js
+++ b/lib/collection-titles.js
@@ -1,0 +1,12 @@
+// libs
+import FetchRequest from "./fetch-request";
+
+/**
+ * Loads the mapping of schema name, @type, and collection names to human-readable titles.
+ * @param {object} session Authentication session object
+ * @returns {Promise} Promise that resolves to the /collection-titles/ object
+ */
+export default async function getCollectionTitles(session) {
+  const request = new FetchRequest({ session });
+  return request.getObject("/collection-titles/", null);
+}

--- a/lib/query-string.js
+++ b/lib/query-string.js
@@ -126,7 +126,11 @@ export default class QueryString {
   }
 
   constructor(query) {
-    this.#query = query[0] === "?" ? query.slice(1) : query;
+    if (query) {
+      this.#query = query[0] === "?" ? query.slice(1) : query;
+    } else {
+      this.#query = "";
+    }
     this.#parsedQuery = [];
     this.#parse();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1584,9 +1584,9 @@
       }
     },
     "node_modules/@pkgr/utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.0.tgz",
-      "integrity": "sha512-2OCURAmRtdlL8iUDTypMrrxfwe8frXTeXaxGsVOaYtc/wrUyk8Z/0OBetM7cdlsy7ZFWlMX72VogKeh+A4Xcjw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.1.tgz",
+      "integrity": "sha512-JOqwkgFEyi+OROIyq7l4Jy28h/WwhDnG/cPkXG2Z1iFbubB6jsHW1NDvmyOzTBxHr3yg68YGirmh1JUgMqa+9w==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -1919,9 +1919,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.6.tgz",
-      "integrity": "sha512-wRZClXn//zxCFW+ye/D2qY65UsYP1Fpex2YXorHc8awoNamkMZSvBxwxdYVInsHOZZd2Ppq8isnSzJL5Mpf8OA==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.7.tgz",
+      "integrity": "sha512-ojrXpSH2XFCmHm7Jy3q44nXDyN54+EYKP2lBhJ2bqfyPj6cIUW/FZW/Csdia34NQgq7KYcAlHi5184m4X88+yw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -1969,9 +1969,9 @@
       "dev": true
     },
     "node_modules/@types/testing-library__jest-dom": {
-      "version": "5.14.5",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz",
-      "integrity": "sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==",
+      "version": "5.14.6",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.6.tgz",
+      "integrity": "sha512-FkHXCb+ikSoUP4Y4rOslzTdX5sqYwMxfefKh1GmZ8ce1GOkEHntSp6b5cGadmNfp5e4BMEWOMx+WSKd5/MqlDA==",
       "dev": true,
       "dependencies": {
         "@types/jest": "*"
@@ -2522,9 +2522,9 @@
       }
     },
     "node_modules/auth0-js": {
-      "version": "9.20.2",
-      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.20.2.tgz",
-      "integrity": "sha512-a6tFTYYK2+DQA3+A/mTKAWt/XOaMeiGWu644SnyAL5P84K79G53QOwtn/ok3DbM9MRfRp+2jYE6U4czTLJnj/g==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.21.0.tgz",
+      "integrity": "sha512-2la4dDWo3BQ0RZQBlT0neorzW6UQ0Ai3pJr//eAF1NJffjn9LFyb2bgcsmjheptN9HPReEceoLOhB3eROQsaQQ==",
       "dev": true,
       "dependencies": {
         "base64-js": "^1.5.1",
@@ -3330,9 +3330,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.12.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.12.0.tgz",
-      "integrity": "sha512-UU5wFQ7SMVCR/hyKok/KmzG6fpZgBHHfrXcHzDmPHWrT+UUetxFzQgt7cxCszlwfozckzwkd22dxMwl/vNkWRw==",
+      "version": "12.13.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.13.0.tgz",
+      "integrity": "sha512-QJlSmdPk+53Zhy69woJMySZQJoWfEWun3X5OOenGsXjRPVfByVTHorxNehbzhZrEzH9RDUDqVcck0ahtlS+N/Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3834,9 +3834,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.403",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.403.tgz",
-      "integrity": "sha512-evCMqXJWmbQHdlh307peXNguqVIMmcLGrQwXiR+Qc98js8jPDeT9rse1+EF2YRjWgueuzj1r4WWLAe4/U+xjMg==",
+      "version": "1.4.405",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.405.tgz",
+      "integrity": "sha512-JdDgnwU69FMZURoesf9gNOej2Cms1XJFfLk24y1IBtnAdhTcJY/mXnokmpmxHN59PcykBP4bgUU98vLY44Lhuw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -3875,9 +3875,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.0.tgz",
-      "integrity": "sha512-+DCows0XNwLDcUhbFJPdlQEVnT2zXlCv7hPxemTz86/O+B/hCQ+mb7ydkPKiflpVraqLPCAfu7lDy+hBXueojw==",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.1.tgz",
+      "integrity": "sha512-Vklwq2vDKtl0y/vtwjSesgJ5MYS7Etuk5txS8VdKL4AOS1aUlD96zqIfsOSLQsdv3xgMRbtkWM8eG9XDfKUPow==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -4992,9 +4992,9 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "10.12.12",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.12.tgz",
-      "integrity": "sha512-DDCqp60U6hR7aUrXj/BXc/t0Sd/U4ep6w/NZQkw898K+u7s+Vv/P8yxq4WTNA86kU9QCsqOgn1Qhz2DpYK0Oag==",
+      "version": "10.12.16",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.16.tgz",
+      "integrity": "sha512-w/SfWEIWJkYSgRHYBmln7EhcNo31ao8Xexol8lGXf1pR/tlnBtf1HcxoUmEiEh6pacB4/geku5ami53AAQWHMQ==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -7921,9 +7921,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.11.tgz",
-      "integrity": "sha512-+M0PwXeU80kRohZ3aT4J/OnR+l9/KD2nVLNNoRgFtnf+umQVFdGBAO2N8+nCnEi0xlh/Wk3zOGC+vNNx+uM79Q==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
+      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -10473,11 +10473,12 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.0.tgz",
+      "integrity": "sha512-8/1wgzdKc7bc9E6my5wZjmdavHLvO/QOmLG1FBugblEvY4IXrLjlViIOmL24HthU042lWTDRO90Fz1Yp66UnMw==",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14",
+        "npm": ">= 7"
       }
     },
     "node_modules/yargs": {
@@ -11674,9 +11675,9 @@
       }
     },
     "@pkgr/utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.0.tgz",
-      "integrity": "sha512-2OCURAmRtdlL8iUDTypMrrxfwe8frXTeXaxGsVOaYtc/wrUyk8Z/0OBetM7cdlsy7ZFWlMX72VogKeh+A4Xcjw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.1.tgz",
+      "integrity": "sha512-JOqwkgFEyi+OROIyq7l4Jy28h/WwhDnG/cPkXG2Z1iFbubB6jsHW1NDvmyOzTBxHr3yg68YGirmh1JUgMqa+9w==",
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.3",
@@ -11969,9 +11970,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.6.tgz",
-      "integrity": "sha512-wRZClXn//zxCFW+ye/D2qY65UsYP1Fpex2YXorHc8awoNamkMZSvBxwxdYVInsHOZZd2Ppq8isnSzJL5Mpf8OA==",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.7.tgz",
+      "integrity": "sha512-ojrXpSH2XFCmHm7Jy3q44nXDyN54+EYKP2lBhJ2bqfyPj6cIUW/FZW/Csdia34NQgq7KYcAlHi5184m4X88+yw==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -12019,9 +12020,9 @@
       "dev": true
     },
     "@types/testing-library__jest-dom": {
-      "version": "5.14.5",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz",
-      "integrity": "sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==",
+      "version": "5.14.6",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.6.tgz",
+      "integrity": "sha512-FkHXCb+ikSoUP4Y4rOslzTdX5sqYwMxfefKh1GmZ8ce1GOkEHntSp6b5cGadmNfp5e4BMEWOMx+WSKd5/MqlDA==",
       "dev": true,
       "requires": {
         "@types/jest": "*"
@@ -12417,9 +12418,9 @@
       "dev": true
     },
     "auth0-js": {
-      "version": "9.20.2",
-      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.20.2.tgz",
-      "integrity": "sha512-a6tFTYYK2+DQA3+A/mTKAWt/XOaMeiGWu644SnyAL5P84K79G53QOwtn/ok3DbM9MRfRp+2jYE6U4czTLJnj/g==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.21.0.tgz",
+      "integrity": "sha512-2la4dDWo3BQ0RZQBlT0neorzW6UQ0Ai3pJr//eAF1NJffjn9LFyb2bgcsmjheptN9HPReEceoLOhB3eROQsaQQ==",
       "dev": true,
       "requires": {
         "base64-js": "^1.5.1",
@@ -12988,9 +12989,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "12.12.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.12.0.tgz",
-      "integrity": "sha512-UU5wFQ7SMVCR/hyKok/KmzG6fpZgBHHfrXcHzDmPHWrT+UUetxFzQgt7cxCszlwfozckzwkd22dxMwl/vNkWRw==",
+      "version": "12.13.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.13.0.tgz",
+      "integrity": "sha512-QJlSmdPk+53Zhy69woJMySZQJoWfEWun3X5OOenGsXjRPVfByVTHorxNehbzhZrEzH9RDUDqVcck0ahtlS+N/Q==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -13365,9 +13366,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.403",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.403.tgz",
-      "integrity": "sha512-evCMqXJWmbQHdlh307peXNguqVIMmcLGrQwXiR+Qc98js8jPDeT9rse1+EF2YRjWgueuzj1r4WWLAe4/U+xjMg==",
+      "version": "1.4.405",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.405.tgz",
+      "integrity": "sha512-JdDgnwU69FMZURoesf9gNOej2Cms1XJFfLk24y1IBtnAdhTcJY/mXnokmpmxHN59PcykBP4bgUU98vLY44Lhuw==",
       "dev": true
     },
     "emittery": {
@@ -13400,9 +13401,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.0.tgz",
-      "integrity": "sha512-+DCows0XNwLDcUhbFJPdlQEVnT2zXlCv7hPxemTz86/O+B/hCQ+mb7ydkPKiflpVraqLPCAfu7lDy+hBXueojw==",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.1.tgz",
+      "integrity": "sha512-Vklwq2vDKtl0y/vtwjSesgJ5MYS7Etuk5txS8VdKL4AOS1aUlD96zqIfsOSLQsdv3xgMRbtkWM8eG9XDfKUPow==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4",
@@ -14251,9 +14252,9 @@
       "dev": true
     },
     "framer-motion": {
-      "version": "10.12.12",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.12.tgz",
-      "integrity": "sha512-DDCqp60U6hR7aUrXj/BXc/t0Sd/U4ep6w/NZQkw898K+u7s+Vv/P8yxq4WTNA86kU9QCsqOgn1Qhz2DpYK0Oag==",
+      "version": "10.12.16",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.16.tgz",
+      "integrity": "sha512-w/SfWEIWJkYSgRHYBmln7EhcNo31ao8Xexol8lGXf1pR/tlnBtf1HcxoUmEiEh6pacB4/geku5ami53AAQWHMQ==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
         "tslib": "^2.4.0"
@@ -16360,9 +16361,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.11.tgz",
-      "integrity": "sha512-+M0PwXeU80kRohZ3aT4J/OnR+l9/KD2nVLNNoRgFtnf+umQVFdGBAO2N8+nCnEi0xlh/Wk3zOGC+vNNx+uM79Q==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
+      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
       "dev": true
     },
     "normalize-path": {
@@ -18152,9 +18153,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.0.tgz",
+      "integrity": "sha512-8/1wgzdKc7bc9E6my5wZjmdavHLvO/QOmLG1FBugblEvY4IXrLjlViIOmL24HthU042lWTDRO90Fz1Yp66UnMw=="
     },
     "yargs": {
       "version": "17.7.2",

--- a/pages/site-search.js
+++ b/pages/site-search.js
@@ -27,6 +27,10 @@ import { UC } from "../lib/constants";
 import FetchRequest from "../lib/fetch-request";
 import QueryString from "../lib/query-string";
 
+function getTypeTitle(searchResult, collectionTitles) {
+  return collectionTitles?.[searchResult.key] || searchResult.key;
+}
+
 /**
  * Displays the header for a single type's top hits.
  */
@@ -44,7 +48,7 @@ function TypeSectionHeader({
   query.addKeyValue("searchTerm", term);
 
   // Get the section title for the top-hits type.
-  const typeTitle = collectionTitles?.[searchResult.key] || searchResult.key;
+  const typeTitle = getTypeTitle(searchResult, collectionTitles);
 
   return (
     <div
@@ -140,6 +144,7 @@ TypeTopHits.propTypes = {
 export default function SiteSearch({ results, term, accessoryData = null }) {
   // Tracks the keys of opened type sections
   const [openedSections, setOpenedSections] = useState([]);
+  const { collectionTitles } = useContext(SessionContext);
 
   function onSectionOpenClick(sectionKey) {
     if (openedSections.includes(sectionKey)) {
@@ -163,6 +168,7 @@ export default function SiteSearch({ results, term, accessoryData = null }) {
         <ul>
           {results.map((result) => {
             const isSectionOpen = openedSections.includes(result.key);
+            const typeTitle = getTypeTitle(result, collectionTitles);
             return (
               <TypeSection key={result.key}>
                 <TypeSectionHeader
@@ -174,13 +180,16 @@ export default function SiteSearch({ results, term, accessoryData = null }) {
                 <AnimatePresence>
                   {isSectionOpen && (
                     <motion.div
-                      className="overflow-hidden text-sm leading-relaxed"
+                      className="overflow-hidden bg-gray-100 text-sm leading-relaxed dark:bg-gray-900"
                       initial="collapsed"
                       animate="open"
                       exit="collapsed"
                       transition={standardAnimationTransition}
                       variants={standardAnimationVariants}
                     >
+                      <div className="px-1 pt-0.5 text-center text-xs font-semibold uppercase text-gray-500">
+                        Top results for {typeTitle}
+                      </div>
                       <TypeTopHits topHits={result.top_hits.hits.hits}>
                         {(item) => {
                           const SearchListItemRenderer =

--- a/pages/site-search.js
+++ b/pages/site-search.js
@@ -1,0 +1,268 @@
+// node_modules
+import { AnimatePresence, motion } from "framer-motion";
+import {
+  Bars4Icon,
+  MinusIcon,
+  PlusIcon,
+  TableCellsIcon,
+} from "@heroicons/react/20/solid";
+import PropTypes from "prop-types";
+import { Fragment, useContext, useEffect, useState } from "react";
+// components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "../components/animation";
+import { ButtonLink } from "../components/form-elements";
+import NoCollectionData from "../components/no-collection-data";
+import PagePreamble from "../components/page-preamble";
+import {
+  getAccessoryData,
+  getSearchListItemRenderer,
+  SearchListItem,
+} from "../components/search";
+import SessionContext from "../components/session-context";
+// lib
+import { UC } from "../lib/constants";
+import FetchRequest from "../lib/fetch-request";
+import QueryString from "../lib/query-string";
+
+/**
+ * Displays the header for a single type's top hits.
+ */
+function TypeSectionHeader({
+  searchResult,
+  term,
+  isSectionOpen,
+  onSectionOpenClick,
+}) {
+  const { collectionTitles } = useContext(SessionContext);
+
+  // Build a query for the list and report views for the top-hits search type.
+  const query = new QueryString();
+  query.addKeyValue("type", searchResult.key);
+  query.addKeyValue("searchTerm", term);
+
+  // Get the section title for the top-hits type.
+  const typeTitle = collectionTitles?.[searchResult.key] || searchResult.key;
+
+  return (
+    <div
+      className={`flex justify-between border-data-border bg-site-search-header p-1${
+        isSectionOpen ? " border-b" : ""
+      }`}
+    >
+      <div className="sm:flex sm:items-center sm:gap-2">
+        <button
+          onClick={() => onSectionOpenClick(searchResult.key)}
+          aria-label={`${
+            isSectionOpen ? "Collapse" : "Expand"
+          } top matches for ${typeTitle}`}
+        >
+          {isSectionOpen ? (
+            <MinusIcon className="h-4 w-4" />
+          ) : (
+            <PlusIcon className="h-4 w-4" />
+          )}
+        </button>
+        <div className="text-lg font-semibold">{typeTitle}</div>
+        <div className="text-sm text-gray-600 dark:text-gray-300">
+          {searchResult.doc_count} item{searchResult.doc_count === 1 ? "" : "s"}
+        </div>
+      </div>
+      <div className="flex gap-1">
+        <ButtonLink
+          href={`/search?${query.format()}`}
+          type="primary"
+          label={`View search list for ${typeTitle} with ${term}`}
+          hasIconOnly
+        >
+          <Bars4Icon className="h-4 w-4" />
+        </ButtonLink>
+        <ButtonLink
+          href={`/report?${query.format()}`}
+          type="primary"
+          label={`View search report for ${typeTitle} with ${term}`}
+          hasIconOnly
+        >
+          <TableCellsIcon className="h-4 w-4" />
+        </ButtonLink>
+      </div>
+    </div>
+  );
+}
+
+TypeSectionHeader.propTypes = {
+  // Search results for a single type
+  searchResult: PropTypes.shape({
+    // Search result type
+    key: PropTypes.string.isRequired,
+    // Total number of matches for the type
+    doc_count: PropTypes.number.isRequired,
+  }),
+  // Term leading to these top-hit results
+  term: PropTypes.string.isRequired,
+  // True if the trigger should show the section is open
+  isSectionOpen: PropTypes.bool.isRequired,
+  // Call to toggle the open state of the section
+  onSectionOpenClick: PropTypes.func.isRequired,
+};
+
+/**
+ * Display the top-hits results for one `@type` of searchTerm results.
+ */
+function TypeSection({ children }) {
+  return (
+    <li className="my-4 border border-data-border bg-panel first:mt-0 last:mb-0">
+      {children}
+    </li>
+  );
+}
+
+/**
+ * Displays the list of top hits for a single type.
+ */
+function TypeTopHits({ topHits, children }) {
+  return (
+    <ul className="p-0.5">
+      {topHits.map((hit) => (
+        <Fragment key={hit._id}>{children(hit._source.embedded)}</Fragment>
+      ))}
+    </ul>
+  );
+}
+
+TypeTopHits.propTypes = {
+  // Top hits results
+  topHits: PropTypes.array.isRequired,
+};
+
+export default function SiteSearch({ results, term, accessoryData = null }) {
+  // Tracks the keys of opened type sections
+  const [openedSections, setOpenedSections] = useState([]);
+
+  function onSectionOpenClick(sectionKey) {
+    if (openedSections.includes(sectionKey)) {
+      setOpenedSections(
+        openedSections.filter((section) => section !== sectionKey)
+      );
+    } else {
+      setOpenedSections(openedSections.concat(sectionKey));
+    }
+  }
+
+  // Close all the type sections if the search term changes.
+  useEffect(() => {
+    setOpenedSections([]);
+  }, [term]);
+
+  return (
+    <>
+      <PagePreamble />
+      {results.length > 0 ? (
+        <ul>
+          {results.map((result) => {
+            const isSectionOpen = openedSections.includes(result.key);
+            return (
+              <TypeSection key={result.key}>
+                <TypeSectionHeader
+                  searchResult={result}
+                  term={term}
+                  isSectionOpen={isSectionOpen}
+                  onSectionOpenClick={onSectionOpenClick}
+                />
+                <AnimatePresence>
+                  {isSectionOpen && (
+                    <motion.div
+                      className="overflow-hidden text-sm leading-relaxed"
+                      initial="collapsed"
+                      animate="open"
+                      exit="collapsed"
+                      transition={standardAnimationTransition}
+                      variants={standardAnimationVariants}
+                    >
+                      <TypeTopHits topHits={result.top_hits.hits.hits}>
+                        {(item) => {
+                          const SearchListItemRenderer =
+                            getSearchListItemRenderer(item);
+                          return (
+                            <SearchListItem
+                              key={item["@id"]}
+                              testid={item["@id"]}
+                              href={item["@id"]}
+                            >
+                              <SearchListItemRenderer
+                                item={item}
+                                accessoryData={accessoryData}
+                              />
+                            </SearchListItem>
+                          );
+                        }}
+                      </TypeTopHits>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </TypeSection>
+            );
+          })}
+        </ul>
+      ) : (
+        <NoCollectionData pageTitle="matching items" />
+      )}
+    </>
+  );
+}
+
+SiteSearch.propTypes = {
+  // Top-hits search result buckets
+  results: PropTypes.array.isRequired,
+  // Search term leading to these results
+  term: PropTypes.string.isRequired,
+  // Accessory data for search results, keyed by each object's `@id`
+  accessoryData: PropTypes.object,
+};
+
+/**
+ * Generate lists of top-hits result items by item type, generating an object with each item type in
+ * the search results as keys. Under each key is an array of search-result items of that type, i.e.:
+ * ```
+ * {
+ *   "PrimaryCell": [primary-cell-item-1, primary-cell-item-2, primary-cell-item-3],
+ *   "Tissue": [tissue-item-1, tissue-item-2],
+ * }
+ * ```
+ * @param {object} topHitsResults Search results from igvfd
+ * @returns {object} Object with item types as keys and arrays of search-result items as values
+ */
+function getTopHitsItemListsByType(topHitsResults) {
+  const buckets = topHitsResults.aggregations.types.types.buckets;
+  const list = {};
+  buckets.forEach((bucket) => {
+    list[bucket.key] = bucket.top_hits.hits.hits.map(
+      (hit) => hit._source.embedded
+    );
+  });
+  return list;
+}
+
+export async function getServerSideProps({ req, query }) {
+  // Accept a single "term=" query-string parameter.
+  const request = new FetchRequest({ cookie: req.headers.cookie });
+  const term = query.term;
+  const topHitsResults = await request.getObject(
+    `/top-hits-raw?searchTerm=${term}`
+  );
+  const itemListsByType = getTopHitsItemListsByType(topHitsResults);
+  const accessoryData = await getAccessoryData(
+    itemListsByType,
+    req.headers.cookie
+  );
+  return {
+    props: {
+      results: topHitsResults.aggregations.types.types.buckets,
+      accessoryData,
+      term,
+      pageContext: { title: `Items with ${UC.ldquo}${term}${UC.rdquo}` },
+    },
+  };
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -91,6 +91,8 @@
   --color-facet-title-background: #b2d0de;
   --color-facet-title-text: #000000;
 
+  --color-site-search-header-background: #c9ebe2;
+
   --color-form-element-background: #ffffff;
   --color-form-element-border: #384977;
   --color-form-element-label: #000000;
@@ -181,6 +183,8 @@
 
   --color-facet-title-background: #536167;
   --color-facet-title-text: #ffffff;
+
+  --color-site-search-header-background: #394240;
 
   --color-data-header-background: #192339;
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -61,6 +61,8 @@ module.exports = {
         "facet-group-button-selected":
           "var(--color-facet-group-button-selected-background)",
         "facet-title": "var(--color-facet-title-background)",
+
+        "site-search-header": "var(--color-site-search-header-background)",
       },
       borderColor: {
         panel: "var(--color-panel-border)",


### PR DESCRIPTION
* The two main new components are `<SiteSearchTrigger>` and `<SiteSearch>`. The former is the button that looks like an input field that triggers the search input to appear overlaid on whatever page the user views. The latter is the page that shows site-wide search results.
* Some list view renderers assumed accessory data is always available — an assumption that can cause crashes — which happened as I tested this branch. I fixed these, and explicitly set a null default value on all `accessoryData` properties as they’re not required properties.
* SessionContext now caches the /collection-titles/ mapping, useful for mapping collection names and `@type` to a human-readable name.