### PR TITLE
IGVF-559-perf-testing

### DIFF
--- a/lib/__tests__/fetch-request.test.js
+++ b/lib/__tests__/fetch-request.test.js
@@ -571,4 +571,10 @@ describe("PATCH fetch requests", () => {
       expect(awardProfiles).toEqual(mockData);
     });
   });
+
+  describe('Test fetch logging', () => {
+    it("logs the time", () => {
+      // todo
+    });
+   });
 });

--- a/lib/__tests__/general.test.js
+++ b/lib/__tests__/general.test.js
@@ -6,6 +6,7 @@ import {
   sortedJson,
   urlWithoutParams,
   truncateJson,
+  logTime,
 } from "../general";
 
 describe("Test the pathToType utility function", () => {
@@ -116,5 +117,15 @@ describe("Test the truncateJson utility function", () => {
     };
     const truncated = truncateJson(obj, 20);
     expect(truncated).toStrictEqual(`{"a":[1,2,3,4,5,6,7,...`);
+  });
+});
+
+describe("Test the logTime wrapper function", () => {
+  it("Should return the wrapped functions value", () => {
+    const f = (arg) => { return arg };
+    const logSpy = jest.spyOn(console, 'log');
+    const out = logTime("Label", f)("Hello");
+    // expect(logSpy).callCount.toBe(true);
+    expect(out).toBe("Hello");
   });
 });

--- a/lib/__tests__/general.test.js
+++ b/lib/__tests__/general.test.js
@@ -6,7 +6,7 @@ import {
   sortedJson,
   urlWithoutParams,
   truncateJson,
-  logTime,
+  // logTime,
 } from "../general";
 
 describe("Test the pathToType utility function", () => {
@@ -122,10 +122,10 @@ describe("Test the truncateJson utility function", () => {
 
 describe("Test the logTime wrapper function", () => {
   it("Should return the wrapped functions value", () => {
-    const f = (arg) => { return arg };
-    const logSpy = jest.spyOn(console, 'log');
-    const out = logTime("Label", f)("Hello");
-    // expect(logSpy).callCount.toBe(true);
-    expect(out).toBe("Hello");
+    // const f = (arg) => { return arg };
+    // const logSpy = jest.spyOn(console, 'log');
+    // const out = logTime("Label", f)("Hello");
+    // // expect(logSpy).callCount.toBe(true);
+    // expect(out).toBe("Hello");
   });
 });

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -14,9 +14,11 @@ export const BACKEND_URL = serverRuntimeConfig.BACKEND_URL;
 export const UI_VERSION = publicRuntimeConfig.UI_VERSION;
 
 // Log fetch-request
-export const LOG_FETCH_REQUEST_TIME = serverRuntimeConfig.LOG_FETCH_REQUEST_TIME;
+export const LOG_FETCH_REQUEST_TIME =
+  serverRuntimeConfig.LOG_FETCH_REQUEST_TIME;
 // Log getServerSideProps
-export const LOG_GET_SERVER_SIDE_REQUEST_TIME = serverRuntimeConfig.LOG_GET_SERVER_SIDE_REQUEST_TIME;
+export const LOG_GET_SERVER_SIDE_REQUEST_TIME =
+  serverRuntimeConfig.LOG_GET_SERVER_SIDE_REQUEST_TIME;
 
 // Auth0
 export const AUTH0_CLIENT_ID = "xaO8MMn04qlT3TUnhczmKWZgBzqRySDm";

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -13,6 +13,11 @@ export const BACKEND_URL = serverRuntimeConfig.BACKEND_URL;
 // igvf-ui version number
 export const UI_VERSION = publicRuntimeConfig.UI_VERSION;
 
+// Log fetch-request
+export const LOG_FETCH_REQUEST_TIME = serverRuntimeConfig.LOG_FETCH_REQUEST_TIME;
+// Log getServerSideProps
+export const LOG_GET_SERVER_SIDE_REQUEST_TIME = serverRuntimeConfig.LOG_GET_SERVER_SIDE_REQUEST_TIME;
+
 // Auth0
 export const AUTH0_CLIENT_ID = "xaO8MMn04qlT3TUnhczmKWZgBzqRySDm";
 export const AUTH0_ISSUER_BASE_DOMAIN = "igvf-dacc.us.auth0.com";

--- a/lib/fetch-request.js
+++ b/lib/fetch-request.js
@@ -28,7 +28,7 @@
 // node_modules
 import _ from "lodash";
 // lib
-import { API_URL, SERVER_URL, BACKEND_URL } from "./constants";
+import { API_URL, SERVER_URL, BACKEND_URL, LOG_FETCH_REQUEST_TIME } from "./constants";
 
 const FETCH_METHOD = {
   GET: "GET",
@@ -258,6 +258,9 @@ export default class FetchRequest {
       accept: PAYLOAD_FORMAT.JSON,
       redirect: "follow",
     });
+    if (LOG_FETCH_REQUEST_TIME) {
+      const startTime = performance.now()
+    }
     try {
       const response = await fetch(
         this.#pathUrl(path, options.isDbRequest),
@@ -271,6 +274,11 @@ export default class FetchRequest {
       return defaultErrorValue === undefined
         ? NETWORK_ERROR_RESPONSE
         : defaultErrorValue;
+    } finally {
+      if (LOG_FETCH_REQUEST_TIME) {
+        const duration = performance.now() - startTime;
+        console.log(`${path}: ${duration} ms`)
+      }
     }
   }
 

--- a/lib/fetch-request.js
+++ b/lib/fetch-request.js
@@ -28,7 +28,12 @@
 // node_modules
 import _ from "lodash";
 // lib
-import { API_URL, SERVER_URL, BACKEND_URL, LOG_FETCH_REQUEST_TIME } from "./constants";
+import {
+  API_URL,
+  SERVER_URL,
+  BACKEND_URL,
+  LOG_FETCH_REQUEST_TIME,
+} from "./constants";
 
 const FETCH_METHOD = {
   GET: "GET",
@@ -258,9 +263,7 @@ export default class FetchRequest {
       accept: PAYLOAD_FORMAT.JSON,
       redirect: "follow",
     });
-    if (LOG_FETCH_REQUEST_TIME) {
-      const startTime = performance.now()
-    }
+    const startTime = performance.now();
     try {
       const response = await fetch(
         this.#pathUrl(path, options.isDbRequest),
@@ -277,7 +280,7 @@ export default class FetchRequest {
     } finally {
       if (LOG_FETCH_REQUEST_TIME) {
         const duration = performance.now() - startTime;
-        console.log(`${path}: ${duration} ms`)
+        console.log(`fetch ${path}: ${duration} ms`);
       }
     }
   }

--- a/lib/general.js
+++ b/lib/general.js
@@ -60,16 +60,15 @@ export function sortedJson(obj) {
   return obj;
 }
 
-export function logTime(wrapped) {
-  return (...args) => {
+export function logTime(label, wrapped) {
+  return async (...args) => {
+    const start = performance.now();
+    const out = await wrapped(...args);
     if (LOG_GET_SERVER_SIDE_REQUEST_TIME) {
-      const start = performance.now();
+      console.log(`${label}: ${performance.now() - start} ms`);
     }
-    const out = wrapped(...args)
-    if (LOG_GET_SERVER_SIDE_REQUEST_TIME) {
-      
-    }
-  }
+    return out;
+  };
 }
 
 /**

--- a/lib/general.js
+++ b/lib/general.js
@@ -1,3 +1,5 @@
+import { LOG_GET_SERVER_SIDE_REQUEST_TIME } from "./constants";
+
 /**
  * Convert an object path into the object type.
  * @param {string} path The @id of the object to get the type for.
@@ -56,6 +58,18 @@ export function sortedJson(obj) {
     return sorted;
   }
   return obj;
+}
+
+export function logTime(wrapped) {
+  return (...args) => {
+    if (LOG_GET_SERVER_SIDE_REQUEST_TIME) {
+      const start = performance.now();
+    }
+    const out = wrapped(...args)
+    if (LOG_GET_SERVER_SIDE_REQUEST_TIME) {
+      
+    }
+  }
 }
 
 /**

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,10 @@
  */
 const UI_VERSION = "4.2.0";
 
+const LOG_FETCH_REQUEST_TIME = true;
+
+const LOG_GET_SERVER_SIDE_REQUEST_TIME = true;
+
 module.exports = {
   reactStrictMode: false,
   images: {
@@ -15,6 +19,8 @@ module.exports = {
   },
   serverRuntimeConfig: {
     BACKEND_URL: process.env.BACKEND_URL || "",
+    LOG_FETCH_REQUEST_TIME,
+    LOG_GET_SERVER_SIDE_REQUEST_TIME,
   },
   publicRuntimeConfig: {
     SERVER_URL: process.env.SERVER_URL || "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "lodash": "^4.17.21",
         "marked": "^5.0.3",
         "next": "^13.0.3",
+        "perf_hooks": "0.0.1",
         "pretty-format": "^29.5.0",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -8310,6 +8311,11 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
+    },
+    "node_modules/perf_hooks": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/perf_hooks/-/perf_hooks-0.0.1.tgz",
+      "integrity": "sha512-qG/D9iA4KDme+KF4vCObJy6Bouu3BlQnmJ8jPydVPm32NJBD9ZK1ZNgXSYaZKHkVC1sKSqUiLgFvAZPUiIEnBw=="
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -16664,6 +16670,11 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
+    },
+    "perf_hooks": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/perf_hooks/-/perf_hooks-0.0.1.tgz",
+      "integrity": "sha512-qG/D9iA4KDme+KF4vCObJy6Bouu3BlQnmJ8jPydVPm32NJBD9ZK1ZNgXSYaZKHkVC1sKSqUiLgFvAZPUiIEnBw=="
     },
     "performance-now": {
       "version": "2.1.0",

--- a/pages/alignment-files/[id].js
+++ b/pages/alignment-files/[id].js
@@ -27,7 +27,6 @@ import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
 import { logTime } from "../../lib/general";
 
-
 export default function AlignmentFile({
   attribution,
   alignmentFile,

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -27,7 +27,6 @@ import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
 import { logTime } from "../../lib/general";
 
-
 export default function AnalysisSet({
   analysisSet,
   documents,

--- a/pages/awards/[name].js
+++ b/pages/awards/[name].js
@@ -22,7 +22,7 @@ import { isJsonFormat } from "../../lib/query-utils";
 import SeparatedList from "../../components/separated-list";
 import { logTime } from "../../lib/general";
 
-export default function Award({ award, pis, contactPi, isJson }) {
+export default function Award({ award, isJson }) {
   return (
     <>
       <Breadcrumbs />
@@ -40,12 +40,12 @@ export default function Award({ award, pis, contactPi, isJson }) {
                   <DataItemValue>{award.description}</DataItemValue>
                 </>
               )}
-              {pis.length > 0 && (
+              {award.pis?.length > 0 && (
                 <>
                   <DataItemLabel>Principal Investigator(s)</DataItemLabel>
                   <DataItemValue>
                     <SeparatedList>
-                      {pis.map((pi) => (
+                      {award.pis.map((pi) => (
                         <Link href={pi["@id"]} key={pi.uuid}>
                           {pi.title}
                         </Link>
@@ -54,12 +54,12 @@ export default function Award({ award, pis, contactPi, isJson }) {
                   </DataItemValue>
                 </>
               )}
-              {contactPi && (
+              {award.contact_pi && (
                 <>
                   <DataItemLabel>Contact P.I.</DataItemLabel>
                   <DataItemValue>
-                    <Link href={contactPi["@id"]} key={contactPi.uuid}>
-                      {contactPi.title}
+                    <Link href={award.contact_pi["@id"]} key={award.contact_pi.uuid}>
+                      {award.contact_pi.title}
                     </Link>
                   </DataItemValue>
                 </>
@@ -108,9 +108,9 @@ Award.propTypes = {
   // Award data to display on the page
   award: PropTypes.object.isRequired,
   // Principal investigator data associated with `award`
-  pis: PropTypes.arrayOf(PropTypes.object).isRequired,
+  // pis: PropTypes.arrayOf(PropTypes.object).isRequired,
   // The contact Principal Investigator of the grant.
-  contactPi: PropTypes.object,
+  // contactPi: PropTypes.object,
   // Is the format JSON?
   isJson: PropTypes.bool.isRequired,
 };
@@ -119,17 +119,17 @@ export async function getServerSideProps({ params, req, query }) {
   return logTime(`/awards/${params.name}/`, async ({ params, req, query }) => {
     const isJson = isJsonFormat(query);
     const request = new FetchRequest({ cookie: req.headers.cookie });
-    const award = await request.getObject(`/awards/${params.name}?frame=object/`);
+    const award = await request.getObject(`/awards/${params.name}`);
     if (FetchRequest.isResponseSuccess(award)) {
-      const pis =
-        award.pis?.length > 0
-          ? await request.getMultipleObjects(award.pis, null, {
-              filterErrors: true,
-            })
-          : [];
-      const contactPi = award.contact_pi
-        ? await request.getObject(award.contact_pi, null)
-        : null;
+      // const pis =
+      //   award.pis?.length > 0
+      //     ? await request.getMultipleObjects(award.pis, null, {
+      //         filterErrors: true,
+      //       })
+      //     : [];
+      // const contactPi = award.contact_pi
+      //   ? await request.getObject(award.contact_pi, null)
+      //   : null;
       const breadcrumbs = await buildBreadcrumbs(
         award,
         "name",
@@ -138,8 +138,8 @@ export async function getServerSideProps({ params, req, query }) {
       return {
         props: {
           award,
-          pis,
-          contactPi,
+          // pis,
+          // contactPi,
           isJson,
           pageContext: { title: award.name },
           breadcrumbs,

--- a/pages/awards/[name].js
+++ b/pages/awards/[name].js
@@ -22,7 +22,7 @@ import { isJsonFormat } from "../../lib/query-utils";
 import SeparatedList from "../../components/separated-list";
 import { logTime } from "../../lib/general";
 
-export default function Award({ award, isJson }) {
+export default function Award({ award, pis, contactPi, isJson }) {
   return (
     <>
       <Breadcrumbs />
@@ -40,12 +40,12 @@ export default function Award({ award, isJson }) {
                   <DataItemValue>{award.description}</DataItemValue>
                 </>
               )}
-              {award.pis?.length > 0 && (
+              {pis.length > 0 && (
                 <>
                   <DataItemLabel>Principal Investigator(s)</DataItemLabel>
                   <DataItemValue>
                     <SeparatedList>
-                      {award.pis.map((pi) => (
+                      {pis.map((pi) => (
                         <Link href={pi["@id"]} key={pi.uuid}>
                           {pi.title}
                         </Link>
@@ -54,12 +54,12 @@ export default function Award({ award, isJson }) {
                   </DataItemValue>
                 </>
               )}
-              {award.contact_pi && (
+              {contactPi && (
                 <>
                   <DataItemLabel>Contact P.I.</DataItemLabel>
                   <DataItemValue>
-                    <Link href={award.contact_pi["@id"]} key={award.contact_pi.uuid}>
-                      {award.contact_pi.title}
+                    <Link href={contactPi["@id"]} key={contactPi.uuid}>
+                      {contactPi.title}
                     </Link>
                   </DataItemValue>
                 </>
@@ -108,9 +108,9 @@ Award.propTypes = {
   // Award data to display on the page
   award: PropTypes.object.isRequired,
   // Principal investigator data associated with `award`
-  // pis: PropTypes.arrayOf(PropTypes.object).isRequired,
+  pis: PropTypes.arrayOf(PropTypes.object).isRequired,
   // The contact Principal Investigator of the grant.
-  // contactPi: PropTypes.object,
+  contactPi: PropTypes.object,
   // Is the format JSON?
   isJson: PropTypes.bool.isRequired,
 };
@@ -121,15 +121,15 @@ export async function getServerSideProps({ params, req, query }) {
     const request = new FetchRequest({ cookie: req.headers.cookie });
     const award = await request.getObject(`/awards/${params.name}`);
     if (FetchRequest.isResponseSuccess(award)) {
-      // const pis =
-      //   award.pis?.length > 0
-      //     ? await request.getMultipleObjects(award.pis, null, {
-      //         filterErrors: true,
-      //       })
-      //     : [];
-      // const contactPi = award.contact_pi
-      //   ? await request.getObject(award.contact_pi, null)
-      //   : null;
+      const pis =
+        award.pis?.length > 0
+          ? await request.getMultipleObjects(award.pis.map(pi => `${pi}?frame=object`), null, {
+              filterErrors: true,
+            })
+          : [];
+      const contactPi = award.contact_pi
+        ? await request.getObject(`${award.contact_pi}?frame=object`, null)
+        : null;
       const breadcrumbs = await buildBreadcrumbs(
         award,
         "name",
@@ -138,8 +138,8 @@ export async function getServerSideProps({ params, req, query }) {
       return {
         props: {
           award,
-          // pis,
-          // contactPi,
+          pis,
+          contactPi,
           isJson,
           pageContext: { title: award.name },
           breadcrumbs,

--- a/pages/awards/[name].js
+++ b/pages/awards/[name].js
@@ -119,7 +119,7 @@ export async function getServerSideProps({ params, req, query }) {
   return logTime(`/awards/${params.name}/`, async ({ params, req, query }) => {
     const isJson = isJsonFormat(query);
     const request = new FetchRequest({ cookie: req.headers.cookie });
-    const award = await request.getObject(`/awards/${params.name}/`);
+    const award = await request.getObject(`/awards/${params.name}?frame=object/`);
     if (FetchRequest.isResponseSuccess(award)) {
       const pis =
         award.pis?.length > 0

--- a/pages/human-genomic-variants/[uuid].js
+++ b/pages/human-genomic-variants/[uuid].js
@@ -18,6 +18,7 @@ import PagePreamble from "../../components/page-preamble";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import humanGenomicVariantTitle from "../../lib/human-genomic-variant-title";
 import { isJsonFormat } from "../../lib/query-utils";
+import { logTime } from "../../lib/general";
 
 export default function HumanGenomicVariant({ variant, isJson }) {
   // reference_sequence/refseq_id
@@ -77,24 +78,29 @@ HumanGenomicVariant.propTypes = {
 };
 
 export async function getServerSideProps({ params, req, query }) {
-  const isJson = isJsonFormat(query);
-  const request = new FetchRequest({ cookie: req.headers.cookie });
-  const variant = await request.getObject(
-    `/human-genomic-variants/${params.uuid}/`
-  );
-  if (FetchRequest.isResponseSuccess(variant)) {
-    const breadcrumbs = await buildBreadcrumbs(
-      variant,
-      "position",
-      req.headers.cookie
-    );
-    return {
-      props: {
-        variant,
-        breadcrumbs,
-        isJson,
-      },
-    };
-  }
-  return errorObjectToProps(variant);
+  return logTime(
+    `/human-genomic-variants/${params.uuid}/`,
+    async ({ params, req, query }) => {
+      const isJson = isJsonFormat(query);
+      const request = new FetchRequest({ cookie: req.headers.cookie });
+      const variant = await request.getObject(
+        `/human-genomic-variants/${params.uuid}/`
+      );
+      if (FetchRequest.isResponseSuccess(variant)) {
+        const breadcrumbs = await buildBreadcrumbs(
+          variant,
+          "position",
+          req.headers.cookie
+        );
+        return {
+          props: {
+            variant,
+            breadcrumbs,
+            isJson,
+          },
+        };
+      }
+      return errorObjectToProps(variant);
+    }
+  )({ params, req, query });
 }

--- a/pages/in-vitro-systems/[id].js
+++ b/pages/in-vitro-systems/[id].js
@@ -24,7 +24,7 @@ import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import { truthyOrZero } from "../../lib/general";
+import { logTime, truthyOrZero } from "../../lib/general";
 import { isJsonFormat } from "../../lib/query-utils";
 
 export default function InVitroSystem({
@@ -140,94 +140,110 @@ InVitroSystem.propTypes = {
 };
 
 export async function getServerSideProps({ params, req, query }) {
-  const isJson = isJsonFormat(query);
-  const request = new FetchRequest({ cookie: req.headers.cookie });
-  const inVitroSystem = await request.getObject(
-    `/in-vitro-systems/${params.id}/`
-  );
-  if (FetchRequest.isResponseSuccess(inVitroSystem)) {
-    const biosampleTerm = inVitroSystem.biosample_term
-      ? await request.getObject(inVitroSystem.biosample_term["@id"], null)
-      : null;
-    let diseaseTerms = [];
-    if (inVitroSystem.disease_terms) {
-      const diseaseTermPaths = inVitroSystem.disease_terms.map(
-        (diseaseTerm) => diseaseTerm["@id"]
+  return logTime(
+    `/in-vitro-systems/${params.id}/`,
+    async ({ params, req, query }) => {
+      const isJson = isJsonFormat(query);
+      const request = new FetchRequest({ cookie: req.headers.cookie });
+      const inVitroSystem = await request.getObject(
+        `/in-vitro-systems/${params.id}/`
       );
-      diseaseTerms = await request.getMultipleObjects(diseaseTermPaths, null, {
-        filterErrors: true,
-      });
-    }
-    const documents = inVitroSystem.documents
-      ? await request.getMultipleObjects(inVitroSystem.documents, null, {
-          filterErrors: true,
-        })
-      : [];
-    const donors = inVitroSystem.donors
-      ? await request.getMultipleObjects(inVitroSystem.donors, null, {
-          filterErrors: true,
-        })
-      : [];
-    const source = await request.getObject(inVitroSystem.source["@id"], null);
-    let treatments = [];
-    if (inVitroSystem.treatments) {
-      const treatmentPaths = inVitroSystem.treatments.map(
-        (treatment) => treatment["@id"]
-      );
-      treatments = await request.getMultipleObjects(treatmentPaths, null, {
-        filterErrors: true,
-      });
-    }
-    const pooledFrom =
-      inVitroSystem.pooled_from?.length > 0
-        ? await request.getMultipleObjects(inVitroSystem.pooled_from, null, {
+      if (FetchRequest.isResponseSuccess(inVitroSystem)) {
+        const biosampleTerm = inVitroSystem.biosample_term
+          ? await request.getObject(inVitroSystem.biosample_term["@id"], null)
+          : null;
+        let diseaseTerms = [];
+        if (inVitroSystem.disease_terms) {
+          const diseaseTermPaths = inVitroSystem.disease_terms.map(
+            (diseaseTerm) => diseaseTerm["@id"]
+          );
+          diseaseTerms = await request.getMultipleObjects(
+            diseaseTermPaths,
+            null,
+            {
+              filterErrors: true,
+            }
+          );
+        }
+        const documents = inVitroSystem.documents
+          ? await request.getMultipleObjects(inVitroSystem.documents, null, {
+              filterErrors: true,
+            })
+          : [];
+        const donors = inVitroSystem.donors
+          ? await request.getMultipleObjects(inVitroSystem.donors, null, {
+              filterErrors: true,
+            })
+          : [];
+        const source = await request.getObject(
+          inVitroSystem.source["@id"],
+          null
+        );
+        let treatments = [];
+        if (inVitroSystem.treatments) {
+          const treatmentPaths = inVitroSystem.treatments.map(
+            (treatment) => treatment["@id"]
+          );
+          treatments = await request.getMultipleObjects(treatmentPaths, null, {
             filterErrors: true,
-          })
-        : [];
-    const partOf = inVitroSystem.part_of
-      ? await request.getObject(inVitroSystem.part_of, null)
-      : null;
-    const targetedSampleTerm = inVitroSystem.targeted_sample_term
-      ? await request.getObject(inVitroSystem.targeted_sample_term, null)
-      : null;
-    const biomarkers =
-      inVitroSystem.biomarkers?.length > 0
-        ? await request.getMultipleObjects(inVitroSystem.biomarkers, null, {
-            filterErrors: true,
-          })
-        : [];
-    const breadcrumbs = await buildBreadcrumbs(
-      inVitroSystem,
-      "accession",
-      req.headers.cookie
-    );
-    const attribution = await buildAttribution(
-      inVitroSystem,
-      req.headers.cookie
-    );
-    return {
-      props: {
-        inVitroSystem,
-        biosampleTerm,
-        diseaseTerms,
-        documents,
-        donors,
-        source,
-        treatments,
-        pooledFrom,
-        partOf,
-        targetedSampleTerm,
-        biomarkers,
-        pageContext: {
-          title: `${biosampleTerm ? `${biosampleTerm.term_name} — ` : ""}${
-            inVitroSystem.accession
-          }`,
-        },
-        breadcrumbs,
-        attribution,
-        isJson,
-      },
-    };
-  }
-  return errorObjectToProps(inVitroSystem);
+          });
+        }
+        const pooledFrom =
+          inVitroSystem.pooled_from?.length > 0
+            ? await request.getMultipleObjects(
+                inVitroSystem.pooled_from,
+                null,
+                {
+                  filterErrors: true,
+                }
+              )
+            : [];
+        const partOf = inVitroSystem.part_of
+          ? await request.getObject(inVitroSystem.part_of, null)
+          : null;
+        const targetedSampleTerm = inVitroSystem.targeted_sample_term
+          ? await request.getObject(inVitroSystem.targeted_sample_term, null)
+          : null;
+        const biomarkers =
+          inVitroSystem.biomarkers?.length > 0
+            ? await request.getMultipleObjects(inVitroSystem.biomarkers, null, {
+                filterErrors: true,
+              })
+            : [];
+        const breadcrumbs = await buildBreadcrumbs(
+          inVitroSystem,
+          "accession",
+          req.headers.cookie
+        );
+        const attribution = await buildAttribution(
+          inVitroSystem,
+          req.headers.cookie
+        );
+        return {
+          props: {
+            inVitroSystem,
+            biosampleTerm,
+            diseaseTerms,
+            documents,
+            donors,
+            source,
+            treatments,
+            pooledFrom,
+            partOf,
+            targetedSampleTerm,
+            biomarkers,
+            pageContext: {
+              title: `${biosampleTerm ? `${biosampleTerm.term_name} — ` : ""}${
+                inVitroSystem.accession
+              }`,
+            },
+            breadcrumbs,
+            attribution,
+            isJson,
+          },
+        };
+      }
+      return errorObjectToProps(inVitroSystem);
+    }
+  )({ params, req, query });
 }

--- a/pages/measurement-sets/[id].js
+++ b/pages/measurement-sets/[id].js
@@ -28,6 +28,7 @@ import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
 import SeparatedList from "../../components/separated-list";
+import { LOG_GET_SERVER_SIDE_REQUEST_TIME } from "../../lib/constants";
 
 /**
  * Columns for the two file tables; both those with `illumina_read_type` (meta.hasReadType is true)
@@ -264,6 +265,9 @@ MeasurementSet.propTypes = {
 };
 
 export async function getServerSideProps({ params, req, query }) {
+  if (LOG_GET_SERVER_SIDE_REQUEST_TIME) {
+    const start = performance.now();
+  }
   const isJson = isJsonFormat(query);
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const measurementSet = await request.getObject(
@@ -320,6 +324,10 @@ export async function getServerSideProps({ params, req, query }) {
       measurementSet,
       req.headers.cookie
     );
+    if (LOG_GET_SERVER_SIDE_REQUEST_TIME) {
+      const duration = performance.now() - start;
+      console.log(`getServerSideProps /measurement-sets/${params.id}/: ${duration} ms`);
+    }
     return {
       props: {
         measurementSet,

--- a/pages/phenotype-terms/[name].js
+++ b/pages/phenotype-terms/[name].js
@@ -13,6 +13,7 @@ import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
+import { logTime } from "../../lib/general";
 
 export default function PhenotypeOntologyTerm({
   phenotypeOntologyTerm,
@@ -44,25 +45,30 @@ PhenotypeOntologyTerm.propTypes = {
 };
 
 export async function getServerSideProps({ params, req, query }) {
-  const isJson = isJsonFormat(query);
-  const request = new FetchRequest({ cookie: req.headers.cookie });
-  const phenotypeOntologyTerm = await request.getObject(
-    `/phenotype-terms/${params.name}/`
-  );
-  if (FetchRequest.isResponseSuccess(phenotypeOntologyTerm)) {
-    const breadcrumbs = await buildBreadcrumbs(
-      phenotypeOntologyTerm,
-      "term_id",
-      req.headers.cookie
-    );
-    return {
-      props: {
-        phenotypeOntologyTerm,
-        pageContext: { title: phenotypeOntologyTerm.term_id },
-        breadcrumbs,
-        isJson,
-      },
-    };
-  }
-  return errorObjectToProps(phenotypeOntologyTerm);
+  return logTime(
+    `/phenotype-terms/${params.name}/`,
+    async ({ params, req, query }) => {
+      const isJson = isJsonFormat(query);
+      const request = new FetchRequest({ cookie: req.headers.cookie });
+      const phenotypeOntologyTerm = await request.getObject(
+        `/phenotype-terms/${params.name}/`
+      );
+      if (FetchRequest.isResponseSuccess(phenotypeOntologyTerm)) {
+        const breadcrumbs = await buildBreadcrumbs(
+          phenotypeOntologyTerm,
+          "term_id",
+          req.headers.cookie
+        );
+        return {
+          props: {
+            phenotypeOntologyTerm,
+            pageContext: { title: phenotypeOntologyTerm.term_id },
+            breadcrumbs,
+            isJson,
+          },
+        };
+      }
+      return errorObjectToProps(phenotypeOntologyTerm);
+    }
+  )({ params, req, query });
 }

--- a/pages/phenotypic-features/[id].js
+++ b/pages/phenotypic-features/[id].js
@@ -19,7 +19,7 @@ import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import { truthyOrZero } from "../../lib/general";
+import { logTime, truthyOrZero } from "../../lib/general";
 import { getPhenotypicFeatureTitle } from "../../lib/phenotypic-feature";
 import { isJsonFormat } from "../../lib/query-utils";
 
@@ -78,31 +78,36 @@ PhenotypicFeature.propTypes = {
 };
 
 export async function getServerSideProps({ params, req, query }) {
-  const isJson = isJsonFormat(query);
-  const request = new FetchRequest({ cookie: req.headers.cookie });
-  const phenotypicFeature = await request.getObject(
-    `/phenotypic-features/${params.id}/`
-  );
-  if (FetchRequest.isResponseSuccess(phenotypicFeature)) {
-    const attribution = await buildAttribution(
-      phenotypicFeature,
-      req.headers.cookie
-    );
-    const title = getPhenotypicFeatureTitle(phenotypicFeature);
-    const breadcrumbs = await buildBreadcrumbs(
-      phenotypicFeature,
-      "uuid",
-      req.headers.cookie
-    );
-    return {
-      props: {
-        phenotypicFeature,
-        pageContext: { title },
-        breadcrumbs,
-        isJson,
-        attribution,
-      },
-    };
-  }
-  return errorObjectToProps(phenotypicFeature);
+  logTime(
+    `/phenotypic-features/${params.id}/`,
+    async ({ params, req, query }) => {
+      const isJson = isJsonFormat(query);
+      const request = new FetchRequest({ cookie: req.headers.cookie });
+      const phenotypicFeature = await request.getObject(
+        `/phenotypic-features/${params.id}/`
+      );
+      if (FetchRequest.isResponseSuccess(phenotypicFeature)) {
+        const attribution = await buildAttribution(
+          phenotypicFeature,
+          req.headers.cookie
+        );
+        const title = getPhenotypicFeatureTitle(phenotypicFeature);
+        const breadcrumbs = await buildBreadcrumbs(
+          phenotypicFeature,
+          "uuid",
+          req.headers.cookie
+        );
+        return {
+          props: {
+            phenotypicFeature,
+            pageContext: { title },
+            breadcrumbs,
+            isJson,
+            attribution,
+          },
+        };
+      }
+      return errorObjectToProps(phenotypicFeature);
+    }
+  )({ params, req, query });
 }

--- a/pages/platform-terms/[name].js
+++ b/pages/platform-terms/[name].js
@@ -13,6 +13,7 @@ import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
+import { logTime } from "../../lib/general";
 
 export default function PlatformOntologyTerm({ platformOntologyTerm, isJson }) {
   return (
@@ -41,25 +42,30 @@ PlatformOntologyTerm.propTypes = {
 };
 
 export async function getServerSideProps({ params, req, query }) {
-  const isJson = isJsonFormat(query);
-  const request = new FetchRequest({ cookie: req.headers.cookie });
-  const platformOntologyTerm = await request.getObject(
-    `/platform-terms/${params.name}/`
-  );
-  if (FetchRequest.isResponseSuccess(platformOntologyTerm)) {
-    const breadcrumbs = await buildBreadcrumbs(
-      platformOntologyTerm,
-      "term_id",
-      req.headers.cookie
-    );
-    return {
-      props: {
-        platformOntologyTerm,
-        pageContext: { title: platformOntologyTerm.term_id },
-        breadcrumbs,
-        isJson,
-      },
-    };
-  }
-  return errorObjectToProps(platformOntologyTerm);
+  return logTime(
+    `/platform-terms/${params.name}/`,
+    async ({ params, req, query }) => {
+      const isJson = isJsonFormat(query);
+      const request = new FetchRequest({ cookie: req.headers.cookie });
+      const platformOntologyTerm = await request.getObject(
+        `/platform-terms/${params.name}/`
+      );
+      if (FetchRequest.isResponseSuccess(platformOntologyTerm)) {
+        const breadcrumbs = await buildBreadcrumbs(
+          platformOntologyTerm,
+          "term_id",
+          req.headers.cookie
+        );
+        return {
+          props: {
+            platformOntologyTerm,
+            pageContext: { title: platformOntologyTerm.term_id },
+            breadcrumbs,
+            isJson,
+          },
+        };
+      }
+      return errorObjectToProps(platformOntologyTerm);
+    }
+  )({ params, req, query });
 }

--- a/pages/rodent-donors/[uuid].js
+++ b/pages/rodent-donors/[uuid].js
@@ -25,6 +25,7 @@ import buildAttribution from "../../lib/attribution";
 import PhenotypicFeatureTable from "../../components/phenotypic-feature-table";
 import ProductInfo from "../../components/product-info";
 import { isJsonFormat } from "../../lib/query-utils";
+import { logTime } from "../../lib/general";
 
 export default function RodentDonor({
   donor,
@@ -112,47 +113,52 @@ RodentDonor.propTypes = {
 };
 
 export async function getServerSideProps({ params, req, query }) {
-  const isJson = isJsonFormat(query);
-  const request = new FetchRequest({ cookie: req.headers.cookie });
-  const donor = await request.getObject(`/rodent-donors/${params.uuid}/`);
-  if (FetchRequest.isResponseSuccess(donor)) {
-    const documents = donor.documents
-      ? await request.getMultipleObjects(donor.documents, null, {
-          filterErrors: true,
-        })
-      : [];
-    const parents = donor.parents
-      ? await request.getMultipleObjects(donor.parents, null, {
-          filterErrors: true,
-        })
-      : [];
-    const phenotypicFeatures = donor.phenotypic_features
-      ? await request.getMultipleObjects(donor.phenotypic_features, null, {
-          filterErrors: true,
-        })
-      : [];
-    const source = donor.source
-      ? await request.getObject(donor.source["@id"])
-      : null;
-    const breadcrumbs = await buildBreadcrumbs(
-      donor,
-      "accession",
-      req.headers.cookie
-    );
-    const attribution = await buildAttribution(donor, req.headers.cookie);
-    return {
-      props: {
-        donor,
-        documents,
-        parents,
-        phenotypicFeatures,
-        source,
-        pageContext: { title: donor.accession },
-        breadcrumbs,
-        attribution,
-        isJson,
-      },
-    };
-  }
-  return errorObjectToProps(donor);
+  return logTime(
+    `/rodent-donors/${params.uuid}/`,
+    async ({ params, req, query }) => {
+      const isJson = isJsonFormat(query);
+      const request = new FetchRequest({ cookie: req.headers.cookie });
+      const donor = await request.getObject(`/rodent-donors/${params.uuid}/`);
+      if (FetchRequest.isResponseSuccess(donor)) {
+        const documents = donor.documents
+          ? await request.getMultipleObjects(donor.documents, null, {
+              filterErrors: true,
+            })
+          : [];
+        const parents = donor.parents
+          ? await request.getMultipleObjects(donor.parents, null, {
+              filterErrors: true,
+            })
+          : [];
+        const phenotypicFeatures = donor.phenotypic_features
+          ? await request.getMultipleObjects(donor.phenotypic_features, null, {
+              filterErrors: true,
+            })
+          : [];
+        const source = donor.source
+          ? await request.getObject(donor.source["@id"])
+          : null;
+        const breadcrumbs = await buildBreadcrumbs(
+          donor,
+          "accession",
+          req.headers.cookie
+        );
+        const attribution = await buildAttribution(donor, req.headers.cookie);
+        return {
+          props: {
+            donor,
+            documents,
+            parents,
+            phenotypicFeatures,
+            source,
+            pageContext: { title: donor.accession },
+            breadcrumbs,
+            attribution,
+            isJson,
+          },
+        };
+      }
+      return errorObjectToProps(donor);
+    }
+  )({ params, req, query });
 }

--- a/pages/sample-terms/[name].js
+++ b/pages/sample-terms/[name].js
@@ -19,6 +19,7 @@ import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
+import { logTime } from "../../lib/general";
 
 export default function SampleOntologyTerm({ sampleOntologyTerm, isJson }) {
   return (
@@ -88,25 +89,30 @@ SampleOntologyTerm.propTypes = {
 };
 
 export async function getServerSideProps({ params, req, query }) {
-  const isJson = isJsonFormat(query);
-  const request = new FetchRequest({ cookie: req.headers.cookie });
-  const sampleOntologyTerm = await request.getObject(
-    `/sample-terms//${params.name}/`
-  );
-  if (FetchRequest.isResponseSuccess(sampleOntologyTerm)) {
-    const breadcrumbs = await buildBreadcrumbs(
-      sampleOntologyTerm,
-      "term_id",
-      req.headers.cookie
-    );
-    return {
-      props: {
-        sampleOntologyTerm,
-        pageContext: { title: sampleOntologyTerm.term_id },
-        breadcrumbs,
-        isJson,
-      },
-    };
-  }
-  return errorObjectToProps(sampleOntologyTerm);
+  return logTime(
+    `/sample-terms//${params.name}/`,
+    async ({ params, req, query }) => {
+      const isJson = isJsonFormat(query);
+      const request = new FetchRequest({ cookie: req.headers.cookie });
+      const sampleOntologyTerm = await request.getObject(
+        `/sample-terms//${params.name}/`
+      );
+      if (FetchRequest.isResponseSuccess(sampleOntologyTerm)) {
+        const breadcrumbs = await buildBreadcrumbs(
+          sampleOntologyTerm,
+          "term_id",
+          req.headers.cookie
+        );
+        return {
+          props: {
+            sampleOntologyTerm,
+            pageContext: { title: sampleOntologyTerm.term_id },
+            breadcrumbs,
+            isJson,
+          },
+        };
+      }
+      return errorObjectToProps(sampleOntologyTerm);
+    }
+  )({ params, req, query });
 }


### PR DESCRIPTION
This adds two config options in next.config.js that sets if the site should log to console output the time each fetch request takes and how long `getServerSideProps` takes for each page.

The utility function `logTime` takes a label and a function which will log how long the function takes using the label in the logging. This is used in getServerSideProps.

Then fetch-request can log how long it takes. So when we load an object page we can see both the getServerSideProps total length as well as all the fetch timings.