### PR TITLE
IGVF-754 Add links to search and report pages for each schema

### DIFF
--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,7 +52,6 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,6 +52,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
+            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/components/__tests__/schema-icon.test.js
+++ b/components/__tests__/schema-icon.test.js
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import SchemaIcon from "../schema-icon";
+
+describe("Test the SchemaIcon component", () => {
+  it("should render a default icon for an unknown schema type", () => {
+    render(<SchemaIcon type="Unknown" />);
+    expect(screen.getByTestId("icon-splat")).toBeInTheDocument();
+  });
+
+  it("should render a default icon for an empty schema type", () => {
+    render(<SchemaIcon type="" />);
+    expect(screen.getByTestId("icon-splat")).toBeInTheDocument();
+  });
+
+  it("should render a default icon for a null schema type", () => {
+    render(<SchemaIcon type={null} />);
+    expect(screen.getByTestId("icon-splat")).toBeInTheDocument();
+  });
+
+  it("should render a default icon for defined schema type", () => {
+    render(<SchemaIcon type="Award" />);
+    expect(screen.getByTestId("icon-award")).toBeInTheDocument();
+  });
+});

--- a/components/schema-icon.js
+++ b/components/schema-icon.js
@@ -1,0 +1,58 @@
+// node_modules
+import {
+  BeakerIcon,
+  BookmarkIcon,
+  CircleStackIcon,
+  DocumentIcon,
+  DocumentTextIcon,
+  InformationCircleIcon,
+  PaperClipIcon,
+  PencilSquareIcon,
+  RectangleGroupIcon,
+  SparklesIcon,
+  TagIcon,
+  UserGroupIcon,
+} from "@heroicons/react/20/solid";
+import PropTypes from "prop-types";
+// components
+import Icon from "./icon";
+
+/**
+ * Maps the `@type` for an individual schema to an icon component. For any `@type` without an icon,
+ * just don't include that `@type` in this map so that a default icon gets used.
+ */
+const schemaIconMap = {
+  Award: Icon.Award,
+  Biomarker: BookmarkIcon,
+  Document: PaperClipIcon,
+  Donor: Icon.Donor,
+  File: DocumentTextIcon,
+  FileSet: Icon.FileSet,
+  Gene: Icon.Gene,
+  Lab: BeakerIcon,
+  Modification: RectangleGroupIcon,
+  OntologyTerm: TagIcon,
+  Page: DocumentIcon,
+  PhenotypicFeature: SparklesIcon,
+  Publication: PencilSquareIcon,
+  Sample: Icon.Sample,
+  Software: CircleStackIcon,
+  Source: InformationCircleIcon,
+  Treatment: Icon.Treatment,
+  User: UserGroupIcon,
+};
+
+/**
+ * Displays an icon for the given schema @type. Schema types without an icon use a default icon.
+ */
+export default function SchemaIcon({ type, className = "w-4 h-4" }) {
+  const SingleSchemaIcon = schemaIconMap[type] || Icon.Splat;
+  return <SingleSchemaIcon className={className} />;
+}
+
+SchemaIcon.propTypes = {
+  // @type of the schema whose icon to display
+  type: PropTypes.string.isRequired,
+  // Additional Tailwind CSS classes to apply to the icon
+  className: PropTypes.string,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1403,23 +1403,23 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@next/env": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.4.tgz",
-      "integrity": "sha512-q/y7VZj/9YpgzDe64Zi6rY1xPizx80JjlU2BTevlajtaE3w1LqweH1gGgxou2N7hdFosXHjGrI4OUvtFXXhGLg=="
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.5.tgz",
+      "integrity": "sha512-SG/gKH6eij4vwQy87b/3mbpQ1X3x2vUdnpwq6/qL2IQWjtq58EY/UuNAp9CoEZoC9sI4L9AD1r+73Z9r4d3uug=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.4.tgz",
-      "integrity": "sha512-5jnh7q6I15efnjR/rR+/TGTc9hn53g3JTbEjAMjmeQiExKqEUgIXqrHI5zlTNlNyzCPkBB860/ctxXheZaF2Vw==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.5.tgz",
+      "integrity": "sha512-/xD/kyJhXmBZq+0xGKOdjL22c9/4i3mBAXaU9aOGEHTXqqFeOz8scJbScWF13aMqigeoFCsDqngIB2MIatcn4g==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.4.tgz",
-      "integrity": "sha512-xfjgXvp4KalNUKZMHmsFxr1Ug+aGmmO6NWP0uoh4G3WFqP/mJ1xxfww0gMOeMeSq/Jyr5k7DvoZ2Pv+XOITTtw==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.5.tgz",
+      "integrity": "sha512-XvTzi2ASUN5bECFIAAcBiSoDb0xsq+KLj4F0bof4d4rdc+FgOqLvseGQaOXwVi1TIh5bHa7o4b6droSJMO5+2g==",
       "cpu": [
         "arm64"
       ],
@@ -1432,9 +1432,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.4.tgz",
-      "integrity": "sha512-ZY9Ti1hkIwJsxGus3nlubIkvYyB0gNOYxKrfsOrLEqD0I2iCX8D7w8v6QQZ2H+dDl6UT29oeEUdDUNGk4UEpfg==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.5.tgz",
+      "integrity": "sha512-NQdqal/VKAqlJTuzhjZmNtdo8QSqwmfO7b2xJSAengTEVxQvsH76oGEzQeIv8Ci4NP6DysAFtFrJq++TmIxcUA==",
       "cpu": [
         "x64"
       ],
@@ -1447,9 +1447,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.4.tgz",
-      "integrity": "sha512-+KZnDeMShYkpkqAvGCEDeqYTRADJXc6SY1jWXz+Uo6qWQO/Jd9CoyhTJwRSxvQA16MoYzvILkGaDqirkRNctyA==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.5.tgz",
+      "integrity": "sha512-nB8TjtpJCXtzIFjYOMbnQu68ajkA8QK58TreHjTGojSQjsF0StDqo5zFHglVVVHrd8d3N/+EjC18yFNSWnd/ZA==",
       "cpu": [
         "arm64"
       ],
@@ -1462,9 +1462,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.4.tgz",
-      "integrity": "sha512-evC1twrny2XDT4uOftoubZvW3EG0zs0ZxMwEtu/dDGVRO5n5pT48S8qqEIBGBUZYu/Xx4zzpOkIxx1vpWdE+9A==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.5.tgz",
+      "integrity": "sha512-W126XUW599OV3giSH9Co40VpT8VAOT47xONVHXZaYEpeca0qEevjj6WUr5IJu/8u+XGWm5xI1S0DYWjR6W+olw==",
       "cpu": [
         "arm64"
       ],
@@ -1477,9 +1477,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.4.tgz",
-      "integrity": "sha512-PX706XcCHr2FfkyhP2lpf+pX/tUvq6/ke7JYnnr0ykNdEMo+sb7cC/o91gnURh4sPYSiZJhsF2gbIqg9rciOHQ==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.5.tgz",
+      "integrity": "sha512-ZbPLO/oztQdtjGmWvGhRmtkZ6j9kQqg65kiO7F7Ijj7ojTtu3hh/vY+XRsHa/4Cse6HgyJ8XGZJMGoLb8ecQfQ==",
       "cpu": [
         "x64"
       ],
@@ -1492,9 +1492,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.4.tgz",
-      "integrity": "sha512-TKUUx3Ftd95JlHV6XagEnqpT204Y+IsEa3awaYIjayn0MOGjgKZMZibqarK3B1FsMSPaieJf2FEAcu9z0yT5aA==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.5.tgz",
+      "integrity": "sha512-f+/h8KMNixVUoRB+2vza8I+jsthJ4KcvopGUsDIUHe7Q4t+m8nKwGFBeyNu9qNIenYK5g5QYEsSwYFEqZylrTQ==",
       "cpu": [
         "x64"
       ],
@@ -1507,9 +1507,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.4.tgz",
-      "integrity": "sha512-FP8AadgSq4+HPtim7WBkCMGbhr5vh9FePXiWx9+YOdjwdQocwoCK5ZVC3OW8oh3TWth6iJ0AXJ/yQ1q1cwSZ3A==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.5.tgz",
+      "integrity": "sha512-dvtPQZ5+J+zUE1uq7gP853Oj63e+n0T1ydZ/yRdVh7d8zW9ZFuC9fFrg3MqP1cv1NPPur8rrTqDKN2mRBkSSBw==",
       "cpu": [
         "arm64"
       ],
@@ -1522,9 +1522,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.4.tgz",
-      "integrity": "sha512-3WekVmtuA2MCdcAOrgrI+PuFiFURtSyyrN1I3UPtS0ckR2HtLqyqmS334Eulf15g1/bdwMteePdK363X/Y9JMg==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.5.tgz",
+      "integrity": "sha512-gK9zwGe25x31S4AjPy3Bf2niQvHIAbmwgkzmqWG3OmD4K2Z/Dh2ju4vuyzPzIt0pwQe4B520meP9NizTBmVWSg==",
       "cpu": [
         "ia32"
       ],
@@ -1537,9 +1537,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.4.tgz",
-      "integrity": "sha512-AHRITu/CrlQ+qzoqQtEMfaTu7GHaQ6bziQln/pVWpOYC1wU+Mq6VQQFlsDtMCnDztPZtppAXdvvbNS7pcfRzlw==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.5.tgz",
+      "integrity": "sha512-iyNQVc7eGehrik9RJt9xGcnO6b/pi8C7GCfg8RGenx1IlalEKbYRgBJloF7DQzwlrV47E9bQl8swT+JawaNcKA==",
       "cpu": [
         "x64"
       ],
@@ -1625,9 +1625,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.2.0.tgz",
-      "integrity": "sha512-OPwQlEdg40HAj5KNF8WW6q2KG4Z+cBCZb3m4ninfTZKaBmbIJodviQsDBoYMPHkOyJJMHnOJo5j2+LKDOhOACg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.1.0.tgz",
+      "integrity": "sha512-w1qd368vtrwttm1PRJWPW1QHlbmHrVDGs1eBH/jZvRPUFS4MNXV9Q33EQdjOdeAxZ7O8+3wM7zxztm2nfUSyKw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -1901,9 +1901,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.48.tgz",
-      "integrity": "sha512-iL0PIMwejpmuVHgfibHpfDwOdsbmB50wr21X71VnF5d7SsBF7WK+ZvP/SCcFm7Iwb9iiYSap9rlrdhToNAWdxg==",
+      "version": "14.18.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.50.tgz",
+      "integrity": "sha512-DdJP83r2Zp5x32la3jEzjIlB85+2gMPUHP1xFL2xFORzbJ94sNwh4b6ZBaF6EN/7BTII6mba3yakqfLEnt5eZg==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -1919,9 +1919,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.9",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.9.tgz",
-      "integrity": "sha512-pL3JAesUkF7PEQGxh5XOwdXGV907te6m1/Qe1ERJLgomojS6Ne790QiA7GUl434JEkFA2aAaB6qJ5z4e1zJn/w==",
+      "version": "18.2.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.11.tgz",
+      "integrity": "sha512-+hsJr9hmwyDecSMQAmX7drgbDpyE+EgSF6t7+5QEBAn1tQK7kl1vWZ4iRf6SjQ8lk7dyEULxUmZOIpN0W5baZA==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -2168,9 +2168,9 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
     },
     "node_modules/ace-builds": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.22.0.tgz",
-      "integrity": "sha512-7IlgBtb/A1qljFLB9Xz+Cuv3vILYHLpxE+9gpujoCzI1G0RpCPc1TKzoCbJ+IWIWtdtbJ0BdXKg3AsO3ZUJosw=="
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.22.1.tgz",
+      "integrity": "sha512-o5RGTPBIiRxguWNors3pT6KuLqj0a2NvNLoqir7/2LLiFm34PJV3BMq4sl9kjPayo4+lmd99m6zAq+XPdhyHQA=="
     },
     "node_modules/acorn": {
       "version": "8.8.2",
@@ -2972,9 +2972,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001495",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz",
-      "integrity": "sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg==",
+      "version": "1.0.30001502",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz",
+      "integrity": "sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3080,9 +3080,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
-      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
     },
     "node_modules/clean-stack": {
@@ -3838,9 +3838,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.425",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.425.tgz",
-      "integrity": "sha512-wv1NufHxu11zfDbY4fglYQApMswleE9FL/DSeyOyauVXDZ+Kco96JK/tPfBUaDqfRarYp2WH2hJ/5UnVywp9Jg==",
+      "version": "1.4.427",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.427.tgz",
+      "integrity": "sha512-HK3r9l+Jm8dYAm1ctXEWIC+hV60zfcjS9UA5BDlYvnI5S7PU/yytjpvSrTNrSSRRkuu3tDyZhdkwIczh+0DWaw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4188,12 +4188,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.4.4.tgz",
-      "integrity": "sha512-z/PMbm6L0iC/fwISULxe8IVy4DtNqZk2wQY711o35klenq70O6ns82A8yuMVCFjHC0DIyB2lyugesRtuk9u8dQ==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.4.5.tgz",
+      "integrity": "sha512-7qgJmRp9ClRzPgkzEz7ahK+Rasiv4k2aU3eqkkORzseNUGdtImZVYomcXUhUheHwkxzdN2p//nbIA7zJrCxsCg==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "13.4.4",
+        "@next/eslint-plugin-next": "13.4.5",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.42.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -5217,6 +5217,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
     "node_modules/global-dirs": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
@@ -5297,8 +5302,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -7693,9 +7697,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-5.0.5.tgz",
-      "integrity": "sha512-auTmKJTBwZM/GLVFOhmkY7pL8v/0DxiDaXRC2kEyajcNJ0XXn9NphLD0106dbWrbPwcyD4Y0Dus16OkCzUMkfg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.0.tgz",
+      "integrity": "sha512-z3/nBe7aTI8JDszlYLk7dDVNpngjw0o1ZJtrA9kIfkkHcIF+xH7mO23aISl4WxP83elU+MFROgahqdpd05lMEQ==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7846,16 +7850,17 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.4.4.tgz",
-      "integrity": "sha512-C5S0ysM0Ily9McL4Jb48nOQHT1BukOWI59uC3X/xCMlYIh9rJZCv7nzG92J6e1cOBqQbKovlpgvHWFmz4eKKEA==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.5.tgz",
+      "integrity": "sha512-pfNsRLVM9e5Y1/z02VakJRfD6hMQkr24FaN2xc9GbcZDBxoOgiNAViSg5cXwlWCoMhtm4U315D7XYhgOr96Q3Q==",
       "dependencies": {
-        "@next/env": "13.4.4",
+        "@next/env": "13.4.5",
         "@swc/helpers": "0.5.1",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
         "styled-jsx": "5.1.1",
+        "watchpack": "2.4.0",
         "zod": "3.21.4"
       },
       "bin": {
@@ -7865,15 +7870,15 @@
         "node": ">=16.8.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.4.4",
-        "@next/swc-darwin-x64": "13.4.4",
-        "@next/swc-linux-arm64-gnu": "13.4.4",
-        "@next/swc-linux-arm64-musl": "13.4.4",
-        "@next/swc-linux-x64-gnu": "13.4.4",
-        "@next/swc-linux-x64-musl": "13.4.4",
-        "@next/swc-win32-arm64-msvc": "13.4.4",
-        "@next/swc-win32-ia32-msvc": "13.4.4",
-        "@next/swc-win32-x64-msvc": "13.4.4"
+        "@next/swc-darwin-arm64": "13.4.5",
+        "@next/swc-darwin-x64": "13.4.5",
+        "@next/swc-linux-arm64-gnu": "13.4.5",
+        "@next/swc-linux-arm64-musl": "13.4.5",
+        "@next/swc-linux-x64-gnu": "13.4.5",
+        "@next/swc-linux-x64-musl": "13.4.5",
+        "@next/swc-win32-arm64-msvc": "13.4.5",
+        "@next/swc-win32-ia32-msvc": "13.4.5",
+        "@next/swc-win32-x64-msvc": "13.4.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -10281,6 +10286,18 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -11595,71 +11612,71 @@
       }
     },
     "@next/env": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.4.tgz",
-      "integrity": "sha512-q/y7VZj/9YpgzDe64Zi6rY1xPizx80JjlU2BTevlajtaE3w1LqweH1gGgxou2N7hdFosXHjGrI4OUvtFXXhGLg=="
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.5.tgz",
+      "integrity": "sha512-SG/gKH6eij4vwQy87b/3mbpQ1X3x2vUdnpwq6/qL2IQWjtq58EY/UuNAp9CoEZoC9sI4L9AD1r+73Z9r4d3uug=="
     },
     "@next/eslint-plugin-next": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.4.tgz",
-      "integrity": "sha512-5jnh7q6I15efnjR/rR+/TGTc9hn53g3JTbEjAMjmeQiExKqEUgIXqrHI5zlTNlNyzCPkBB860/ctxXheZaF2Vw==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.5.tgz",
+      "integrity": "sha512-/xD/kyJhXmBZq+0xGKOdjL22c9/4i3mBAXaU9aOGEHTXqqFeOz8scJbScWF13aMqigeoFCsDqngIB2MIatcn4g==",
       "dev": true,
       "requires": {
         "glob": "7.1.7"
       }
     },
     "@next/swc-darwin-arm64": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.4.tgz",
-      "integrity": "sha512-xfjgXvp4KalNUKZMHmsFxr1Ug+aGmmO6NWP0uoh4G3WFqP/mJ1xxfww0gMOeMeSq/Jyr5k7DvoZ2Pv+XOITTtw==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.5.tgz",
+      "integrity": "sha512-XvTzi2ASUN5bECFIAAcBiSoDb0xsq+KLj4F0bof4d4rdc+FgOqLvseGQaOXwVi1TIh5bHa7o4b6droSJMO5+2g==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.4.tgz",
-      "integrity": "sha512-ZY9Ti1hkIwJsxGus3nlubIkvYyB0gNOYxKrfsOrLEqD0I2iCX8D7w8v6QQZ2H+dDl6UT29oeEUdDUNGk4UEpfg==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.5.tgz",
+      "integrity": "sha512-NQdqal/VKAqlJTuzhjZmNtdo8QSqwmfO7b2xJSAengTEVxQvsH76oGEzQeIv8Ci4NP6DysAFtFrJq++TmIxcUA==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.4.tgz",
-      "integrity": "sha512-+KZnDeMShYkpkqAvGCEDeqYTRADJXc6SY1jWXz+Uo6qWQO/Jd9CoyhTJwRSxvQA16MoYzvILkGaDqirkRNctyA==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.5.tgz",
+      "integrity": "sha512-nB8TjtpJCXtzIFjYOMbnQu68ajkA8QK58TreHjTGojSQjsF0StDqo5zFHglVVVHrd8d3N/+EjC18yFNSWnd/ZA==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.4.tgz",
-      "integrity": "sha512-evC1twrny2XDT4uOftoubZvW3EG0zs0ZxMwEtu/dDGVRO5n5pT48S8qqEIBGBUZYu/Xx4zzpOkIxx1vpWdE+9A==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.5.tgz",
+      "integrity": "sha512-W126XUW599OV3giSH9Co40VpT8VAOT47xONVHXZaYEpeca0qEevjj6WUr5IJu/8u+XGWm5xI1S0DYWjR6W+olw==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.4.tgz",
-      "integrity": "sha512-PX706XcCHr2FfkyhP2lpf+pX/tUvq6/ke7JYnnr0ykNdEMo+sb7cC/o91gnURh4sPYSiZJhsF2gbIqg9rciOHQ==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.5.tgz",
+      "integrity": "sha512-ZbPLO/oztQdtjGmWvGhRmtkZ6j9kQqg65kiO7F7Ijj7ojTtu3hh/vY+XRsHa/4Cse6HgyJ8XGZJMGoLb8ecQfQ==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.4.tgz",
-      "integrity": "sha512-TKUUx3Ftd95JlHV6XagEnqpT204Y+IsEa3awaYIjayn0MOGjgKZMZibqarK3B1FsMSPaieJf2FEAcu9z0yT5aA==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.5.tgz",
+      "integrity": "sha512-f+/h8KMNixVUoRB+2vza8I+jsthJ4KcvopGUsDIUHe7Q4t+m8nKwGFBeyNu9qNIenYK5g5QYEsSwYFEqZylrTQ==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.4.tgz",
-      "integrity": "sha512-FP8AadgSq4+HPtim7WBkCMGbhr5vh9FePXiWx9+YOdjwdQocwoCK5ZVC3OW8oh3TWth6iJ0AXJ/yQ1q1cwSZ3A==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.5.tgz",
+      "integrity": "sha512-dvtPQZ5+J+zUE1uq7gP853Oj63e+n0T1ydZ/yRdVh7d8zW9ZFuC9fFrg3MqP1cv1NPPur8rrTqDKN2mRBkSSBw==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.4.tgz",
-      "integrity": "sha512-3WekVmtuA2MCdcAOrgrI+PuFiFURtSyyrN1I3UPtS0ckR2HtLqyqmS334Eulf15g1/bdwMteePdK363X/Y9JMg==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.5.tgz",
+      "integrity": "sha512-gK9zwGe25x31S4AjPy3Bf2niQvHIAbmwgkzmqWG3OmD4K2Z/Dh2ju4vuyzPzIt0pwQe4B520meP9NizTBmVWSg==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.4.tgz",
-      "integrity": "sha512-AHRITu/CrlQ+qzoqQtEMfaTu7GHaQ6bziQln/pVWpOYC1wU+Mq6VQQFlsDtMCnDztPZtppAXdvvbNS7pcfRzlw==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.5.tgz",
+      "integrity": "sha512-iyNQVc7eGehrik9RJt9xGcnO6b/pi8C7GCfg8RGenx1IlalEKbYRgBJloF7DQzwlrV47E9bQl8swT+JawaNcKA==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -11721,9 +11738,9 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.2.0.tgz",
-      "integrity": "sha512-OPwQlEdg40HAj5KNF8WW6q2KG4Z+cBCZb3m4ninfTZKaBmbIJodviQsDBoYMPHkOyJJMHnOJo5j2+LKDOhOACg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.1.0.tgz",
+      "integrity": "sha512-w1qd368vtrwttm1PRJWPW1QHlbmHrVDGs1eBH/jZvRPUFS4MNXV9Q33EQdjOdeAxZ7O8+3wM7zxztm2nfUSyKw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^3.0.0"
@@ -11963,9 +11980,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.48.tgz",
-      "integrity": "sha512-iL0PIMwejpmuVHgfibHpfDwOdsbmB50wr21X71VnF5d7SsBF7WK+ZvP/SCcFm7Iwb9iiYSap9rlrdhToNAWdxg==",
+      "version": "14.18.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.50.tgz",
+      "integrity": "sha512-DdJP83r2Zp5x32la3jEzjIlB85+2gMPUHP1xFL2xFORzbJ94sNwh4b6ZBaF6EN/7BTII6mba3yakqfLEnt5eZg==",
       "dev": true
     },
     "@types/prettier": {
@@ -11981,9 +11998,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.2.9",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.9.tgz",
-      "integrity": "sha512-pL3JAesUkF7PEQGxh5XOwdXGV907te6m1/Qe1ERJLgomojS6Ne790QiA7GUl434JEkFA2aAaB6qJ5z4e1zJn/w==",
+      "version": "18.2.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.11.tgz",
+      "integrity": "sha512-+hsJr9hmwyDecSMQAmX7drgbDpyE+EgSF6t7+5QEBAn1tQK7kl1vWZ4iRf6SjQ8lk7dyEULxUmZOIpN0W5baZA==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -12168,9 +12185,9 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
     },
     "ace-builds": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.22.0.tgz",
-      "integrity": "sha512-7IlgBtb/A1qljFLB9Xz+Cuv3vILYHLpxE+9gpujoCzI1G0RpCPc1TKzoCbJ+IWIWtdtbJ0BdXKg3AsO3ZUJosw=="
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.22.1.tgz",
+      "integrity": "sha512-o5RGTPBIiRxguWNors3pT6KuLqj0a2NvNLoqir7/2LLiFm34PJV3BMq4sl9kjPayo4+lmd99m6zAq+XPdhyHQA=="
     },
     "acorn": {
       "version": "8.8.2",
@@ -12736,9 +12753,9 @@
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001495",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz",
-      "integrity": "sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg=="
+      "version": "1.0.30001502",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz",
+      "integrity": "sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -12800,9 +12817,9 @@
       "dev": true
     },
     "cjs-module-lexer": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
-      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
     },
     "clean-stack": {
@@ -13377,9 +13394,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.425",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.425.tgz",
-      "integrity": "sha512-wv1NufHxu11zfDbY4fglYQApMswleE9FL/DSeyOyauVXDZ+Kco96JK/tPfBUaDqfRarYp2WH2hJ/5UnVywp9Jg==",
+      "version": "1.4.427",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.427.tgz",
+      "integrity": "sha512-HK3r9l+Jm8dYAm1ctXEWIC+hV60zfcjS9UA5BDlYvnI5S7PU/yytjpvSrTNrSSRRkuu3tDyZhdkwIczh+0DWaw==",
       "dev": true
     },
     "emittery": {
@@ -13681,12 +13698,12 @@
       }
     },
     "eslint-config-next": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.4.4.tgz",
-      "integrity": "sha512-z/PMbm6L0iC/fwISULxe8IVy4DtNqZk2wQY711o35klenq70O6ns82A8yuMVCFjHC0DIyB2lyugesRtuk9u8dQ==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.4.5.tgz",
+      "integrity": "sha512-7qgJmRp9ClRzPgkzEz7ahK+Rasiv4k2aU3eqkkORzseNUGdtImZVYomcXUhUheHwkxzdN2p//nbIA7zJrCxsCg==",
       "dev": true,
       "requires": {
-        "@next/eslint-plugin-next": "13.4.4",
+        "@next/eslint-plugin-next": "13.4.5",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.42.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -14415,6 +14432,11 @@
         "is-glob": "^4.0.3"
       }
     },
+    "glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
     "global-dirs": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
@@ -14468,8 +14490,7 @@
     "graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "graphemer": {
       "version": "1.4.0",
@@ -16232,9 +16253,9 @@
       }
     },
     "marked": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-5.0.5.tgz",
-      "integrity": "sha512-auTmKJTBwZM/GLVFOhmkY7pL8v/0DxiDaXRC2kEyajcNJ0XXn9NphLD0106dbWrbPwcyD4Y0Dus16OkCzUMkfg=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.0.tgz",
+      "integrity": "sha512-z3/nBe7aTI8JDszlYLk7dDVNpngjw0o1ZJtrA9kIfkkHcIF+xH7mO23aISl4WxP83elU+MFROgahqdpd05lMEQ=="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -16334,25 +16355,26 @@
       "dev": true
     },
     "next": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.4.4.tgz",
-      "integrity": "sha512-C5S0ysM0Ily9McL4Jb48nOQHT1BukOWI59uC3X/xCMlYIh9rJZCv7nzG92J6e1cOBqQbKovlpgvHWFmz4eKKEA==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.5.tgz",
+      "integrity": "sha512-pfNsRLVM9e5Y1/z02VakJRfD6hMQkr24FaN2xc9GbcZDBxoOgiNAViSg5cXwlWCoMhtm4U315D7XYhgOr96Q3Q==",
       "requires": {
-        "@next/env": "13.4.4",
-        "@next/swc-darwin-arm64": "13.4.4",
-        "@next/swc-darwin-x64": "13.4.4",
-        "@next/swc-linux-arm64-gnu": "13.4.4",
-        "@next/swc-linux-arm64-musl": "13.4.4",
-        "@next/swc-linux-x64-gnu": "13.4.4",
-        "@next/swc-linux-x64-musl": "13.4.4",
-        "@next/swc-win32-arm64-msvc": "13.4.4",
-        "@next/swc-win32-ia32-msvc": "13.4.4",
-        "@next/swc-win32-x64-msvc": "13.4.4",
+        "@next/env": "13.4.5",
+        "@next/swc-darwin-arm64": "13.4.5",
+        "@next/swc-darwin-x64": "13.4.5",
+        "@next/swc-linux-arm64-gnu": "13.4.5",
+        "@next/swc-linux-arm64-musl": "13.4.5",
+        "@next/swc-linux-x64-gnu": "13.4.5",
+        "@next/swc-linux-x64-musl": "13.4.5",
+        "@next/swc-win32-arm64-msvc": "13.4.5",
+        "@next/swc-win32-ia32-msvc": "13.4.5",
+        "@next/swc-win32-x64-msvc": "13.4.5",
         "@swc/helpers": "0.5.1",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
         "styled-jsx": "5.1.1",
+        "watchpack": "2.4.0",
         "zod": "3.21.4"
       },
       "dependencies": {
@@ -18029,6 +18051,15 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
+      }
+    },
+    "watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "requires": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
       }
     },
     "webidl-conversions": {

--- a/pages/profiles/index.js
+++ b/pages/profiles/index.js
@@ -1,10 +1,13 @@
 // node_modules
+import { Bars4Icon, TableCellsIcon } from "@heroicons/react/20/solid";
 import Link from "next/link";
 import PropTypes from "prop-types";
 // components
-import Breadcrumbs from "../../components/breadcrumbs";
 import { AddLink } from "../../components/add";
+import Breadcrumbs from "../../components/breadcrumbs";
+import { AttachedButtons, ButtonLink } from "../../components/form-elements";
 import PagePreamble from "../../components/page-preamble";
+import SchemaIcon from "../../components/schema-icon";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
@@ -27,6 +30,41 @@ function isDisplayableType(objectType, schemas, tree) {
 }
 
 /**
+ * Displays links to the search-list and report pages for the given schema object type.
+ */
+function SearchAndReportType({ type, title }) {
+  return (
+    <AttachedButtons>
+      <ButtonLink
+        href={`/search?type=${type}`}
+        label={`List view of all ${title} objects`}
+        type="secondary"
+        size="sm"
+        hasIconOnly
+      >
+        <Bars4Icon />
+      </ButtonLink>
+      <ButtonLink
+        href={`/report?type=${type}`}
+        label={`Report view of all ${title} objects`}
+        type="secondary"
+        size="sm"
+        hasIconOnly
+      >
+        <TableCellsIcon />
+      </ButtonLink>
+    </AttachedButtons>
+  );
+}
+
+SearchAndReportType.propTypes = {
+  // @type to search for
+  type: PropTypes.string.isRequired,
+  // Human-readable title for the schema
+  title: PropTypes.string.isRequired,
+};
+
+/**
  * Displays a schema element and its children. This component uses recursion, so every element at
  * different times exists as a child and a parent -- possibly a parent with no children.
  */
@@ -39,19 +77,27 @@ function SubTree({ tree, objectType, schemas, collectionTitles }) {
 
   return (
     <div className="my-1">
-      {schema ? (
-        <div
-          className="flex gap-1"
-          data-testid={`schema-${toShishkebabCase(title)}`}
-        >
-          <Link href={`${schema.$id.replace(".json", "")}`} className="block">
-            {title}
-          </Link>
-          <AddLink schema={schema} label={`Add ${schema.title}`} />
-        </div>
-      ) : (
-        <div className="font-bold">{title}</div>
-      )}
+      <div
+        className="flex items-center gap-1"
+        data-testid={`schema-${toShishkebabCase(title)}`}
+      >
+        <SchemaIcon type={objectType} />
+        {schema ? (
+          <>
+            <Link
+              href={`${schema.$id.replace(".json", "")}`}
+              aria-label={`View schema for ${title}`}
+              className="block"
+            >
+              {title}
+            </Link>
+            <SearchAndReportType type={objectType} title={title} />
+            <AddLink schema={schema} label={`Add ${schema.title}`} />
+          </>
+        ) : (
+          <div className="font-bold">{title}</div>
+        )}
+      </div>
       {childObjectTypes.length > 0 && (
         <div className="ml-4">
           {childObjectTypes.map((childObjectType) => {
@@ -116,7 +162,11 @@ export default function Profiles({ schemas, collectionTitles = null }) {
 
 Profiles.propTypes = {
   // List of schemas to display in the list; directly from /profiles endpoint
-  schemas: PropTypes.object.isRequired,
+  schemas: PropTypes.shape({
+    _hierarchy: PropTypes.shape({
+      Item: PropTypes.object.isRequired,
+    }).isRequired,
+  }),
   // Map of collection names to corresponding schema titles
   collectionTitles: PropTypes.object,
 };


### PR DESCRIPTION
Going forward we will still need search and object pages for new objects, as requested by Wranglers. But with IGVF-534 they mostly won’t get linked from main navigation, but will automatically appear linked from the Schemas page with this branch. I still display the icons, but now on the Schemas page — the main navigation will get new icons with IGVF-534. So we should still make icons for new objects as we have time to make them. Any new objects without icons get displayed with a splat icon on the Schemas page in this branch.