### PR TITLE
IGVF-770 Display formatted pages for unknown objects

### DIFF
--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,7 +52,6 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -52,6 +52,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
+            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '72'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/components/__tests__/unspecified-property.test.js
+++ b/components/__tests__/unspecified-property.test.js
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import UnspecifiedProperty from "../unspecified-property";
+
+describe("Test UnspecifiedProperty component", () => {
+  it("renders strings and numbers", () => {
+    render(<UnspecifiedProperty property="hello" />);
+    expect(screen.getByText("hello")).toBeInTheDocument();
+
+    render(<UnspecifiedProperty property={5} />);
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("renders booleans", () => {
+    render(<UnspecifiedProperty property={true} />);
+    expect(screen.getByText("true")).toBeInTheDocument();
+
+    render(<UnspecifiedProperty property={false} />);
+    expect(screen.getByText("false")).toBeInTheDocument();
+  });
+
+  it("renders arrays of strings and numbers", () => {
+    render(<UnspecifiedProperty property={["hello", 5]} />);
+    expect(screen.getByText("hello, 5")).toBeInTheDocument();
+  });
+
+  it("renders an embedded object with an @id", () => {
+    const property = {
+      "@id": "/example/path/",
+      title: "Example",
+    };
+    render(<UnspecifiedProperty property={property} />);
+    expect(screen.getByRole("link")).toHaveTextContent("/example/path/");
+  });
+
+  it("renders an array of embedded objects with @ids", () => {
+    const property = [
+      {
+        "@id": "/example/path/",
+        title: "Example",
+      },
+      {
+        "@id": "/example/path2/",
+        title: "Example 2",
+      },
+    ];
+    render(<UnspecifiedProperty property={property} />);
+    expect(
+      screen.getByRole("link", { name: "/example/path/" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "/example/path2/" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders an embedded object without an @id as JSON", () => {
+    const property = {
+      title: "Example",
+    };
+    render(<UnspecifiedProperty property={property} />);
+    expect(screen.getByText('{"title":"Example"}')).toBeInTheDocument();
+  });
+
+  it("renders an array of embedded objects without @ids as JSON", () => {
+    const property = [
+      {
+        title: "Example",
+      },
+      {
+        title: "Example 2",
+      },
+    ];
+    render(<UnspecifiedProperty property={property} />);
+    expect(
+      screen.getByText('[{"title":"Example"},{"title":"Example 2"}]')
+    ).toBeInTheDocument();
+  });
+});

--- a/components/common-data-items.js
+++ b/components/common-data-items.js
@@ -3,6 +3,11 @@
  * derive from others, so you would typically use these components to display properties within a
  * parent schema so that the components displaying objects for the child schemas can all display
  * the same parent properties.
+ *
+ * Each common data item renderer component in this module should include a `commonProperties`
+ * property that lists the properties it displays. That lets the `UnknownTypePanel` component know
+ * which remaining properties to display as generic properties. Be careful to maintain this list so
+ * we don't have duplicate or missing properties for objects that don't have a custom page renderer.
  */
 
 // node_modules
@@ -21,28 +26,28 @@ import { truthyOrZero } from "../lib/general";
 /**
  * Display the data items common to all donor-derived objects.
  */
-export function DonorDataItems({ donor, parents, children }) {
+export function DonorDataItems({ item, parents = null, children }) {
   return (
     <>
-      {donor.taxa && (
+      {item.taxa && (
         <>
           <DataItemLabel>Taxa</DataItemLabel>
-          <DataItemValue>{donor.taxa}</DataItemValue>
+          <DataItemValue>{item.taxa}</DataItemValue>
         </>
       )}
-      {donor.ethnicities?.length > 0 && (
+      {item.ethnicities?.length > 0 && (
         <>
           <DataItemLabel>Ethnicities</DataItemLabel>
-          <DataItemValue>{donor.ethnicities.join(", ")}</DataItemValue>
+          <DataItemValue>{item.ethnicities.join(", ")}</DataItemValue>
         </>
       )}
-      {donor.sex && (
+      {item.sex && (
         <>
           <DataItemLabel>Sex</DataItemLabel>
-          <DataItemValue>{donor.sex}</DataItemValue>
+          <DataItemValue>{item.sex}</DataItemValue>
         </>
       )}
-      {parents.length > 0 && (
+      {parents?.length > 0 && (
         <>
           <DataItemLabel>Parents</DataItemLabel>
           <DataItemValue>
@@ -61,39 +66,39 @@ export function DonorDataItems({ donor, parents, children }) {
         </>
       )}
       {children}
-      {donor.submitter_comment && (
+      {item.submitter_comment && (
         <>
           <DataItemLabel>Submitter Comment</DataItemLabel>
-          <DataItemValue>{donor.submitter_comment}</DataItemValue>
+          <DataItemValue>{item.submitter_comment}</DataItemValue>
         </>
       )}
-      {donor.revoke_detail && (
+      {item.revoke_detail && (
         <>
           <DataItemLabel>Revoke Detail</DataItemLabel>
-          <DataItemValue>{donor.revoke_detail}</DataItemValue>
+          <DataItemValue>{item.revoke_detail}</DataItemValue>
         </>
       )}
-      {donor.aliases?.length > 0 && (
+      {item.aliases?.length > 0 && (
         <>
           <DataItemLabel>Aliases</DataItemLabel>
           <DataItemValue>
-            <AliasList aliases={donor.aliases} />
+            <AliasList aliases={item.aliases} />
           </DataItemValue>
         </>
       )}
-      {donor.references?.length > 0 && (
+      {item.references?.length > 0 && (
         <>
           <DataItemLabel>References</DataItemLabel>
           <DataItemValue>
-            <DbxrefList dbxrefs={donor.references} />
+            <DbxrefList dbxrefs={item.references} />
           </DataItemValue>
         </>
       )}
-      {donor.url && (
+      {item.url && (
         <>
           <DataItemLabel>URL</DataItemLabel>
           <DataItemValue>
-            <Link href={donor.url}>{donor.url}</Link>
+            <Link href={item.url}>{item.url}</Link>
           </DataItemValue>
         </>
       )}
@@ -103,16 +108,27 @@ export function DonorDataItems({ donor, parents, children }) {
 
 DonorDataItems.propTypes = {
   // Object derived from donor.json schema
-  donor: PropTypes.object.isRequired,
+  item: PropTypes.object.isRequired,
   // Parents of this donor
-  parents: PropTypes.arrayOf(PropTypes.object).isRequired,
+  parents: PropTypes.arrayOf(PropTypes.object),
 };
+
+DonorDataItems.commonProperties = [
+  "aliases",
+  "ethnicities",
+  "references",
+  "revoke_detail",
+  "sex",
+  "submitter_comment",
+  "taxa",
+  "url",
+];
 
 /**
  * Display data items common to all sample-derived objects.
  */
 export function SampleDataItems({
-  sample,
+  item,
   source = null,
   options = {
     dateObtainedTitle: "Date Obtained",
@@ -122,79 +138,79 @@ export function SampleDataItems({
   return (
     <>
       <DataItemLabel>Summary</DataItemLabel>
-      <DataItemValue>{sample.summary}</DataItemValue>
+      <DataItemValue>{item.summary}</DataItemValue>
       {children}
-      {(sample.lot_id || source) && (
+      {(item.lot_id || source) && (
         <>
           <DataItemLabel>Source</DataItemLabel>
           <DataItemValue>
             <ProductInfo
-              lotId={sample.lot_id}
-              productId={sample.product_id}
+              lotId={item.lot_id}
+              productId={item.product_id}
               source={source}
             />
           </DataItemValue>
         </>
       )}
-      {truthyOrZero(sample.starting_amount) && (
+      {truthyOrZero(item.starting_amount) && (
         <>
           <DataItemLabel>Starting Amount</DataItemLabel>
           <DataItemValue>
-            {sample.starting_amount}
-            {sample.starting_amount_units ? (
-              <> {sample.starting_amount_units}</>
+            {item.starting_amount}
+            {item.starting_amount_units ? (
+              <> {item.starting_amount_units}</>
             ) : (
               ""
             )}
           </DataItemValue>
         </>
       )}
-      {sample.date_obtained && (
+      {item.date_obtained && (
         <>
           <DataItemLabel>{options.dateObtainedTitle}</DataItemLabel>
-          <DataItemValue>{formatDate(sample.date_obtained)}</DataItemValue>
+          <DataItemValue>{formatDate(item.date_obtained)}</DataItemValue>
         </>
       )}
-      {sample.url && (
+      {item.url && (
         <>
           <DataItemLabel>Additional Information</DataItemLabel>
           <DataItemValue>
             <a
               className="break-all"
-              href={sample.url}
+              href={item.url}
               target="_blank"
               rel="noreferrer"
             >
-              {sample.url}
+              {item.url}
             </a>
           </DataItemValue>
         </>
       )}
-      {sample.dbxrefs?.length > 0 && (
+      {item.dbxrefs?.length > 0 && (
         <>
           <DataItemLabel>External Resources</DataItemLabel>
           <DataItemValue>
-            <DbxrefList dbxrefs={sample.dbxrefs} />
+            <DbxrefList dbxrefs={item.dbxrefs} />
           </DataItemValue>
         </>
       )}
-      {sample.submitter_comment && (
+      {item.submitter_comment && (
         <>
           <DataItemLabel>Submitter Comment</DataItemLabel>
-          <DataItemValue>{sample.submitter_comment}</DataItemValue>
+          <DataItemValue>{item.submitter_comment}</DataItemValue>
         </>
       )}
-      {sample.revoke_detail && (
+      {item.revoke_detail && (
         <>
           <DataItemLabel>Revoke Detail</DataItemLabel>
-          <DataItemValue>{sample.revoke_detail}</DataItemValue>
+          <DataItemValue>{item.revoke_detail}</DataItemValue>
         </>
       )}
-      {sample.aliases && (
+      {item.aliases && (
         <>
           <DataItemLabel>Aliases</DataItemLabel>
           <DataItemValue>
-            <AliasList aliases={sample.aliases} />
+            <AliasList aliases={item.aliases} />
           </DataItemValue>
         </>
       )}
@@ -204,7 +220,7 @@ export function SampleDataItems({
 
 SampleDataItems.propTypes = {
   // Object derived from the sample.json schema
-  sample: PropTypes.object.isRequired,
+  item: PropTypes.object.isRequired,
   // Source lab or source for this sample
   source: PropTypes.object,
   // General options to alter the display of the data items
@@ -214,26 +230,39 @@ SampleDataItems.propTypes = {
   }),
 };
 
+SampleDataItems.commonProperties = [
+  "aliases",
+  "date_obtained",
+  "dbxrefs",
+  "lot_id",
+  "revoke_detail",
+  "starting_amount",
+  "starting_amount_units",
+  "summary",
+  "url",
+  "submitter_comment",
+];
+
 /**
  * Display data items common to all biosample-derived objects.
  */
 export function BiosampleDataItems({
-  biosample,
+  item,
   source = null,
-  donors = [],
+  donors = null,
   biosampleTerm = null,
   diseaseTerms = null,
-  pooledFrom,
-  partOf,
+  pooledFrom = null,
+  partOf = null,
   classification = null,
   children,
 }) {
   return (
-    <SampleDataItems sample={biosample} source={source}>
-      {biosample.taxa && (
+    <SampleDataItems item={item} source={source}>
+      {item.taxa && (
         <>
           <DataItemLabel>Taxa</DataItemLabel>
-          <DataItemValue>{biosample.taxa}</DataItemValue>
+          <DataItemValue>{item.taxa}</DataItemValue>
         </>
       )}
       {biosampleTerm && (
@@ -250,34 +279,34 @@ export function BiosampleDataItems({
           <DataItemValue>{classification}</DataItemValue>
         </>
       )}
-      {biosample.sex && (
+      {item.sex && (
         <>
           <DataItemLabel>Sex</DataItemLabel>
-          <DataItemValue>{biosample.sex}</DataItemValue>
+          <DataItemValue>{item.sex}</DataItemValue>
         </>
       )}
       <>
         <DataItemLabel>Age</DataItemLabel>
         <DataItemValue>
-          {biosample.age === "unknown"
-            ? biosample.embryonic
+          {item.age === "unknown"
+            ? item.embryonic
               ? "Embryonic"
               : "unknown"
-            : biosample.embryonic
-            ? `Emryonic ${biosample.age}`
-            : biosample.age}
-          {biosample.age_units ? (
+            : item.embryonic
+            ? `Embryonic ${item.age}`
+            : item.age}
+          {item.age_units ? (
             <>
               {" "}
-              {biosample.age_units}
-              {biosample.age !== "1" ? "s" : ""}
+              {item.age_units}
+              {item.age !== "1" ? "s" : ""}
             </>
           ) : (
             ""
           )}
         </DataItemValue>
       </>
-      {pooledFrom.length > 0 && (
+      {pooledFrom?.length > 0 && (
         <>
           <DataItemLabel>Biosample(s) Pooled From</DataItemLabel>
           <DataItemValue>
@@ -313,15 +342,13 @@ export function BiosampleDataItems({
           </DataItemValue>
         </>
       )}
-      {biosample.nih_institutional_certification && (
+      {item.nih_institutional_certification && (
         <>
           <DataItemLabel>NIH Institutional Certification</DataItemLabel>
-          <DataItemValue>
-            {biosample.nih_institutional_certification}
-          </DataItemValue>
+          <DataItemValue>{item.nih_institutional_certification}</DataItemValue>
         </>
       )}
-      {donors.length > 0 && (
+      {donors?.length > 0 && (
         <>
           <DataItemLabel>Donors</DataItemLabel>
           <DataItemValue>
@@ -342,7 +369,7 @@ export function BiosampleDataItems({
 
 BiosampleDataItems.propTypes = {
   // Object derived from the biosample.json schema
-  biosample: PropTypes.object.isRequired,
+  item: PropTypes.object.isRequired,
   // Source lab or source for this biosample
   source: PropTypes.object,
   // Donors for this biosample
@@ -359,17 +386,25 @@ BiosampleDataItems.propTypes = {
   classification: PropTypes.string,
 };
 
+BiosampleDataItems.commonProperties = [
+  "age",
+  "age_units",
+  "nih_institutional_certification",
+  "sex",
+  "taxa",
+];
+
 /**
  * Display data items common to all ontology-term-derived objects.
  */
-export function OntologyTermDataItems({ ontologyTerm, isA, children }) {
+export function OntologyTermDataItems({ item, isA, children }) {
   return (
     <>
       <DataItemLabel>Term Name</DataItemLabel>
-      <DataItemValue>{ontologyTerm.term_name}</DataItemValue>
+      <DataItemValue>{item.term_name}</DataItemValue>
       <DataItemLabel>External Reference</DataItemLabel>
       <DataItemValue>
-        <DbxrefList dbxrefs={[ontologyTerm.term_id]} />
+        <DbxrefList dbxrefs={[item.term_id]} />
       </DataItemValue>
       {isA?.length > 0 && (
         <>
@@ -385,31 +420,31 @@ export function OntologyTermDataItems({ ontologyTerm, isA, children }) {
           </DataItemValue>
         </>
       )}
-      {ontologyTerm.synonyms.length > 0 && (
+      {item.synonyms.length > 0 && (
         <>
           <DataItemLabel>Synonyms</DataItemLabel>
-          <DataItemValue>{ontologyTerm.synonyms.join(", ")}</DataItemValue>
+          <DataItemValue>{item.synonyms.join(", ")}</DataItemValue>
         </>
       )}
-      {ontologyTerm.aliases?.length > 0 && (
+      {item.aliases?.length > 0 && (
         <>
           <DataItemLabel>Aliases</DataItemLabel>
           <DataItemValue>
-            <AliasList aliases={ontologyTerm.aliases} />
+            <AliasList aliases={item.aliases} />
           </DataItemValue>
         </>
       )}
-      {ontologyTerm.summary && (
+      {item.summary && (
         <>
           <DataItemLabel>Summary</DataItemLabel>
-          <DataItemValue>{ontologyTerm.summary}</DataItemValue>
+          <DataItemValue>{item.summary}</DataItemValue>
         </>
       )}
       {children}
-      {ontologyTerm.submitter_comment && (
+      {item.submitter_comment && (
         <>
           <DataItemLabel>Submitter Comment</DataItemLabel>
-          <DataItemValue>{ontologyTerm.submitter_comment}</DataItemValue>
+          <DataItemValue>{item.submitter_comment}</DataItemValue>
         </>
       )}
     </>
@@ -418,15 +453,29 @@ export function OntologyTermDataItems({ ontologyTerm, isA, children }) {
 
 OntologyTermDataItems.propTypes = {
   // Ontology term object
-  ontologyTerm: PropTypes.object.isRequired,
+  item: PropTypes.object.isRequired,
   // List of term names
   isA: PropTypes.arrayOf(PropTypes.object),
 };
 
+OntologyTermDataItems.commonProperties = [
+  "aliases",
+  "submitter_comment",
+  "summary",
+  "synonyms",
+  "term_id",
+  "term_name",
+];
+
 /**
  * Display data items common to all file-derived objects.
  */
-export function FileDataItems({ file, fileSet = null, derivedFrom, children }) {
+export function FileDataItems({
+  item,
+  fileSet = null,
+  derivedFrom = null,
+  children,
+}) {
   return (
     <>
       {fileSet && (
@@ -444,24 +493,24 @@ export function FileDataItems({ file, fileSet = null, derivedFrom, children }) {
         </>
       )}
       <DataItemLabel>File Format</DataItemLabel>
-      <DataItemValue>{file.file_format}</DataItemValue>
+      <DataItemValue>{item.file_format}</DataItemValue>
       <DataItemLabel>Content Type</DataItemLabel>
-      <DataItemValue>{file.content_type}</DataItemValue>
+      <DataItemValue>{item.content_type}</DataItemValue>
       <DataItemLabel>md5sum</DataItemLabel>
-      <DataItemValue>{file.md5sum}</DataItemValue>
-      {file.content_md5sum && (
+      <DataItemValue>{item.md5sum}</DataItemValue>
+      {item.content_md5sum && (
         <>
           <DataItemLabel>Content MD5sum</DataItemLabel>
-          <DataItemValue>{file.content_md5sum}</DataItemValue>
+          <DataItemValue>{item.content_md5sum}</DataItemValue>
         </>
       )}
-      {truthyOrZero(file.file_size) && (
+      {truthyOrZero(item.file_size) && (
         <>
           <DataItemLabel>File Size</DataItemLabel>
-          <DataItemValue>{file.file_size}</DataItemValue>
+          <DataItemValue>{item.file_size}</DataItemValue>
         </>
       )}
-      {derivedFrom.length > 0 && (
+      {derivedFrom?.length > 0 && (
         <>
           <DataItemLabel>Derived From</DataItemLabel>
           <DataItemValue>
@@ -480,19 +529,19 @@ export function FileDataItems({ file, fileSet = null, derivedFrom, children }) {
         </>
       )}
       {children}
-      {file.aliases?.length > 0 && (
+      {item.aliases?.length > 0 && (
         <>
           <DataItemLabel>Aliases</DataItemLabel>
           <DataItemValue>
-            <AliasList aliases={file.aliases} />
+            <AliasList aliases={item.aliases} />
           </DataItemValue>
         </>
       )}
-      {file.dbxrefs?.length > 0 && (
+      {item.dbxrefs?.length > 0 && (
         <>
           <DataItemLabel>External Resources</DataItemLabel>
           <DataItemValue>
-            <DbxrefList dbxrefs={file.dbxrefs} />
+            <DbxrefList dbxrefs={item.dbxrefs} />
           </DataItemValue>
         </>
       )}
@@ -502,9 +551,61 @@ export function FileDataItems({ file, fileSet = null, derivedFrom, children }) {
 
 FileDataItems.propTypes = {
   // file object common for all file types
-  file: PropTypes.object.isRequired,
+  item: PropTypes.object.isRequired,
   // file set for this file
   fileSet: PropTypes.object,
   // files this file is derived from
-  derivedFrom: PropTypes.array.isRequired,
+  derivedFrom: PropTypes.array,
 };
+
+FileDataItems.commonProperties = [
+  "aliases",
+  "content_md5sum",
+  "content_type",
+  "dbxrefs",
+  "file_format",
+  "file_size",
+  "md5sum",
+];
+
+/**
+ * `UnknownTypePanel` uses the following data and functions to use common data item renderers based
+ * on the parent type of unknown objects.
+ */
+
+/**
+ * When adding a new common data item renderer component, add the @type that it handles as a key to
+ * this object, and the corresponding component as the value. Keep the object keys in alphabetical
+ * order to make them easier to find by visually scanning. This lets `UnknownTypePanel` find the
+ * appropriate common data item renderer component for the parent type of an unknown object type.
+ */
+const commonDataRenderers = {
+  Biosample: BiosampleDataItems,
+  Donor: DonorDataItems,
+  File: FileDataItems,
+  OntologyTerm: OntologyTermDataItems,
+};
+
+/**
+ * Data item renderer to use when no common data item renderer exists for the given unknown item's
+ * parent type. It just lets `UnknownTypePanel` render all the unknown item's properties without
+ * any common properties.
+ */
+function EmptyDataItems({ children }) {
+  return <>{children}</>;
+}
+
+/**
+ * Find a common data item renderer component, if any, appropriate for the given unknown item
+ * object. Normally an appropriate renderer handles the unknown object's parent type. Return that
+ * React component, or the `EmptyDataItems` renderer if none found.
+ * @param {object} item Generic object
+ * @returns {React.Component} Common data item renderer component
+ */
+export function findCommonDataRenderer(item) {
+  const definedCommonDataTypes = Object.keys(commonDataRenderers);
+  const commonDataType = item["@type"].find((type) =>
+    definedCommonDataTypes.includes(type)
+  );
+  return commonDataType ? commonDataRenderers[commonDataType] : EmptyDataItems;
+}

--- a/components/data-area.js
+++ b/components/data-area.js
@@ -19,7 +19,7 @@ import PropTypes from "prop-types";
 export function DataPanel({ className = "", children }) {
   return (
     <div
-      className={`border border-panel bg-panel p-4 ${className}`}
+      className={`border border-panel bg-panel p-4 @container ${className}`}
       data-testid="datapanel"
     >
       {children}
@@ -40,7 +40,7 @@ DataPanel.propTypes = {
 export function DataArea({ children }) {
   return (
     <div
-      className="md:grid md:grid-cols-data-item md:gap-4"
+      className="@md:grid @md:grid-cols-data-item @md:gap-4"
       data-testid="dataarea"
     >
       {children}
@@ -65,7 +65,7 @@ export function DataAreaTitle({ children }) {
 export function DataItemLabel({ className = "", children }) {
   return (
     <div
-      className={`mt-4 break-words font-semibold text-data-label first:mt-0 dark:text-gray-400 md:mt-0 ${className}`}
+      className={`mt-4 break-words font-semibold text-data-label first:mt-0 @md:mt-0 dark:text-gray-400 ${className}`}
       data-testid="dataitemlabel"
     >
       {children}
@@ -84,7 +84,7 @@ DataItemLabel.propTypes = {
 export function DataItemValue({ children }) {
   return (
     <div
-      className="mb-4 font-medium text-data-value last:mb-0 md:mb-0"
+      className="mb-4 font-medium text-data-value last:mb-0 @md:mb-0 @md:min-w-0"
       data-testid="dataitemvalue"
     >
       {children}

--- a/components/report/cell-renderers.js
+++ b/components/report/cell-renderers.js
@@ -12,9 +12,9 @@ import PropTypes from "prop-types";
 // components
 import ChromosomeLocations from "../chromosome-locations";
 import SeparatedList from "../separated-list";
+import UnspecifiedProperty from "../unspecified-property";
 // lib
 import { attachmentToServerHref } from "../../lib/attachment";
-import { truncateJson } from "../../lib/general";
 
 /**
  * Display the @id of an object as a link to the object's page. This works much like the `Path`
@@ -297,41 +297,10 @@ function UnknownObject({ id, source }) {
   }
 
   if (property) {
-    // Determine the display method for the embedded property depending on its type.
-    let displayedProperty = null;
-    if (typeof property === "string" || typeof property === "number") {
-      displayedProperty = property;
-    } else if (typeof property === "object") {
-      if (Array.isArray(property)) {
-        if (property.length > 0) {
-          if (typeof property[0] === "object") {
-            if (property[0]["@id"]) {
-              // Array of objects with @ids; join their @ids with commas.
-              displayedProperty = property
-                .map((item) => item["@id"])
-                .join(", ");
-            } else {
-              // Array of objects without @ids; display it as JSON.
-              displayedProperty = truncateJson(property);
-            }
-          } else {
-            // Array of simple types; join them with commas.
-            displayedProperty = property.join(", ");
-          }
-        }
-      } else {
-        if (property["@id"]) {
-          // The embedded property is an object with an @id. Display the @id.
-          displayedProperty = property["@id"];
-        } else {
-          // The embedded property is an object without an @id. Display it as JSON.
-          displayedProperty = truncateJson(property);
-        }
-      }
-    }
-
     return (
-      <div data-testid="cell-type-unknown-object">{displayedProperty}</div>
+      <div data-testid="cell-type-unknown-object">
+        <UnspecifiedProperty property={property} />
+      </div>
     );
   }
 

--- a/components/unknown-type-panel.js
+++ b/components/unknown-type-panel.js
@@ -1,0 +1,82 @@
+// node_modules
+import _ from "lodash";
+import PropTypes from "prop-types";
+import { Fragment, useContext } from "react";
+// components
+import Attribution from "./attribution";
+import { findCommonDataRenderer } from "./common-data-items";
+import { DataArea, DataItemLabel, DataItemValue, DataPanel } from "./data-area";
+import SessionContext from "./session-context";
+import UnspecifiedProperty from "./unspecified-property";
+
+/** @type {string[]} Properties to never display */
+const PROPERTIES_TO_OMIT = [
+  "@context",
+  "@id",
+  "@type",
+  "actions",
+  "award",
+  "audit",
+  "collections",
+  "contact_pi",
+  "lab",
+  "pis",
+  "schema_version",
+  "status",
+  "uuid",
+];
+
+/**
+ * Displays a formatted page to represent an object that doesn't yet have a custom page defined.
+ * It attempts to use the same formatting as other objects sharing the same parent type, and also
+ * displays the remaining properties as best it can given the limited knowledge of the item.
+ */
+export default function UnknownTypePanel({ item, attribution = null }) {
+  // Get the schema corresponding to the given item. It might not have loaded yet.
+  const { profiles } = useContext(SessionContext);
+  const profile = profiles?.[item["@type"][0]];
+
+  // Get the common data renderer for the parent type of the given item so that the properties it
+  // shares with other objects with the same parent type get rendered the same way.
+  const CommonDataRenderer = findCommonDataRenderer(item);
+
+  // Ask the common data renderer for the properties it displays so that we can omit them from the
+  // generic properties. `commonProperties` plus `genericProperties` equals all the properties of
+  // the item, minus some properties we never display.
+  const commonProperties = CommonDataRenderer.commonProperties || [];
+  const genericProperties = Object.keys(item).filter(
+    (property) =>
+      !commonProperties.includes(property) &&
+      !PROPERTIES_TO_OMIT.includes(property)
+  );
+
+  return (
+    <>
+      <DataPanel>
+        <DataArea>
+          <CommonDataRenderer item={item}>
+            {_.sortBy(genericProperties).map((property) => {
+              const label = profile?.properties[property]?.title || property;
+              return (
+                <Fragment key={property}>
+                  <DataItemLabel>{label}</DataItemLabel>
+                  <DataItemValue>
+                    <UnspecifiedProperty property={item[property]} />
+                  </DataItemValue>
+                </Fragment>
+              );
+            })}
+          </CommonDataRenderer>
+        </DataArea>
+      </DataPanel>
+      <Attribution attribution={attribution} />
+    </>
+  );
+}
+
+UnknownTypePanel.propTypes = {
+  // Object that doesn't have a custom page defined
+  item: PropTypes.object.isRequired,
+  // Attribution object for the unknown item
+  attribution: PropTypes.object,
+};

--- a/components/unspecified-property.js
+++ b/components/unspecified-property.js
@@ -1,0 +1,82 @@
+// node_modules
+import Link from "next/link";
+import PropTypes from "prop-types";
+// components
+import SeparatedList from "./separated-list";
+// lib
+import { truncateJson } from "../lib/general";
+
+/**
+ * Display a property of an item as a JSON string, truncated to a certain number of characters.
+ */
+function JsonDisplay({ property }) {
+  return (
+    <div className="break-all font-mono text-sm">{truncateJson(property)}</div>
+  );
+}
+
+JsonDisplay.propTypes = {
+  // Property to display as a truncated JSON value
+  property: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
+};
+
+/**
+ * Generate a displayable form of the given property, whether a simple type, an object, or an
+ * array, without the benefit of a schema to help us determine how to display that property.
+ * Objects and arrays of objects with `@id` properties display as linked `@id` values, while arrays
+ * of simple types display as a comma-separated list of the values. In more complex cases, the
+ * property gets displayed as a JSON string, truncated to 200 characters.
+ */
+export default function UnspecifiedProperty({ property }) {
+  if (typeof property === "string" || typeof property === "number") {
+    return <div>{property}</div>;
+  }
+  if (typeof property === "boolean") {
+    return <div>{property ? "true" : "false"}</div>;
+  }
+
+  // Else the property is an object or an array, after PropTypes gatekeeping.
+  if (Array.isArray(property)) {
+    if (property.length > 0) {
+      if (typeof property[0] === "object") {
+        if (property[0]["@id"]) {
+          // Array of objects with @ids; join their @ids with commas.
+          return (
+            <SeparatedList>
+              {property.map((item) => (
+                <Link key={item["@id"]} href={item["@id"]}>
+                  {item["@id"]}
+                </Link>
+              ))}
+            </SeparatedList>
+          );
+        }
+
+        // Array of objects without @ids; display it as JSON.
+        return <JsonDisplay property={property} />;
+      }
+
+      // Array of simple types; join them with commas.
+      return <div>{property.join(", ")}</div>;
+    }
+  }
+
+  // For embedded object properties with an @id, display the linked @id.
+  if (property["@id"]) {
+    return <Link href={property["@id"]}>{property["@id"]}</Link>;
+  }
+
+  // The embedded property is an object without an @id. Display it as JSON.
+  return <JsonDisplay property={property} />;
+}
+
+UnspecifiedProperty.propTypes = {
+  // Property to display in as good a form as possible
+  property: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.bool,
+    PropTypes.object,
+    PropTypes.array,
+  ]).isRequired,
+};

--- a/pages/alignment-files/[id].js
+++ b/pages/alignment-files/[id].js
@@ -47,7 +47,7 @@ export default function AlignmentFile({
           <DataPanel>
             <DataArea>
               <FileDataItems
-                file={alignmentFile}
+                item={alignmentFile}
                 fileSet={fileSet}
                 derivedFrom={derivedFrom}
               >

--- a/pages/assay-terms/[name].js
+++ b/pages/assay-terms/[name].js
@@ -29,7 +29,7 @@ export default function AssayOntologyTerm({ assayOntologyTerm, isA, isJson }) {
         <JsonDisplay item={assayOntologyTerm} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>
-              <OntologyTermDataItems ontologyTerm={assayOntologyTerm} isA={isA}>
+              <OntologyTermDataItems item={assayOntologyTerm} isA={isA}>
                 {assayOntologyTerm.category_slims.length > 0 && (
                   <>
                     <DataItemLabel>Assay Category</DataItemLabel>

--- a/pages/human-donors/[uuid].js
+++ b/pages/human-donors/[uuid].js
@@ -34,7 +34,7 @@ export default function HumanDonor({
         <JsonDisplay item={donor} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>
-              <DonorDataItems donor={donor} parents={parents} />
+              <DonorDataItems item={donor} parents={parents} />
             </DataArea>
           </DataPanel>
           {phenotypicFeatures.length > 0 && (

--- a/pages/in-vitro-systems/[id].js
+++ b/pages/in-vitro-systems/[id].js
@@ -52,7 +52,7 @@ export default function InVitroSystem({
           <DataPanel>
             <DataArea>
               <BiosampleDataItems
-                biosample={inVitroSystem}
+                item={inVitroSystem}
                 source={source}
                 donors={donors}
                 biosampleTerm={biosampleTerm}

--- a/pages/phenotype-terms/[name].js
+++ b/pages/phenotype-terms/[name].js
@@ -27,7 +27,7 @@ export default function PhenotypeOntologyTerm({
         <JsonDisplay item={phenotypeOntologyTerm} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>
-              <OntologyTermDataItems ontologyTerm={phenotypeOntologyTerm} />
+              <OntologyTermDataItems item={phenotypeOntologyTerm} />
             </DataArea>
           </DataPanel>
         </JsonDisplay>

--- a/pages/platform-terms/[name].js
+++ b/pages/platform-terms/[name].js
@@ -24,7 +24,7 @@ export default function PlatformOntologyTerm({ platformOntologyTerm, isJson }) {
         <JsonDisplay item={platformOntologyTerm} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>
-              <OntologyTermDataItems ontologyTerm={platformOntologyTerm} />
+              <OntologyTermDataItems item={platformOntologyTerm} />
             </DataArea>
           </DataPanel>
         </JsonDisplay>

--- a/pages/primary-cells/[uuid].js
+++ b/pages/primary-cells/[uuid].js
@@ -50,7 +50,7 @@ export default function PrimaryCell({
           <DataPanel>
             <DataArea>
               <BiosampleDataItems
-                biosample={primaryCell}
+                item={primaryCell}
                 source={source}
                 donors={donors}
                 biosampleTerm={biosampleTerm}

--- a/pages/reference-files/[id].js
+++ b/pages/reference-files/[id].js
@@ -45,7 +45,7 @@ export default function ReferenceFile({
           <DataPanel>
             <DataArea>
               <FileDataItems
-                file={referenceFile}
+                item={referenceFile}
                 fileSet={fileSet}
                 derivedFrom={derivedFrom}
               >

--- a/pages/rodent-donors/[uuid].js
+++ b/pages/rodent-donors/[uuid].js
@@ -44,7 +44,7 @@ export default function RodentDonor({
         <JsonDisplay item={donor} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>
-              <DonorDataItems donor={donor} parents={parents}>
+              <DonorDataItems item={donor} parents={parents}>
                 <DataItemLabel>Strain</DataItemLabel>
                 <DataItemValue>{donor.strain}</DataItemValue>
                 {donor.strain_background && (

--- a/pages/sample-terms/[name].js
+++ b/pages/sample-terms/[name].js
@@ -38,7 +38,7 @@ export default function SampleOntologyTerm({ sampleOntologyTerm, isJson }) {
                   </DataItemValue>
                 </>
               )}
-              <OntologyTermDataItems ontologyTerm={sampleOntologyTerm}>
+              <OntologyTermDataItems item={sampleOntologyTerm}>
                 {sampleOntologyTerm.organ_slims.length > 0 && (
                   <>
                     <DataItemLabel>Organs</DataItemLabel>

--- a/pages/sequence-files/[id].js
+++ b/pages/sequence-files/[id].js
@@ -45,7 +45,7 @@ export default function SequenceFile({
           <DataPanel>
             <DataArea>
               <FileDataItems
-                file={sequenceFile}
+                item={sequenceFile}
                 fileSet={fileSet}
                 derivedFrom={derivedFrom}
               >

--- a/pages/signal-files/[id].js
+++ b/pages/signal-files/[id].js
@@ -47,7 +47,7 @@ export default function SignalFile({
           <DataPanel>
             <DataArea>
               <FileDataItems
-                file={signalFile}
+                item={signalFile}
                 fileSet={fileSet}
                 derivedFrom={derivedFrom}
               >

--- a/pages/sources/[id].js
+++ b/pages/sources/[id].js
@@ -8,15 +8,15 @@ import {
   DataItemValue,
   DataPanel,
 } from "../../components/data-area";
+import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import { EditableItem } from "../../components/edit";
 // lib
+import AliasList from "../../components/alias-list";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import AliasList from "../../components/alias-list";
 import { isJsonFormat } from "../../lib/query-utils";
 
 export default function Source({ source, isJson }) {

--- a/pages/technical-samples/[uuid].js
+++ b/pages/technical-samples/[uuid].js
@@ -41,7 +41,7 @@ export default function TechnicalSample({
         <JsonDisplay item={sample} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>
-              <SampleDataItems sample={sample} source={source}>
+              <SampleDataItems item={sample} source={source}>
                 {sample.date && (
                   <>
                     <DataItemLabel>Technical Sample Date</DataItemLabel>

--- a/pages/tissues/[uuid].js
+++ b/pages/tissues/[uuid].js
@@ -49,7 +49,7 @@ export default function Tissue({
           <DataPanel>
             <DataArea>
               <BiosampleDataItems
-                biosample={tissue}
+                item={tissue}
                 source={source}
                 donors={donors}
                 biosampleTerm={biosampleTerm}

--- a/pages/whole-organisms/[id].js
+++ b/pages/whole-organisms/[id].js
@@ -43,7 +43,7 @@ export default function WholeOrganism({
           <DataPanel>
             <DataArea>
               <BiosampleDataItems
-                biosample={sample}
+                item={sample}
                 source={source}
                 donors={donors}
                 biosampleTerm={biosampleTerm}


### PR DESCRIPTION
The changes in the data-panel code relate to using container queries for the property labels and their values, so that the labels in appear above their values in more appropriate cases, such as narrow-ish browser-window widths with non-collapsed navigation, and then labels appearing next to their values when collapsing navigation.

I renamed the main property for common data renderers from a specific name to `item` so that they can accept unknown objects. This comprises the bulk of the changes within the `pages` directory.
