### PR TITLE
IGVF-712 Add file download links to file tables and file pages

### DIFF
--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,7 +52,6 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,6 +52,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
+            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/components/audit.js
+++ b/components/audit.js
@@ -319,9 +319,13 @@ AuditDetail.propTypes = {
  */
 export function AuditStatus({ item, auditState }) {
   const { isAuthenticated } = useAuth0();
-  const hasAudits = item.audit && Object.keys(item.audit).length > 0;
+  const itemAuditLevels = item.audit
+    ? Object.keys(item.audit).filter((level) => {
+        return isAuthenticated || publicLevels.includes(level);
+      })
+    : [];
 
-  if (hasAudits) {
+  if (itemAuditLevels.length > 0) {
     // Make an array of the human-readable audit levels for screen readers.
     const auditLevelTexts = Object.keys(item.audit).map(
       (level) => auditMap[level]?.humanReadable || "Unknown"
@@ -340,19 +344,17 @@ export function AuditStatus({ item, auditState }) {
         } audits for ${auditLevelTexts.join(", ")}`}
         data-testid="audit-status-button"
       >
-        {Object.keys(item.audit).map((level) => {
-          if (isAuthenticated || publicLevels.includes(level)) {
-            const Icon = auditMap[level]?.Icon;
-            if (Icon) {
-              return (
-                <Icon
-                  className={`h-3 w-3 ${auditMap[level].color}`}
-                  key={level}
-                />
-              );
-            }
-            return null;
+        {itemAuditLevels.map((level) => {
+          const Icon = auditMap[level]?.Icon;
+          if (Icon) {
+            return (
+              <Icon
+                className={`h-3 w-3 ${auditMap[level].color}`}
+                key={level}
+              />
+            );
           }
+          return null;
         })}
       </button>
     );

--- a/components/edit-func.js
+++ b/components/edit-func.js
@@ -155,7 +155,7 @@ export function EditLink({ item }) {
   if (isAuthenticated && itemSchema && canEdit(itemSchema)) {
     const editPath = `${removeTrailingSlash(item["@id"])}#!edit`;
     return (
-      <div className="mb-1 flex justify-end">
+      <div className="flex justify-end">
         <ButtonLink
           label="Edit"
           href={editPath}

--- a/components/file-download.js
+++ b/components/file-download.js
@@ -1,0 +1,71 @@
+// node_modules
+import { ArrowDownOnSquareIcon } from "@heroicons/react/20/solid";
+import Link from "next/link";
+import PropTypes from "prop-types";
+// lib
+import { API_URL } from "../lib/constants";
+
+/**
+ * Display a file-download link and download icon. Only files with an `upload_status` of
+ * `validated` show a download link.
+ */
+export function FileDownload({ file, className = "h-4 w-4" }) {
+  const fileName = file.href.substr(file.href.lastIndexOf("/") + 1);
+
+  return (
+    <>
+      {file.upload_status === "validated" && (
+        <a
+          aria-label={`Download file ${file.accession}`}
+          href={`${API_URL}${file.href}`}
+          download={fileName}
+          data-bypass="true"
+        >
+          <ArrowDownOnSquareIcon className={className} />
+        </a>
+      )}
+    </>
+  );
+}
+
+FileDownload.propTypes = {
+  // File to download
+  file: PropTypes.object.isRequired,
+  // Tailwind CSS classes for the download icon
+  className: PropTypes.string,
+};
+
+/**
+ * File download link for the file object page headers.
+ */
+export function FileHeaderDownload({ file }) {
+  return (
+    <div className="flex grow items-center px-1">
+      <FileDownload file={file} />
+    </div>
+  );
+}
+
+FileHeaderDownload.propTypes = {
+  // File to download
+  file: PropTypes.object.isRequired,
+};
+
+/**
+ * Display a file's accession and download link on one row.
+ */
+export function FileAccessionAndDownload({ file }) {
+  return (
+    <div>
+      <div className="flex items-center gap-1">
+        <Link href={file["@id"]}>{file.accession}</Link>
+        <FileDownload file={file} />
+      </div>
+    </div>
+  );
+}
+
+FileAccessionAndDownload.propTypes = {
+  // File to link to and download
+  file: PropTypes.object.isRequired,
+};

--- a/components/file-table.js
+++ b/components/file-table.js
@@ -1,8 +1,8 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import { DataGridContainer } from "./data-grid";
+import { FileAccessionAndDownload } from "./file-download";
 import SortableGrid from "./sortable-grid";
 import Status from "./status";
 
@@ -10,9 +10,7 @@ const filesColumns = [
   {
     id: "accession",
     title: "Accession",
-    display: ({ source }) => {
-      return <Link href={source["@id"]}>{source.accession}</Link>;
-    },
+    display: ({ source }) => <FileAccessionAndDownload file={source} />,
   },
   {
     id: "file_format",

--- a/components/json-button.js
+++ b/components/json-button.js
@@ -24,7 +24,7 @@ import { removeTrailingSlash } from "../lib/general";
 export function JsonViewLink({ item }) {
   const jsonPath = `${removeTrailingSlash(item["@id"])}?format=json`;
   return (
-    <div className="mb-1 flex justify-end">
+    <div className="flex justify-end">
       <ButtonLink
         label="Json view"
         href={jsonPath}
@@ -50,7 +50,7 @@ JsonViewLink.propTypes = {
 export function ObjectViewLink({ item }) {
   const objectPath = removeTrailingSlash(item["@id"]);
   return (
-    <div className="mb-1 flex justify-end">
+    <div className="flex justify-end">
       <ButtonLink
         label="Object view"
         href={objectPath}

--- a/components/json-display.js
+++ b/components/json-display.js
@@ -2,7 +2,6 @@
 import PropTypes from "prop-types";
 // components
 import { DataPanel } from "./data-area";
-import ObjectPageHeader from "./object-page-header";
 
 /**
  * This function will display a raw JSON view for a given object if the query is in JSON format, otherwise it will display an object view.
@@ -14,7 +13,6 @@ import ObjectPageHeader from "./object-page-header";
 export default function JsonDisplay({ item, isJsonFormat, children }) {
   return (
     <>
-      <ObjectPageHeader item={item} isJsonFormat={isJsonFormat} />
       {isJsonFormat ? (
         <DataPanel>
           <div className="border border-gray-300 bg-gray-100 text-xs dark:border-gray-800 dark:bg-gray-900">

--- a/components/object-page-header.js
+++ b/components/object-page-header.js
@@ -7,15 +7,18 @@ import { JsonViewLink, ObjectViewLink } from "./json-button";
 import QualitySection from "./quality-section";
 
 /**
- * Display the header above the data areas of an object page.
+ * Display the header above the data areas of an object page. This generally comprises controls on
+ * the left and right side of the header, but you can also insert other content between them as a
+ * child of this component.
  */
-export default function ObjectPageHeader({ item, isJsonFormat }) {
+export default function ObjectPageHeader({ item, isJsonFormat, children }) {
   const auditState = useAudit();
 
   return (
     <>
-      <div className="flex justify-between">
+      <div className="mb-1 flex justify-between">
         <QualitySection item={item} auditState={auditState} />
+        {children}
         <div className="flex justify-end gap-1">
           <EditLink item={item} />
           {isJsonFormat ? (

--- a/components/quality-section.js
+++ b/components/quality-section.js
@@ -10,7 +10,7 @@ import Status from "./status";
  */
 export default function QualitySection({ item, auditState }) {
   return (
-    <section className="mb-1 flex items-center gap-1">
+    <section className="flex items-center gap-1">
       {item.status && <Status status={item.status} />}
       <AuditStatus item={item} auditState={auditState} />
     </section>

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,9 +3,11 @@ import getConfig from "next/config";
 
 const { serverRuntimeConfig, publicRuntimeConfig } = getConfig();
 
-// igvfd data server URL
+// igvf-ui NextJS server URL
 export const SERVER_URL = publicRuntimeConfig.SERVER_URL;
+// igvfd server URL
 export const API_URL = publicRuntimeConfig.PUBLIC_BACKEND_URL;
+// Docker internal network URL
 export const BACKEND_URL = serverRuntimeConfig.BACKEND_URL;
 
 // igvf-ui version number

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@auth0/auth0-spa-js": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.0.6.tgz",
-      "integrity": "sha512-uZfYZEPi6jZCsixMQWpsaET9fUfTFDct0Bi/zR49Sw/y843WkMJyWDmt9XIae12/JKG+ehZNYYSI+/739jaa9Q=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.0.7.tgz",
+      "integrity": "sha512-iQ22AZCqOMG0q8/YPkvT4lGe2gsaopZ2kZb2cIBa7w+0hhGJhl6ANpFI6FzAKMzGRGmVocKxYdHha7lxAhbyPA=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.21.4",
@@ -846,9 +846,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.41.0.tgz",
-      "integrity": "sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.42.0.tgz",
+      "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -878,9 +878,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -1818,9 +1818,9 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.0.tgz",
-      "integrity": "sha512-TBOjqAGf0hmaqRwpii5LLkJLg7c6OMm4nHLmpsUxwk9bBHtoTC6dAHdVWdGv4TBxj2CZOZY8Xfq8WmfoVi7n4Q==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.1.tgz",
+      "integrity": "sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7"
@@ -1919,9 +1919,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.7.tgz",
-      "integrity": "sha512-ojrXpSH2XFCmHm7Jy3q44nXDyN54+EYKP2lBhJ2bqfyPj6cIUW/FZW/Csdia34NQgq7KYcAlHi5184m4X88+yw==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.8.tgz",
+      "integrity": "sha512-lTyWUNrd8ntVkqycEEplasWy2OxNlShj3zqS0LuB1ENUGis5HodmhM7DtCoUGbxj3VW/WsGA0DUhpG6XrM7gPA==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -2014,14 +2014,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.59.8",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.8.tgz",
-      "integrity": "sha512-AnR19RjJcpjoeGojmwZtCwBX/RidqDZtzcbG3xHrmz0aHHoOcbWnpDllenRDmDvsV0RQ6+tbb09/kyc+UT9Orw==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.9.tgz",
+      "integrity": "sha512-FsPkRvBtcLQ/eVK1ivDiNYBjn3TGJdXy2fhXX+rc7czWl4ARwnpArwbihSOHI2Peg9WbtGHrbThfBUkZZGTtvQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.59.8",
-        "@typescript-eslint/types": "5.59.8",
-        "@typescript-eslint/typescript-estree": "5.59.8",
+        "@typescript-eslint/scope-manager": "5.59.9",
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/typescript-estree": "5.59.9",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2041,13 +2041,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.59.8",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.8.tgz",
-      "integrity": "sha512-/w08ndCYI8gxGf+9zKf1vtx/16y8MHrZs5/tnjHhMLNSixuNcJavSX4wAiPf4aS5x41Es9YPCn44MIe4cxIlig==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.9.tgz",
+      "integrity": "sha512-8RA+E+w78z1+2dzvK/tGZ2cpGigBZ58VMEHDZtpE1v+LLjzrYGc8mMaTONSxKyEkz3IuXFM0IqYiGHlCsmlZxQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.8",
-        "@typescript-eslint/visitor-keys": "5.59.8"
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/visitor-keys": "5.59.9"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2058,9 +2058,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.59.8",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.8.tgz",
-      "integrity": "sha512-+uWuOhBTj/L6awoWIg0BlWy0u9TyFpCHrAuQ5bNfxDaZ1Ppb3mx6tUigc74LHcbHpOHuOTOJrBoAnhdHdaea1w==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.9.tgz",
+      "integrity": "sha512-uW8H5NRgTVneSVTfiCVffBb8AbwWSKg7qcA4Ot3JI3MPCJGsB4Db4BhvAODIIYE5mNj7Q+VJkK7JxmRhk2Lyjw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2071,13 +2071,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.8",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.8.tgz",
-      "integrity": "sha512-Jy/lPSDJGNow14vYu6IrW790p7HIf/SOV1Bb6lZ7NUkLc2iB2Z9elESmsaUtLw8kVqogSbtLH9tut5GCX1RLDg==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.9.tgz",
+      "integrity": "sha512-pmM0/VQ7kUhd1QyIxgS+aRvMgw+ZljB3eDb+jYyp6d2bC0mQWLzUDF+DLwCTkQ3tlNyVsvZRXjFyV0LkU/aXjA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.8",
-        "@typescript-eslint/visitor-keys": "5.59.8",
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/visitor-keys": "5.59.9",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2098,17 +2098,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.59.8",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.8.tgz",
-      "integrity": "sha512-Tr65630KysnNn9f9G7ROF3w1b5/7f6QVCJ+WK9nhIocWmx9F+TmCAcglF26Vm7z8KCTwoKcNEBZrhlklla3CKg==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.9.tgz",
+      "integrity": "sha512-1PuMYsju/38I5Ggblaeb98TOoUvjhRvLpLa1DoTOFaLWqaXl/1iQ1eGurTXgBY58NUdtfTXKP5xBq7q9NDaLKg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.59.8",
-        "@typescript-eslint/types": "5.59.8",
-        "@typescript-eslint/typescript-estree": "5.59.8",
+        "@typescript-eslint/scope-manager": "5.59.9",
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/typescript-estree": "5.59.9",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -2146,12 +2146,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.8",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.8.tgz",
-      "integrity": "sha512-pJhi2ms0x0xgloT7xYabil3SGGlojNNKjK/q6dB3Ey0uJLMjK2UDGJvHieiyJVW/7C3KI+Z4Q3pEHkm4ejA+xQ==",
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.9.tgz",
+      "integrity": "sha512-bT7s0td97KMaLwpEBckbzj/YohnvXtqbe2XgqNvTl6RJVakY5mvENOTPvw5u66nljfZxthESpDozs86U+oLY8Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.8",
+        "@typescript-eslint/types": "5.59.9",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -2972,9 +2972,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001492",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
-      "integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==",
+      "version": "1.0.30001495",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz",
+      "integrity": "sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3465,9 +3465,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.8.tgz",
+      "integrity": "sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -3838,9 +3838,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.414",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.414.tgz",
-      "integrity": "sha512-RRuCvP6ekngVh2SAJaOKT/hxqc9JAsK+Pe0hP5tGQIfonU2Zy9gMGdJ+mBdyl/vNucMG6gkXYtuM4H/1giws5w==",
+      "version": "1.4.422",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.422.tgz",
+      "integrity": "sha512-OQMid0IRbJv27BhlPiBK8CfGzjeq4ZCBSmpwNi1abyS8w17/BajOUu7hBI49ptDTBCz9NRFbORhWvt41dF7dwg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4132,16 +4132,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.41.0.tgz",
-      "integrity": "sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.42.0.tgz",
+      "integrity": "sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
         "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.41.0",
-        "@humanwhocodes/config-array": "^0.11.8",
+        "@eslint/js": "8.42.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
@@ -6611,9 +6611,9 @@
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
@@ -7262,9 +7262,9 @@
       }
     },
     "node_modules/jsdom/node_modules/tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -10016,9 +10016,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -10107,9 +10107,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -10117,7 +10117,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/pages/alignment-files/[id].js
+++ b/pages/alignment-files/[id].js
@@ -14,7 +14,9 @@ import {
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
+import { FileHeaderDownload } from "../../components/file-download";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SeparatedList from "../../components/separated-list";
 // lib
@@ -38,6 +40,9 @@ export default function AlignmentFile({
       <Breadcrumbs />
       <EditableItem item={alignmentFile}>
         <PagePreamble />
+        <ObjectPageHeader item={alignmentFile} isJsonFormat={isJson}>
+          <FileHeaderDownload file={alignmentFile} />
+        </ObjectPageHeader>
         <JsonDisplay item={alignmentFile} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -16,6 +16,7 @@ import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SeparatedList from "../../components/separated-list";
 // lib
@@ -40,6 +41,7 @@ export default function AnalysisSet({
       <Breadcrumbs />
       <EditableItem item={analysisSet}>
         <PagePreamble />
+        <ObjectPageHeader item={analysisSet} isJsonFormat={isJson} />
         <JsonDisplay item={analysisSet} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/assay-terms/[name].js
+++ b/pages/assay-terms/[name].js
@@ -11,6 +11,7 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -24,6 +25,7 @@ export default function AssayOntologyTerm({ assayOntologyTerm, isA, isJson }) {
       <Breadcrumbs />
       <EditableItem item={assayOntologyTerm}>
         <PagePreamble />
+        <ObjectPageHeader item={assayOntologyTerm} isJsonFormat={isJson} />
         <JsonDisplay item={assayOntologyTerm} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/awards/[name].js
+++ b/pages/awards/[name].js
@@ -11,6 +11,7 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -26,6 +27,7 @@ export default function Award({ award, pis, contactPi, isJson }) {
       <Breadcrumbs />
       <EditableItem item={award}>
         <PagePreamble />
+        <ObjectPageHeader item={award} isJsonFormat={isJson} />
         <JsonDisplay item={award} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/biomarkers/[id].js
+++ b/pages/biomarkers/[id].js
@@ -13,6 +13,7 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -33,6 +34,7 @@ export default function Biomarker({
       <Breadcrumbs />
       <EditableItem item={biomarker}>
         <PagePreamble />
+        <ObjectPageHeader item={biomarker} isJsonFormat={isJson} />
         <JsonDisplay item={biomarker} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/curated-sets/[id].js
+++ b/pages/curated-sets/[id].js
@@ -15,6 +15,7 @@ import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SeparatedList from "../../components/separated-list";
 // lib
@@ -39,6 +40,7 @@ export default function CuratedSet({
       <Breadcrumbs />
       <EditableItem item={curatedSet}>
         <PagePreamble />
+        <ObjectPageHeader item={curatedSet} isJsonFormat={isJson} />
         <JsonDisplay item={curatedSet} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/documents/[id].js
+++ b/pages/documents/[id].js
@@ -14,6 +14,7 @@ import {
 import DocumentAttachmentLink from "../../components/document-link";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -28,6 +29,7 @@ export default function Document({ document, attribution = null, isJson }) {
       <Breadcrumbs />
       <EditableItem item={document}>
         <PagePreamble />
+        <ObjectPageHeader item={document} isJsonFormat={isJson} />
         <JsonDisplay item={document} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/genes/[id].js
+++ b/pages/genes/[id].js
@@ -12,6 +12,7 @@ import DbxrefList from "../../components/dbxref-list";
 import ChromosomeLocations from "../../components/chromosome-locations";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import Status from "../../components/status";
 // lib
@@ -42,6 +43,7 @@ export default function Gene({ gene, isJson }) {
       <Breadcrumbs />
       <EditableItem item={gene}>
         <PagePreamble />
+        <ObjectPageHeader item={gene} isJsonFormat={isJson} />
         <JsonDisplay item={gene} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/human-genomic-variants/[uuid].js
+++ b/pages/human-genomic-variants/[uuid].js
@@ -12,6 +12,7 @@ import { EditableItem } from "../../components/edit";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -28,6 +29,7 @@ export default function HumanGenomicVariant({ variant, isJson }) {
       <Breadcrumbs />
       <EditableItem item={variant}>
         <PagePreamble pageTitle={humanGenomicVariantTitle(variant)} />
+        <ObjectPageHeader item={variant} isJsonFormat={isJson} />
         <JsonDisplay item={variant} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/in-vitro-systems/[id].js
+++ b/pages/in-vitro-systems/[id].js
@@ -16,6 +16,7 @@ import {
 import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import TreatmentTable from "../../components/treatment-table";
 // lib
@@ -46,6 +47,7 @@ export default function InVitroSystem({
       <Breadcrumbs />
       <EditableItem item={inVitroSystem}>
         <PagePreamble />
+        <ObjectPageHeader item={inVitroSystem} isJsonFormat={isJson} />
         <JsonDisplay item={inVitroSystem} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/labs/[name].js
+++ b/pages/labs/[name].js
@@ -11,6 +11,7 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SeparatedList from "../../components/separated-list";
 // lib
@@ -25,6 +26,7 @@ export default function Lab({ lab, awards = null, pi = null, isJson }) {
       <Breadcrumbs />
       <EditableItem item={lab}>
         <PagePreamble />
+        <ObjectPageHeader item={lab} isJsonFormat={isJson} />
         <JsonDisplay item={lab} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/measurement-sets/[id].js
+++ b/pages/measurement-sets/[id].js
@@ -14,7 +14,9 @@ import {
 import { DataGridContainer } from "../../components/data-grid";
 import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
+import { FileAccessionAndDownload } from "../../components/file-download";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SortableGrid from "../../components/sortable-grid";
 import Status from "../../components/status";
@@ -35,9 +37,7 @@ const filesColumns = [
   {
     id: "accession",
     title: "Accession",
-    display: ({ source }) => (
-      <Link href={source["@id"]}>{source.accession}</Link>
-    ),
+    display: ({ source }) => <FileAccessionAndDownload file={source} />,
   },
   {
     id: "file_format",
@@ -148,6 +148,7 @@ export default function MeasurementSet({
       <Breadcrumbs />
       <EditableItem item={measurementSet}>
         <PagePreamble />
+        <ObjectPageHeader item={measurementSet} isJsonFormat={isJson} />
         <JsonDisplay item={measurementSet} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/modifications/[uuid].js
+++ b/pages/modifications/[uuid].js
@@ -12,6 +12,7 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -31,6 +32,7 @@ export default function Modification({
       <Breadcrumbs />
       <EditableItem item={modification}>
         <PagePreamble />
+        <ObjectPageHeader item={modification} isJsonFormat={isJson} />
         <JsonDisplay item={modification} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/phenotype-terms/[name].js
+++ b/pages/phenotype-terms/[name].js
@@ -6,6 +6,7 @@ import { DataArea, DataPanel } from "../../components/data-area";
 import { OntologyTermDataItems } from "../../components/common-data-items";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -22,6 +23,7 @@ export default function PhenotypeOntologyTerm({
       <Breadcrumbs />
       <EditableItem item={phenotypeOntologyTerm}>
         <PagePreamble />
+        <ObjectPageHeader item={phenotypeOntologyTerm} isJsonFormat={isJson} />
         <JsonDisplay item={phenotypeOntologyTerm} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/phenotypic-features/[id].js
+++ b/pages/phenotypic-features/[id].js
@@ -12,6 +12,7 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -33,6 +34,7 @@ export default function PhenotypicFeature({
       <Breadcrumbs />
       <EditableItem item={phenotypicFeature}>
         <PagePreamble />
+        <ObjectPageHeader item={phenotypicFeature} isJsonFormat={isJson} />
         <JsonDisplay item={phenotypicFeature} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/platform-terms/[name].js
+++ b/pages/platform-terms/[name].js
@@ -6,6 +6,7 @@ import { DataArea, DataPanel } from "../../components/data-area";
 import { OntologyTermDataItems } from "../../components/common-data-items";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -19,6 +20,7 @@ export default function PlatformOntologyTerm({ platformOntologyTerm, isJson }) {
       <Breadcrumbs />
       <EditableItem item={platformOntologyTerm}>
         <PagePreamble />
+        <ObjectPageHeader item={platformOntologyTerm} isJsonFormat={isJson} />
         <JsonDisplay item={platformOntologyTerm} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/primary-cells/[uuid].js
+++ b/pages/primary-cells/[uuid].js
@@ -15,6 +15,7 @@ import BiomarkerTable from "../../components/biomarker-table";
 import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import TreatmentTable from "../../components/treatment-table";
 // lib
@@ -44,6 +45,7 @@ export default function PrimaryCell({
       <Breadcrumbs />
       <EditableItem item={primaryCell}>
         <PagePreamble />
+        <ObjectPageHeader item={primaryCell} isJsonFormat={isJson} />
         <JsonDisplay item={primaryCell} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/publications/[id].js
+++ b/pages/publications/[id].js
@@ -14,6 +14,7 @@ import DbxrefList from "../../components/dbxref-list";
 import DocumentAttachmentLink from "../../components/document-link";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -32,6 +33,7 @@ export default function Publication({
       <Breadcrumbs />
       <EditableItem item={publication}>
         <PagePreamble />
+        <ObjectPageHeader item={publication} isJsonFormat={isJson} />
         <JsonDisplay item={publication} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/reference-files/[id].js
+++ b/pages/reference-files/[id].js
@@ -14,7 +14,9 @@ import {
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
+import { FileHeaderDownload } from "../../components/file-download";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -36,6 +38,9 @@ export default function ReferenceFile({
       <Breadcrumbs />
       <EditableItem item={referenceFile}>
         <PagePreamble />
+        <ObjectPageHeader item={referenceFile} isJsonFormat={isJson}>
+          <FileHeaderDownload file={referenceFile} />
+        </ObjectPageHeader>
         <JsonDisplay item={referenceFile} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/rodent-donors/[uuid].js
+++ b/pages/rodent-donors/[uuid].js
@@ -15,6 +15,7 @@ import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
 import ExternalResources from "../../components/external-resources";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -39,6 +40,7 @@ export default function RodentDonor({
       <Breadcrumbs />
       <EditableItem item={donor}>
         <PagePreamble />
+        <ObjectPageHeader item={donor} isJsonFormat={isJson} />
         <JsonDisplay item={donor} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/sample-terms/[name].js
+++ b/pages/sample-terms/[name].js
@@ -12,6 +12,7 @@ import {
 import DbxrefList from "../../components/dbxref-list";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -25,6 +26,7 @@ export default function SampleOntologyTerm({ sampleOntologyTerm, isJson }) {
       <Breadcrumbs />
       <EditableItem item={sampleOntologyTerm}>
         <PagePreamble />
+        <ObjectPageHeader item={sampleOntologyTerm} isJsonFormat={isJson} />
         <JsonDisplay item={sampleOntologyTerm} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/sequence-files/[id].js
+++ b/pages/sequence-files/[id].js
@@ -13,7 +13,9 @@ import {
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
+import { FileHeaderDownload } from "../../components/file-download";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -36,6 +38,9 @@ export default function SequenceFile({
       <Breadcrumbs />
       <EditableItem item={sequenceFile}>
         <PagePreamble />
+        <ObjectPageHeader item={sequenceFile} isJsonFormat={isJson}>
+          <FileHeaderDownload file={sequenceFile} />
+        </ObjectPageHeader>
         <JsonDisplay item={sequenceFile} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/signal-files/[id].js
+++ b/pages/signal-files/[id].js
@@ -14,7 +14,9 @@ import {
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
+import { FileHeaderDownload } from "../../components/file-download";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SeparatedList from "../../components/separated-list";
 // lib
@@ -38,6 +40,9 @@ export default function SignalFile({
       <Breadcrumbs />
       <EditableItem item={signalFile}>
         <PagePreamble />
+        <ObjectPageHeader item={signalFile} isJsonFormat={isJson}>
+          <FileHeaderDownload file={signalFile} />
+        </ObjectPageHeader>
         <JsonDisplay item={signalFile} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/software/[id].js
+++ b/pages/software/[id].js
@@ -12,6 +12,7 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SoftwareVersionTable from "../../components/software-version-table";
 // lib
@@ -33,6 +34,7 @@ export default function Software({
       <Breadcrumbs />
       <EditableItem item={software}>
         <PagePreamble />
+        <ObjectPageHeader item={software} isJsonFormat={isJson} />
         <JsonDisplay item={software} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/sources/[id].js
+++ b/pages/sources/[id].js
@@ -9,6 +9,7 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import { EditableItem } from "../../components/edit";
 // lib
@@ -24,6 +25,7 @@ export default function Source({ source, isJson }) {
       <Breadcrumbs />
       <EditableItem item={source}>
         <PagePreamble />
+        <ObjectPageHeader item={source} isJsonFormat={isJson} />
         <JsonDisplay item={source} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/technical-samples/[uuid].js
+++ b/pages/technical-samples/[uuid].js
@@ -15,6 +15,7 @@ import {
 import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -35,6 +36,7 @@ export default function TechnicalSample({
       <Breadcrumbs />
       <EditableItem item={sample}>
         <PagePreamble />
+        <ObjectPageHeader item={sample} isJsonFormat={isJson} />
         <JsonDisplay item={sample} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/tissues/[uuid].js
+++ b/pages/tissues/[uuid].js
@@ -15,6 +15,7 @@ import { EditableItem } from "../../components/edit";
 import BiomarkerTable from "../../components/biomarker-table";
 import DocumentTable from "../../components/document-table";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import TreatmentTable from "../../components/treatment-table";
 // lib
@@ -43,6 +44,7 @@ export default function Tissue({
       <Breadcrumbs />
       <EditableItem item={tissue}>
         <PagePreamble />
+        <ObjectPageHeader item={tissue} isJsonFormat={isJson} />
         <JsonDisplay item={tissue} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/treatments/[uuid].js
+++ b/pages/treatments/[uuid].js
@@ -13,6 +13,7 @@ import {
 import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -28,6 +29,7 @@ export default function Treatment({ treatment, documents, isJson }) {
       <Breadcrumbs />
       <EditableItem item={treatment}>
         <PagePreamble />
+        <ObjectPageHeader item={treatment} isJsonFormat={isJson} />
         <JsonDisplay item={treatment} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>

--- a/pages/users/[uuid].js
+++ b/pages/users/[uuid].js
@@ -12,6 +12,7 @@ import {
 import { EditableItem } from "../../components/edit";
 import NoContent from "../../components/no-content";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -25,6 +26,7 @@ export default function User({ user, lab = null, isJson }) {
       <Breadcrumbs />
       <EditableItem item={user}>
         <PagePreamble />
+        <ObjectPageHeader item={user} isJsonFormat={isJson} />
         <JsonDisplay item={user} isJsonFormat={isJson}>
           {user.status || user.job_title || lab || user.email ? (
             <DataPanel>

--- a/pages/whole-organisms/[id].js
+++ b/pages/whole-organisms/[id].js
@@ -9,6 +9,7 @@ import BiomarkerTable from "../../components/biomarker-table";
 import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import TreatmentTable from "../../components/treatment-table";
 // lib
@@ -37,6 +38,7 @@ export default function WholeOrganism({
       <Breadcrumbs />
       <EditableItem item={sample}>
         <PagePreamble />
+        <ObjectPageHeader item={sample} isJsonFormat={isJson} />
         <JsonDisplay item={sample} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>


### PR DESCRIPTION
* I moved `<ObjectPageHeader>` out of `<JsonDisplay>` so that I can alter it for specific pages — file pages in this case. This means each page needs to use `<ObjectPageHeader>`, causing most of the file changes in this branch.
* In addition, `<ObjectPageHeader>` now takes optional children. I use that to add a file-download button to file pages. Other pages don’t pass children to `<ObjectPageHeader>`.
* I noticed a bug with audits when you haven’t logged in and the only audits are INTERNAL_ACTION. I now filter out INTERNAL_ACTION for logged-out users _before_ determining whether to display the audit trigger or not.