### PR TITLE
IGVF-756 Display properties not in schema as report columns

### DIFF
--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,7 +52,6 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,6 +52,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
+            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/components/__mocks__/profile.js
+++ b/components/__mocks__/profile.js
@@ -627,6 +627,40 @@ const profiles = {
     },
   },
 
+  InVitroSystem: {
+    title: "In Vitro System",
+    $id: "/profiles/in_vitro_system.json",
+    required: [
+      "award",
+      "lab",
+      "source",
+      "donors",
+      "biosample_term",
+      "classification",
+    ],
+    identifyingProperties: [
+      "uuid",
+      "accession",
+      "alternate_accessions",
+      "aliases",
+    ],
+    properties: {
+      accession: {
+        title: "Accession",
+        type: "string",
+      },
+      introduced_factors: {
+        title: "Introduced Factors",
+        type: "array",
+        items: {
+          title: "Treatment",
+          type: "string",
+          linkTo: "Treatment",
+        },
+      },
+    },
+  },
+
   Page: {
     title: "Page",
     $id: "/profiles/page.json",

--- a/components/__tests__/schema-icon.test.js
+++ b/components/__tests__/schema-icon.test.js
@@ -7,16 +7,6 @@ describe("Test the SchemaIcon component", () => {
     expect(screen.getByTestId("icon-splat")).toBeInTheDocument();
   });
 
-  it("should render a default icon for an empty schema type", () => {
-    render(<SchemaIcon type="" />);
-    expect(screen.getByTestId("icon-splat")).toBeInTheDocument();
-  });
-
-  it("should render a default icon for a null schema type", () => {
-    render(<SchemaIcon type={null} />);
-    expect(screen.getByTestId("icon-splat")).toBeInTheDocument();
-  });
-
   it("should render a default icon for defined schema type", () => {
     render(<SchemaIcon type="Award" />);
     expect(screen.getByTestId("icon-award")).toBeInTheDocument();

--- a/components/report/__tests__/cell-renderers.test.js
+++ b/components/report/__tests__/cell-renderers.test.js
@@ -912,7 +912,7 @@ describe("Page cell-rendering tests", () => {
       "cell-type-unknown-object"
     );
     expect(unknown).toHaveTextContent(
-      '{"blocks":[{"@id":"#block1","body":"# Donor Help This is some help text about donors.","@type":"mark...'
+      '{"blocks":[{"@id":"#block1","body":"# Donor Help This is some help text about donors.","@type":"markdown","direction":"ltr"}]}'
     );
   });
 
@@ -970,5 +970,366 @@ describe("Page cell-rendering tests", () => {
 
     const parentLink = within(cells[2]).queryByRole("link");
     expect(parentLink).toBeNull();
+  });
+});
+
+describe("Unknown-field cell-rendering tests", () => {
+  it("renders a simple unknown field", () => {
+    const COLUMN_UNKNOWN = 1;
+
+    const searchResults = {
+      "@id": "/report?type=HumanDonor&field=%40id&field=unknown_field",
+      "@type": ["Report"],
+      "@graph": [
+        {
+          "@id": "/human-donors/IGVFDO499FAP/",
+          "@type": ["HumanDonor", "Item"],
+          unknown_field: "Unknown value",
+        },
+      ],
+      columns: {
+        "@id": {
+          title: "ID",
+        },
+      },
+      filters: [
+        {
+          field: "type",
+          term: "HumanDonor",
+          remove: "/report",
+        },
+      ],
+    };
+
+    const onHeaderCellClick = jest.fn();
+    const sortedColumnId = getSortColumn(searchResults);
+
+    const columns = generateColumns(searchResults, profiles);
+    render(
+      <SessionContext.Provider value={{ profiles }}>
+        <DataGridContainer>
+          <SortableGrid
+            data={searchResults["@graph"]}
+            columns={columns}
+            initialSort={{ isSortingSuppressed: true }}
+            meta={{
+              onHeaderCellClick,
+              sortedColumnId,
+              nonSortableColumnIds: searchResults.non_sortable || [],
+            }}
+            CustomHeaderCell={ReportHeaderCell}
+          />
+        </DataGridContainer>
+      </SessionContext.Provider>
+    );
+    const cells = screen.getAllByRole("cell");
+
+    // Test that the unknown field has the correct contents.
+    expect(cells[COLUMN_UNKNOWN]).toHaveTextContent("Unknown value");
+  });
+
+  it("renders an unknown field containing an array of objects with @ids", () => {
+    const COLUMN_UNKNOWN = 1;
+
+    const searchResults = {
+      "@id": "/report?type=HumanDonor&field=%40id&field=unknown_field",
+      "@type": ["Report"],
+      "@graph": [
+        {
+          "@id": "/human-donors/IGVFDO1080XFGV/",
+          "@type": ["HumanDonor", "Item"],
+          unknown_field: [
+            {
+              "@id": "/human-donors/IGVFDO8315PGTI/",
+              "@type": ["HumanDonor", "Item"],
+            },
+            {
+              "@id": "/human-donors/IGVFDO9208RPQQ/",
+              "@type": ["HumanDonor", "Item"],
+            },
+          ],
+        },
+      ],
+      columns: {
+        "@id": {
+          title: "ID",
+        },
+      },
+      filters: [
+        {
+          field: "type",
+          term: "HumanDonor",
+          remove: "/report",
+        },
+      ],
+    };
+
+    const onHeaderCellClick = jest.fn();
+    const sortedColumnId = getSortColumn(searchResults);
+
+    const columns = generateColumns(searchResults, profiles);
+    render(
+      <SessionContext.Provider value={{ profiles }}>
+        <DataGridContainer>
+          <SortableGrid
+            data={searchResults["@graph"]}
+            columns={columns}
+            initialSort={{ isSortingSuppressed: true }}
+            meta={{
+              onHeaderCellClick,
+              sortedColumnId,
+              nonSortableColumnIds: searchResults.non_sortable || [],
+            }}
+            CustomHeaderCell={ReportHeaderCell}
+          />
+        </DataGridContainer>
+      </SessionContext.Provider>
+    );
+    const cells = screen.getAllByRole("cell");
+
+    // Test that the unknown field has the correct contents.
+    expect(cells[COLUMN_UNKNOWN]).toHaveTextContent(
+      "/human-donors/IGVFDO8315PGTI/, /human-donors/IGVFDO9208RPQQ/"
+    );
+  });
+
+  it("renders an unknown field containing an array simple objects", () => {
+    const COLUMN_UNKNOWN = 1;
+
+    const searchResults = {
+      "@id": "/report?type=HumanDonor&field=%40id&field=unknown_field",
+      "@type": ["Report"],
+      "@graph": [
+        {
+          "@id": "/human-donors/IGVFDO1080XFGV/",
+          "@type": ["HumanDonor", "Item"],
+          unknown_field: ["IGVFDO8315PGTI", "IGVFDO9208RPQQ"],
+        },
+      ],
+      columns: {
+        "@id": {
+          title: "ID",
+        },
+      },
+      filters: [
+        {
+          field: "type",
+          term: "HumanDonor",
+          remove: "/report",
+        },
+      ],
+    };
+
+    const onHeaderCellClick = jest.fn();
+    const sortedColumnId = getSortColumn(searchResults);
+
+    const columns = generateColumns(searchResults, profiles);
+    render(
+      <SessionContext.Provider value={{ profiles }}>
+        <DataGridContainer>
+          <SortableGrid
+            data={searchResults["@graph"]}
+            columns={columns}
+            initialSort={{ isSortingSuppressed: true }}
+            meta={{
+              onHeaderCellClick,
+              sortedColumnId,
+              nonSortableColumnIds: searchResults.non_sortable || [],
+            }}
+            CustomHeaderCell={ReportHeaderCell}
+          />
+        </DataGridContainer>
+      </SessionContext.Provider>
+    );
+    const cells = screen.getAllByRole("cell");
+
+    // Test that the unknown field has the correct contents.
+    expect(cells[COLUMN_UNKNOWN]).toHaveTextContent(
+      "IGVFDO8315PGTI, IGVFDO9208RPQQ"
+    );
+  });
+
+  it("renders an unknown field containing an object with an @id", () => {
+    const COLUMN_UNKNOWN = 1;
+
+    const searchResults = {
+      "@id": "/report?type=HumanDonor&field=%40id&field=unknown_field",
+      "@type": ["Report"],
+      "@graph": [
+        {
+          "@id": "/human-donors/IGVFDO1080XFGV/",
+          "@type": ["HumanDonor", "Item"],
+          unknown_field: {
+            "@id": "/human-donors/IGVFDO8315PGTI/",
+            "@type": ["HumanDonor", "Item"],
+          },
+        },
+      ],
+      columns: {
+        "@id": {
+          title: "ID",
+        },
+      },
+      filters: [
+        {
+          field: "type",
+          term: "HumanDonor",
+          remove: "/report",
+        },
+      ],
+    };
+
+    const onHeaderCellClick = jest.fn();
+    const sortedColumnId = getSortColumn(searchResults);
+
+    const columns = generateColumns(searchResults, profiles);
+    render(
+      <SessionContext.Provider value={{ profiles }}>
+        <DataGridContainer>
+          <SortableGrid
+            data={searchResults["@graph"]}
+            columns={columns}
+            initialSort={{ isSortingSuppressed: true }}
+            meta={{
+              onHeaderCellClick,
+              sortedColumnId,
+              nonSortableColumnIds: searchResults.non_sortable || [],
+            }}
+            CustomHeaderCell={ReportHeaderCell}
+          />
+        </DataGridContainer>
+      </SessionContext.Provider>
+    );
+    const cells = screen.getAllByRole("cell");
+
+    // Test that the unknown field has the correct contents.
+    expect(cells[COLUMN_UNKNOWN]).toHaveTextContent(
+      "/human-donors/IGVFDO8315PGTI/"
+    );
+  });
+
+  it("renders an unknown field containing an object with no @id", () => {
+    const COLUMN_UNKNOWN = 1;
+
+    const searchResults = {
+      "@id": "/report?type=HumanDonor&field=%40id&field=unknown_field",
+      "@type": ["Report"],
+      "@graph": [
+        {
+          "@id": "/human-donors/IGVFDO1080XFGV/",
+          "@type": ["HumanDonor", "Item"],
+          unknown_field: {
+            prop0: "value0",
+            prop1: "value1",
+          },
+        },
+      ],
+      columns: {
+        "@id": {
+          title: "ID",
+        },
+      },
+      filters: [
+        {
+          field: "type",
+          term: "HumanDonor",
+          remove: "/report",
+        },
+      ],
+    };
+
+    const onHeaderCellClick = jest.fn();
+    const sortedColumnId = getSortColumn(searchResults);
+
+    const columns = generateColumns(searchResults, profiles);
+    render(
+      <SessionContext.Provider value={{ profiles }}>
+        <DataGridContainer>
+          <SortableGrid
+            data={searchResults["@graph"]}
+            columns={columns}
+            initialSort={{ isSortingSuppressed: true }}
+            meta={{
+              onHeaderCellClick,
+              sortedColumnId,
+              nonSortableColumnIds: searchResults.non_sortable || [],
+            }}
+            CustomHeaderCell={ReportHeaderCell}
+          />
+        </DataGridContainer>
+      </SessionContext.Provider>
+    );
+    const cells = screen.getAllByRole("cell");
+
+    // Test that the unknown field has the correct contents.
+    expect(cells[COLUMN_UNKNOWN]).toHaveTextContent(
+      `{"prop0":"value0","prop1":"value1"}`
+    );
+  });
+
+  it("renders an unknown field containing an array of objects", () => {
+    const COLUMN_UNKNOWN = 1;
+
+    const searchResults = {
+      "@id":
+        "/report?type=InVitroSystem&field=%40id&field=introduced_factors.purpose",
+      "@type": ["Report"],
+      "@graph": [
+        {
+          "@id": "/in-vitro-system/IGVFSM0000AAAZ/",
+          "@type": ["InVitroSystem", "Biosample", "Sample", "Item"],
+          introduced_factors: [
+            {
+              purpose: "selection",
+              "@id": "/treatments/10c05ac0-52a2-11e6-bdf4-0800200c9a66/",
+            },
+            {
+              purpose: "differentiation",
+              "@id": "/treatments/bd2cb34e-c72c-11ec-9d64-0242ac120002/",
+            },
+          ],
+        },
+      ],
+      columns: {
+        "@id": {
+          title: "ID",
+        },
+      },
+      filters: [
+        {
+          field: "type",
+          term: "InVitroSystem",
+          remove: "/report",
+        },
+      ],
+    };
+
+    const onHeaderCellClick = jest.fn();
+    const sortedColumnId = getSortColumn(searchResults);
+
+    const columns = generateColumns(searchResults, profiles);
+    render(
+      <SessionContext.Provider value={{ profiles }}>
+        <DataGridContainer>
+          <SortableGrid
+            data={searchResults["@graph"]}
+            columns={columns}
+            initialSort={{ isSortingSuppressed: true }}
+            meta={{
+              onHeaderCellClick,
+              sortedColumnId,
+              nonSortableColumnIds: searchResults.non_sortable || [],
+            }}
+            CustomHeaderCell={ReportHeaderCell}
+          />
+        </DataGridContainer>
+      </SessionContext.Provider>
+    );
+    const cells = screen.getAllByRole("cell");
+
+    // Test that the unknown field has the correct contents.
+    expect(cells[COLUMN_UNKNOWN]).toHaveTextContent(
+      "selection, differentiation"
+    );
   });
 });

--- a/components/report/column-selector.js
+++ b/components/report/column-selector.js
@@ -91,7 +91,6 @@ export default function ColumnSelector({
     // Determine whether any column is hidden given the current report URL. Use this to determine
     // whether to display the "hidden columns" indicator.
     const columnSpecs = getReportTypeColumnSpecs(reportType, profiles);
-    console.log("COLUMNSPEC %o", columnSpecs);
     const visibleColumnSpecs = getVisibleReportColumnSpecs(
       searchResults,
       profiles

--- a/components/report/column-selector.js
+++ b/components/report/column-selector.js
@@ -10,6 +10,7 @@ import SessionContext from "../session-context";
 import HiddenColumnsIndicator from "./hidden-columns-indicator";
 // lib
 import {
+  getManuallyEnteredColumnIds,
   getReportTypeColumnSpecs,
   getReportType,
   getVisibleReportColumnSpecs,
@@ -38,6 +39,37 @@ ChangeAllControls.propTypes = {
 };
 
 /**
+ * Wrapper for the group of checkboxes for the user to select which columns to display and which
+ * to hide.
+ */
+function CheckboxArea({ className = "", children }) {
+  return <div className={`md:flex md:flex-wrap ${className}`}>{children}</div>;
+}
+
+CheckboxArea.propTypes = {
+  // Tailwind CSS classes to add to the checkbox area wrapper
+  className: PropTypes.string,
+};
+
+/**
+ * Wrapper for advisory notes within the column-selection modal.
+ */
+function Note({ className = "", children }) {
+  return (
+    <div
+      className={`text-center text-sm text-gray-500 dark:text-gray-300 md:flex-grow md:text-left ${className}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+Note.propTypes = {
+  // Tailwind CSS classes to add to the note wrapper
+  className: PropTypes.string,
+};
+
+/**
  * Display the actuator button to display the modal for the user to select which columns to
  * display and which to hide. This also displays that modal.
  */
@@ -55,6 +87,7 @@ export default function ColumnSelector({
     // Determine whether any column is hidden given the current report URL. Use this to determine
     // whether to display the "hidden columns" indicator.
     const columnSpecs = getReportTypeColumnSpecs(reportType, profiles);
+    console.log("COLUMNSPEC %o", columnSpecs);
     const visibleColumnSpecs = getVisibleReportColumnSpecs(
       searchResults,
       profiles
@@ -63,6 +96,13 @@ export default function ColumnSelector({
       (columnSpec) => columnSpec.id
     );
     const isAnyColumnHidden = columnSpecs.length > visibleColumnSpecs.length;
+
+    // Get visible columns not in the type's schema, indicating ones the user manually added to
+    // the query string.
+    const manuallyEnteredColumnIds = getManuallyEnteredColumnIds(
+      visibleColumnIds,
+      columnSpecs
+    );
 
     return (
       <>
@@ -81,33 +121,53 @@ export default function ColumnSelector({
           <Modal.Body>
             <div className="mb-3 md:flex md:items-center">
               <ChangeAllControls onChangeAll={onChangeAll} />
-              <div className="text-center text-sm text-gray-700 dark:text-gray-300 md:ml-2 md:flex-grow md:text-left">
+              <Note className="md:ml-2">
                 The <i>ID</i> column cannot be hidden
-              </div>
+              </Note>
             </div>
-            <fieldset>
-              <div className="md:flex md:flex-wrap">
-                {columnSpecs.map((columnSpec) => {
-                  if (columnSpec.id !== "@id") {
-                    const isVisible = visibleColumnIds.includes(columnSpec.id);
+            <CheckboxArea>
+              {columnSpecs.map((columnSpec) => {
+                if (columnSpec.id !== "@id") {
+                  const isVisible = visibleColumnIds.includes(columnSpec.id);
+                  return (
+                    <Checkbox
+                      key={columnSpec.id}
+                      name={columnSpec.id}
+                      checked={isVisible}
+                      onChange={() => onChange(columnSpec.id, isVisible)}
+                      className="block md:basis-1/2 lg:basis-1/3"
+                    >
+                      {columnSpec.title}
+                    </Checkbox>
+                  );
+                }
+
+                // Don't include @id property; @id is always visible.
+                return null;
+              })}
+            </CheckboxArea>
+            {manuallyEnteredColumnIds.length > 0 && (
+              <div className="mt-3 border-t pt-2">
+                <Note className="mb-2">
+                  Manually entered columns disappear as soon as you uncheck them
+                </Note>
+                <CheckboxArea>
+                  {manuallyEnteredColumnIds.map((columnId) => {
                     return (
                       <Checkbox
-                        key={columnSpec.id}
-                        name={columnSpec.id}
-                        checked={isVisible}
-                        onChange={() => onChange(columnSpec.id, isVisible)}
+                        key={columnId}
+                        name={columnId}
+                        checked={true}
+                        onChange={() => onChange(columnId, true)}
                         className="block md:basis-1/2 lg:basis-1/3"
                       >
-                        {columnSpec.title}
+                        {columnId}
                       </Checkbox>
                     );
-                  }
-
-                  // Don't include @id property; @id is always visible.
-                  return null;
-                })}
+                  })}
+                </CheckboxArea>
               </div>
-            </fieldset>
+            )}
           </Modal.Body>
 
           <Modal.Footer>

--- a/components/report/column-selector.js
+++ b/components/report/column-selector.js
@@ -43,7 +43,11 @@ ChangeAllControls.propTypes = {
  * to hide.
  */
 function CheckboxArea({ className = "", children }) {
-  return <div className={`md:flex md:flex-wrap ${className}`}>{children}</div>;
+  return (
+    <fieldset className={`md:flex md:flex-wrap ${className}`}>
+      {children}
+    </fieldset>
+  );
 }
 
 CheckboxArea.propTypes = {

--- a/lib/__tests__/general.test.js
+++ b/lib/__tests__/general.test.js
@@ -5,6 +5,7 @@ import {
   removeTrailingSlash,
   sortedJson,
   urlWithoutParams,
+  truncateJson,
 } from "../general";
 
 describe("Test the pathToType utility function", () => {
@@ -63,5 +64,57 @@ describe("Test the removeTrailingSlash utility function", () => {
   it("Should remove a trailing slash from a string", () => {
     expect(removeTrailingSlash("/path/object/")).toBe("/path/object");
     expect(removeTrailingSlash("/path/object")).toBe("/path/object");
+  });
+});
+
+describe("Test the truncateJson utility function", () => {
+  it("doesn't truncate a JSON object that's shorter than 200 characters", () => {
+    const obj = {
+      a: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      b: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      c: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      d: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      e: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      f: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      g: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    };
+    const truncated = truncateJson(obj);
+    expect(truncated).toStrictEqual(
+      `{"a":[1,2,3,4,5,6,7,8,9,10],"b":[1,2,3,4,5,6,7,8,9,10],"c":[1,2,3,4,5,6,7,8,9,10],"d":[1,2,3,4,5,6,7,8,9,10],"e":[1,2,3,4,5,6,7,8,9,10],"f":[1,2,3,4,5,6,7,8,9,10],"g":[1,2,3,4,5,6,7,8,9,10]}`
+    );
+  });
+
+  it("truncates a JSON object that's longer than 200 characters", () => {
+    const obj = {
+      a: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      b: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      c: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      d: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      e: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      f: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      g: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      h: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    };
+    const truncated = truncateJson(obj);
+    expect(truncated).toStrictEqual(
+      `{"a":[1,2,3,4,5,6,7,8,9,10],"b":[1,2,3,4,5,6,7,8,9,10],"c":[1,2,3,4,5,6,7,8,9,10],"d":[1,2,3,4,5,6,7,8,9,10],"e":[1,2,3,4,5,6,7,8,9,10],"f":[1,2,3,4,5,6,7,8,9,10],"g":[1,2,3,4,5,6,7,8,9,10],"h":[1,2,3...`
+    );
+  });
+
+  it("doesn't truncate a JSON object that's shorter than a specified number of characters", () => {
+    const obj = {
+      a: [1, 2],
+    };
+    const truncated = truncateJson(obj, 20);
+    expect(truncated).toStrictEqual(`{"a":[1,2]}`);
+  });
+
+  it("truncates a JSON object that's longer than a specified number of characters", () => {
+    const obj = {
+      a: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      b: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    };
+    const truncated = truncateJson(obj, 20);
+    expect(truncated).toStrictEqual(`{"a":[1,2,3,4,5,6,7,...`);
   });
 });

--- a/lib/__tests__/report.test.js
+++ b/lib/__tests__/report.test.js
@@ -307,6 +307,10 @@ describe("Test `getVisibleReportColumnSpecs()`", () => {
         id: "uuid",
         title: "UUID",
       },
+      {
+        id: "notreal",
+        title: "notreal",
+      },
     ]);
   });
 

--- a/lib/__tests__/report.test.js
+++ b/lib/__tests__/report.test.js
@@ -305,12 +305,12 @@ describe("Test `getVisibleReportColumnSpecs()`", () => {
         title: "ID",
       },
       {
-        id: "uuid",
-        title: "UUID",
-      },
-      {
         id: "notreal",
         title: "notreal",
+      },
+      {
+        id: "uuid",
+        title: "UUID",
       },
     ]);
   });

--- a/lib/__tests__/report.test.js
+++ b/lib/__tests__/report.test.js
@@ -1,4 +1,5 @@
 import {
+  getManuallyEnteredColumnIds,
   getReportType,
   getReportTypeColumnSpecs,
   getSchemaForReportType,
@@ -454,5 +455,43 @@ describe("Test `schemaColumnsToColumnSpecs()`", () => {
         title: "UUID",
       },
     ]);
+  });
+});
+
+describe("Test `getVisibleReportColumnSpecs()`", () => {
+  it("should return column IDs when the visible column IDs have values outside the column specs", () => {
+    const visibleColumnIds = ["@id", "uuid", "submitted_by.title"];
+    const columnSpecs = [
+      { id: "@id", title: "ID" },
+      { id: "uuid", title: "UUID" },
+    ];
+
+    const manuallyEnteredColumnIds = getManuallyEnteredColumnIds(
+      visibleColumnIds,
+      columnSpecs
+    );
+    expect(manuallyEnteredColumnIds).toEqual(["submitted_by.title"]);
+  });
+
+  it("should return empty array when the visible column IDs have values inside the column specs", () => {
+    const visibleColumnIds = ["@id", "uuid"];
+    const columnSpecs = [
+      { id: "@id", title: "ID" },
+      { id: "uuid", title: "UUID" },
+    ];
+    expect(getManuallyEnteredColumnIds(visibleColumnIds, columnSpecs)).toEqual(
+      []
+    );
+  });
+
+  it("should return empty array when the visible column IDs are empty", () => {
+    const visibleColumnIds = [];
+    const columnSpecs = [
+      { id: "@id", title: "ID" },
+      { id: "uuid", title: "UUID" },
+    ];
+    expect(getManuallyEnteredColumnIds(visibleColumnIds, columnSpecs)).toEqual(
+      []
+    );
   });
 });

--- a/lib/general.js
+++ b/lib/general.js
@@ -90,3 +90,21 @@ export function removeTrailingSlash(url) {
 export function truthyOrZero(value) {
   return value || value === 0;
 }
+
+/**
+ * Maximum number of characters to display for a JSON object in a cell.
+ */
+const MAX_CELL_JSON_LENGTH = 200;
+
+/**
+ * Convert an object to stringified JSON and truncate it to the desired length.
+ * @param {object} obj Object or array to stringify and truncate
+ * @param {number} [maxOutputLength] Maximum number of characters to display
+ * @returns {string} Truncated JSON
+ */
+export function truncateJson(obj, maxOutputLength = MAX_CELL_JSON_LENGTH) {
+  const json = JSON.stringify(obj);
+  return json.length > maxOutputLength
+    ? `${json.substring(0, maxOutputLength)}...`
+    : json;
+}

--- a/lib/report.js
+++ b/lib/report.js
@@ -129,7 +129,8 @@ export function getSortColumn(searchResults) {
 function sortColumnSpecs(columnSpecs) {
   return _.sortBy(columnSpecs, [
     (columnSpec) => columnSpec.id !== "@id",
-    (columnSpec) => (columnSpec.id === "@id" ? 0 : columnSpec.title),
+    (columnSpec) =>
+      columnSpec.id === "@id" ? 0 : columnSpec.title.toLowerCase(),
   ]);
 }
 

--- a/lib/report.js
+++ b/lib/report.js
@@ -147,3 +147,17 @@ export function schemaColumnsToColumnSpecs(schemaColumns) {
   }));
   return sortColumnSpecs(columnSpecs);
 }
+
+/**
+ * Get the manually entered column IDs the user entered in the query string. These are the ones
+ * that don't exist in the schema for the report type. An empty array gets returned if no manually
+ * entered columns exist.
+ * @param {array} visibleColumnIds Array of column IDs that are visible in the report
+ * @param {array} columnSpecs Array of columnSpec objects for the report type
+ * @returns {array} Array of manually entered column IDs
+ */
+export function getManuallyEnteredColumnIds(visibleColumnIds, columnSpecs) {
+  return visibleColumnIds.filter(
+    (columnId) => !columnSpecs.find((columnSpec) => columnSpec.id === columnId)
+  );
+}

--- a/lib/report.js
+++ b/lib/report.js
@@ -93,15 +93,10 @@ export function getVisibleReportColumnSpecs(searchResults, profiles) {
     // Collect all properties from the schema. This represents all possible columns for the report.
     const columnSpecs = columnIds
       .map((propertyName) => {
-        if (schema.properties[propertyName]) {
-          return {
-            id: propertyName,
-            title: schema.properties[propertyName].title,
-          };
-        }
-
-        // The specified column wasn't found in the schema, so ignore it.
-        return null;
+        return {
+          id: propertyName,
+          title: schema.properties[propertyName]?.title || propertyName,
+        };
       })
       .filter((columnSpec) => columnSpec !== null);
     return sortColumnSpecs(columnSpecs);


### PR DESCRIPTION
This involves changing `<UnknownObject>` to now detect the type of the property the user requested to display as a report column and display something relevant to that, because these properties don’t have a corresponding schema property from which we can determine its type.

The other part of this involves the report view no longer filtering out requested properties if they don’t appear in the schema. We attempt to display any property in case the user wants to see one not in the schema, such as embedded properties. Only if we can’t figure out anything about the property do we display nothing.

I changed the length of truncated JSON to 200 characters and moved the truncation code to its own function to reduce code duplication.