### PR TITLE
IGVF-831 Fix search-result list renderer when the object type isn’t known to the UI

### DIFF
--- a/components/search/list-renderer/index.js
+++ b/components/search/list-renderer/index.js
@@ -150,7 +150,7 @@ export function getSearchListItemRenderer(item) {
  */
 function getAccessoryDataPathsGenerator(itemType) {
   const renderer = renderers[itemType];
-  return renderer.getAccessoryDataPaths || null;
+  return renderer?.getAccessoryDataPaths || null;
 }
 
 /**


### PR DESCRIPTION
Restore original fix.