### PR TITLE
IGVF-692 Add Cypress tests for site and ID search

### DIFF
--- a/components/id-search-trigger.js
+++ b/components/id-search-trigger.js
@@ -96,6 +96,7 @@ export default function IdSearchTrigger() {
       <button
         onClick={onTriggerClick}
         className="grow-0 rounded"
+        data-testid="id-search-trigger"
         title={`Go to an item${UC.rsquo}s page from its identifier (${UC.cmd}${UC.shift}K or ${UC.ctrl}${UC.shift}K)`}
       >
         <IdSearchIcon className="h-8 w-8 fill-gray-500" />

--- a/components/search-modal.js
+++ b/components/search-modal.js
@@ -128,6 +128,7 @@ export default function SearchModal({
             </button>
             <input
               type="text"
+              data-testid="search-input"
               ref={inputRef}
               placeholder={searchBoxPlaceholder}
               spellCheck="false"

--- a/components/site-search-trigger.js
+++ b/components/site-search-trigger.js
@@ -17,6 +17,7 @@ function SearchTriggerExpanded({ onClick }) {
     <button
       onClick={onClick}
       className="flex h-8 w-full grow items-center gap-2 rounded border border-panel bg-form-element p-2 text-form-element"
+      data-testid="site-search-trigger-expanded"
       label="Search the site for a word or phrase"
     >
       <MagnifyingGlassIcon className="h-4 w-4" />
@@ -38,6 +39,7 @@ function SearchTriggerCollapsed({ onClick }) {
     <button
       onClick={onClick}
       className="block"
+      id="site-search-trigger-collapsed"
       label="Search the site for a word or phrase"
     >
       <MagnifyingGlassIcon className="h-8 w-8 fill-black dark:fill-white" />

--- a/cypress/e2e/site-id-search.cy.js
+++ b/cypress/e2e/site-id-search.cy.js
@@ -1,0 +1,121 @@
+/// <reference types="cypress" />
+
+describe("Test site search", () => {
+  it("does a successful search correctly", () => {
+    cy.visit("/");
+
+    // Search the site for "cherry" and make sure at least one type section gets displayed.
+    cy.get(`[data-testid^="site-search-trigger"]`).click();
+    cy.get(`[data-testid="search-input"]`).type("cherry{enter}");
+    cy.get("h1").contains("Items with “cherry”");
+    cy.get(`[data-testid^="site-search-type-section-"]`).should(
+      "have.length.least",
+      1
+    );
+
+    // Check that we can work with the first top-items section.
+    cy.get(`[data-testid^="site-search-type-section-"]`)
+      .first()
+      .within(() => {
+        // Expand the first top-items section and make sure it has at least one item.
+        cy.get(`[aria-label^="Expand top matches for"]`).click();
+        cy.get(`[data-testid^="search-list-item-"]`).should(
+          "have.length.least",
+          1
+        );
+
+        // Collapse the first top-items section and make sure it hides the items.
+        cy.get(`[aria-label^="Collapse top matches for"]`).click();
+        cy.get(`[data-testid^="search-list-item-"]`).should("have.length", 0);
+
+        // Click the list button and make sure it takes us to the list page.
+        cy.get(`[aria-label^="View search list for"]`).click();
+        cy.url().should(
+          "match",
+          /\/search\?type=[a-zA-Z0-9]+&searchTerm=cherry$/
+        );
+        cy.go("back");
+
+        // Click the list button and make sure it takes us to the list page.
+        cy.get(`[aria-label^="View search report for"]`).click();
+        cy.url().should(
+          "match",
+          /\/report\?type=[a-zA-Z0-9]+&searchTerm=cherry$/
+        );
+      });
+  });
+
+  it("does a failed search correctly", () => {
+    cy.visit("/");
+
+    // Search the site for "cherry" and make sure the error message gets displayed.
+    cy.get(`[data-testid^="site-search-trigger"]`).click();
+    cy.get(`[data-testid="search-input"]`).type("abcdefg{enter}");
+    cy.get("h1").contains("Items with “abcdefg”");
+    cy.contains("No matching items to display");
+  });
+
+  it("remembers past search terms and lets the user select them", () => {
+    cy.visit("/");
+
+    // Search the site for "cherry" and make sure we then go to the site-search page.
+    cy.get(`[data-testid^="site-search-trigger"]`).click();
+    cy.get(`[data-testid="search-input"]`).type("cherry");
+    cy.get(`[aria-label="Search for cherry"]`).click();
+    cy.get("h1").contains("Items with “cherry”");
+
+    // Go back to the home page, open the search box, and make sure we can select the "human" term.
+    cy.visit("/");
+    cy.get(`[data-testid^="site-search-trigger"]`).click();
+    cy.get(
+      `[aria-label="Enter the recent search, cherry, into the search box"]`
+    ).click();
+    cy.get(`[data-testid="search-input"]`).should("have.value", "cherry");
+    cy.get(`[aria-label="Search for cherry"]`).click();
+    cy.get("h1").contains("Items with “cherry”");
+  });
+});
+
+describe("Test ID search", () => {
+  it("does a successful ID search correctly", () => {
+    cy.visit("/");
+    cy.get(`[data-testid="id-search-trigger"]`).click();
+    cy.get(`[data-testid="search-input"]`).type(
+      "860c4750-8d3c-40f5-8f2c-90c5e5d19e88{enter}"
+    );
+    cy.url().should("include", "/users/860c4750-8d3c-40f5-8f2c-90c5e5d19e88");
+  });
+
+  it("does an unsuccessful ID search correctly", () => {
+    cy.visit("/");
+    cy.get(`[data-testid="id-search-trigger"]`).click();
+    cy.get(`[data-testid="search-input"]`).type("abcdefg{enter}");
+    cy.contains("No item with the identifier “abcdefg” to display");
+  });
+
+  it("remembers past search terms and lets the user select them", () => {
+    cy.visit("/");
+
+    // Search the site for a UUID and make sure we then go to that object's page.
+    cy.get(`[data-testid^="id-search-trigger"]`).click();
+    cy.get(`[data-testid="search-input"]`).type(
+      "860c4750-8d3c-40f5-8f2c-90c5e5d19e88{enter}"
+    );
+    cy.url().should("include", "/users/860c4750-8d3c-40f5-8f2c-90c5e5d19e88");
+
+    // Go back to the home page, open the ID search box, and make sure we can select the UUID.
+    cy.visit("/");
+    cy.get(`[data-testid^="id-search-trigger"]`).click();
+    cy.get(
+      `[aria-label="Enter the recent search, 860c4750-8d3c-40f5-8f2c-90c5e5d19e88, into the search box"]`
+    ).click();
+    cy.get(`[data-testid="search-input"]`).should(
+      "have.value",
+      "860c4750-8d3c-40f5-8f2c-90c5e5d19e88"
+    );
+    cy.get(
+      `[aria-label="Search for 860c4750-8d3c-40f5-8f2c-90c5e5d19e88"]`
+    ).click();
+    cy.url().should("include", "/users/860c4750-8d3c-40f5-8f2c-90c5e5d19e88");
+  });
+});

--- a/pages/site-search.js
+++ b/pages/site-search.js
@@ -25,6 +25,7 @@ import SessionContext from "../components/session-context";
 // lib
 import { UC } from "../lib/constants";
 import FetchRequest from "../lib/fetch-request";
+import { toShishkebabCase } from "../lib/general";
 import QueryString from "../lib/query-string";
 
 function getTypeTitle(searchResult, collectionTitles) {
@@ -115,13 +116,21 @@ TypeSectionHeader.propTypes = {
 /**
  * Display the top-hits results for one `@type` of searchTerm results.
  */
-function TypeSection({ children }) {
+function TypeSection({ type, children }) {
   return (
-    <li className="my-4 border border-data-border bg-panel first:mt-0 last:mb-0">
+    <li
+      className="my-4 border border-data-border bg-panel first:mt-0 last:mb-0"
+      data-testid={`site-search-type-section-${toShishkebabCase(type)}`}
+    >
       {children}
     </li>
   );
 }
+
+TypeSection.propTypes = {
+  // Object type for this section of search results
+  type: PropTypes.string.isRequired,
+};
 
 /**
  * Displays the list of top hits for a single type.
@@ -170,7 +179,7 @@ export default function SiteSearch({ results, term, accessoryData = null }) {
             const isSectionOpen = openedSections.includes(result.key);
             const typeTitle = getTypeTitle(result, collectionTitles);
             return (
-              <TypeSection key={result.key}>
+              <TypeSection type={result.key} key={result.key}>
                 <TypeSectionHeader
                   searchResult={result}
                   term={term}


### PR DESCRIPTION
In addition to the Cypress tests, I added some `data-testid` attributes so the tests can find them. We don’t need a demo for this ticket.