### PR TITLE
IGVF-707 Fix display of properties with value of zero

### DIFF
--- a/components/common-data-items.js
+++ b/components/common-data-items.js
@@ -16,6 +16,7 @@ import ProductInfo from "./product-info";
 import SeparatedList from "./separated-list";
 // lib
 import { formatDate } from "../lib/dates";
+import { truthyOrZero } from "../lib/general";
 
 /**
  * Display the data items common to all donor-derived objects.
@@ -135,7 +136,7 @@ export function SampleDataItems({
           </DataItemValue>
         </>
       )}
-      {sample.starting_amount && (
+      {truthyOrZero(sample.starting_amount) && (
         <>
           <DataItemLabel>Starting Amount</DataItemLabel>
           <DataItemValue>
@@ -229,8 +230,12 @@ export function BiosampleDataItems({
 }) {
   return (
     <SampleDataItems sample={biosample} source={source}>
-      <DataItemLabel>Taxa</DataItemLabel>
-      <DataItemValue>{biosample.taxa}</DataItemValue>
+      {biosample.taxa && (
+        <>
+          <DataItemLabel>Taxa</DataItemLabel>
+          <DataItemValue>{biosample.taxa}</DataItemValue>
+        </>
+      )}
       {biosampleTerm && (
         <>
           <DataItemLabel>Biosample Term</DataItemLabel>
@@ -446,7 +451,7 @@ export function FileDataItems({ file, fileSet, derivedFrom, children }) {
           <DataItemValue>{file.content_md5sum}</DataItemValue>
         </>
       )}
-      {file.file_size && (
+      {truthyOrZero(file.file_size) && (
         <>
           <DataItemLabel>File Size</DataItemLabel>
           <DataItemValue>{file.file_size}</DataItemValue>

--- a/components/search/list-renderer/treatment.js
+++ b/components/search/list-renderer/treatment.js
@@ -11,6 +11,7 @@ import {
 } from "./search-list-item";
 // lib
 import { UC } from "../../../lib/constants";
+import { truthyOrZero } from "../../../lib/general";
 
 export default function Treatment({ item: treatment }) {
   return (
@@ -20,7 +21,7 @@ export default function Treatment({ item: treatment }) {
           <SearchListItemType item={treatment} />
           {treatment.treatment_term_id}
         </SearchListItemUniqueId>
-        {treatment.duration ? (
+        {truthyOrZero(treatment.duration) ? (
           <SearchListItemTitle>
             {treatment.treatment_term_name} {UC.mdash}{" "}
             {treatment.treatment_type} {UC.mdash} {treatment.amount}{" "}

--- a/lib/general.js
+++ b/lib/general.js
@@ -80,3 +80,13 @@ export function toShishkebabCase(text) {
 export function removeTrailingSlash(url) {
   return url.endsWith("/") ? url.slice(0, url.length - 1) : url;
 }
+
+/**
+ * Tests numeric values that we should display even if zero, but shouldn't get displayed if
+ * undefined.
+ * @param {number} value Check for truthy or zero
+ * @returns {boolean} True if the value is truthy or zero
+ */
+export function truthyOrZero(value) {
+  return value || value === 0;
+}

--- a/lib/phenotypic-feature.js
+++ b/lib/phenotypic-feature.js
@@ -1,3 +1,6 @@
+// lib
+import { truthyOrZero } from "./general";
+
 /**
  * Use the same title for PhenotypicFeature search page and PhenotypicFeature object page for that PhenotypicFeature
  * @param {object} phenotypicFeature Object to get the title from
@@ -5,7 +8,7 @@
  */
 export function getPhenotypicFeatureTitle(phenotypicFeature) {
   const title = `${phenotypicFeature.feature.term_name} ${
-    phenotypicFeature.quantity
+    truthyOrZero(phenotypicFeature.quantity)
       ? ` - ${phenotypicFeature.quantity} ${phenotypicFeature.quantity_units}`
       : ""
   }`;

--- a/pages/in-vitro-systems/[id].js
+++ b/pages/in-vitro-systems/[id].js
@@ -23,6 +23,7 @@ import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
+import { truthyOrZero } from "../../lib/general";
 import { isJsonFormat } from "../../lib/query-utils";
 
 export default function InVitroSystem({
@@ -71,7 +72,7 @@ export default function InVitroSystem({
                     </DataItemValue>
                   </>
                 )}
-                {inVitroSystem.passage_number && (
+                {truthyOrZero(inVitroSystem.passage_number) && (
                   <>
                     <DataItemLabel>Passage Number</DataItemLabel>
                     <DataItemValue>

--- a/pages/phenotypic-features/[id].js
+++ b/pages/phenotypic-features/[id].js
@@ -18,6 +18,7 @@ import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
+import { truthyOrZero } from "../../lib/general";
 import { getPhenotypicFeatureTitle } from "../../lib/phenotypic-feature";
 import { isJsonFormat } from "../../lib/query-utils";
 
@@ -39,7 +40,7 @@ export default function PhenotypicFeature({
               <DataItemValue>
                 <Link href={phenotypicFeature.feature["@id"]}>{feature}</Link>
               </DataItemValue>
-              {phenotypicFeature.quantity && (
+              {truthyOrZero(phenotypicFeature.quantity) && (
                 <>
                   <DataItemLabel>Quantity</DataItemLabel>
                   <DataItemValue>

--- a/pages/platform-terms/[name].js
+++ b/pages/platform-terms/[name].js
@@ -33,7 +33,7 @@ export default function PlatformOntologyTerm({ platformOntologyTerm, isJson }) {
 
 PlatformOntologyTerm.propTypes = {
   // Platform ontology term to display
-  platformOntologyTerm: PropTypes.object.isRequied,
+  platformOntologyTerm: PropTypes.object.isRequired,
   // Is the format JSON?
   isJson: PropTypes.bool.isRequired,
 };

--- a/pages/primary-cells/[uuid].js
+++ b/pages/primary-cells/[uuid].js
@@ -22,6 +22,7 @@ import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
+import { truthyOrZero } from "../../lib/general";
 import { isJsonFormat } from "../../lib/query-utils";
 
 export default function PrimaryCell({
@@ -58,7 +59,7 @@ export default function PrimaryCell({
                   dateObtainedTitle: "Date Harvested",
                 }}
               >
-                {primaryCell.passage_number && (
+                {truthyOrZero(primaryCell.passage_number) && (
                   <>
                     <DataItemLabel>Passage Number</DataItemLabel>
                     <DataItemValue>{primaryCell.passage_number}</DataItemValue>

--- a/pages/sequence-files/[id].js
+++ b/pages/sequence-files/[id].js
@@ -3,23 +3,24 @@ import PropTypes from "prop-types";
 // components
 import Attribution from "../../components/attribution";
 import Breadcrumbs from "../../components/breadcrumbs";
+import { FileDataItems } from "../../components/common-data-items";
 import {
   DataArea,
+  DataAreaTitle,
   DataItemLabel,
   DataItemValue,
   DataPanel,
 } from "../../components/data-area";
+import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
 import PagePreamble from "../../components/page-preamble";
 // lib
+import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import { DataAreaTitle } from "../../components/data-area";
-import DocumentTable from "../../components/document-table";
-import { FileDataItems } from "../../components/common-data-items";
-import buildAttribution from "../../lib/attribution";
+import { truthyOrZero } from "../../lib/general";
 import { isJsonFormat } from "../../lib/query-utils";
 
 export default function SequenceFile({
@@ -45,13 +46,13 @@ export default function SequenceFile({
               >
                 <DataItemLabel>Sequencing Run</DataItemLabel>
                 <DataItemValue>{sequenceFile.sequencing_run}</DataItemValue>
-                {sequenceFile.read_count && (
+                {truthyOrZero(sequenceFile.read_count) && (
                   <>
                     <DataItemLabel>Read Count</DataItemLabel>
                     <DataItemValue>{sequenceFile.read_count}</DataItemValue>
                   </>
                 )}
-                {sequenceFile.mean_read_length && (
+                {truthyOrZero(sequenceFile.mean_read_length) && (
                   <>
                     <DataItemLabel>Read Length</DataItemLabel>
                     <DataItemValue>

--- a/pages/treatments/[uuid].js
+++ b/pages/treatments/[uuid].js
@@ -19,6 +19,7 @@ import buildBreadcrumbs from "../../lib/breadcrumbs";
 import { UC } from "../../lib/constants";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
+import { truthyOrZero } from "../../lib/general";
 import { isJsonFormat } from "../../lib/query-utils";
 
 export default function Treatment({ treatment, documents, isJson }) {
@@ -38,7 +39,7 @@ export default function Treatment({ treatment, documents, isJson }) {
               <DataItemValue>
                 {treatment.amount} {treatment.amount_units}
               </DataItemValue>
-              {treatment.duration && (
+              {truthyOrZero(treatment.duration) && (
                 <>
                   <DataItemLabel>Duration</DataItemLabel>
                   <DataItemValue>
@@ -47,7 +48,7 @@ export default function Treatment({ treatment, documents, isJson }) {
                   </DataItemValue>
                 </>
               )}
-              {treatment.pH && (
+              {truthyOrZero(treatment.pH) && (
                 <>
                   <DataItemLabel>pH</DataItemLabel>
                   <DataItemValue>{treatment.pH}</DataItemValue>
@@ -59,7 +60,7 @@ export default function Treatment({ treatment, documents, isJson }) {
                   <DataItemValue>{treatment.purpose}</DataItemValue>
                 </>
               )}
-              {treatment.post_treatment_time && (
+              {truthyOrZero(treatment.post_treatment_time) && (
                 <>
                   <DataItemLabel>Post-Treatment Time</DataItemLabel>
                   <DataItemValue>
@@ -69,7 +70,7 @@ export default function Treatment({ treatment, documents, isJson }) {
                   </DataItemValue>
                 </>
               )}
-              {treatment.temperature && (
+              {truthyOrZero(treatment.temperature) && (
                 <>
                   <DataItemLabel>Temperature</DataItemLabel>
                   <DataItemValue>


### PR DESCRIPTION
We’ve been using `{numericProperty && <Display>}` for several things, but this breaks if the numeric property has the value 0. The result of this expression is the value “0” instead of nothing at all. So I made a new very minimal function (`truthyOrZero()`) we can use to check a numeric value in which 0 is a valid, displayable value.

I made this a function so we don’t have to repeat the same expression twice wherever we need it. An alternative is comparing the typeof the property with the string “untitled” but that has more complicated syntax.
