### PR TITLE
IGVF-913 Fix FileSet object pages to match FileSet embedding change

### DIFF
--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -32,7 +32,6 @@ export default function AnalysisSet({
   inputFileSets,
   donors,
   files,
-  samples,
   attribution = null,
   isJson,
 }) {
@@ -81,13 +80,13 @@ export default function AnalysisSet({
                   </DataItemValue>
                 </>
               )}
-              {samples.length > 0 && (
+              {analysisSet.samples?.length > 0 && (
                 <>
                   <DataItemLabel>Samples</DataItemLabel>
                   <DataItemValue>
                     <SeparatedList>
-                      {samples.map((sample) => (
-                        <Link href={sample["@id"]} key={sample.uuid}>
+                      {analysisSet.samples.map((sample) => (
+                        <Link href={sample["@id"]} key={sample["@id"]}>
                           {sample.accession}
                         </Link>
                       ))}
@@ -122,8 +121,6 @@ AnalysisSet.propTypes = {
   donors: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Files to display
   files: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Samples to display
-  samples: PropTypes.arrayOf(PropTypes.object).isRequired,
   // input_file_sets to this analysis set
   inputFileSets: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Documents associated with this analysis set
@@ -149,16 +146,13 @@ export async function getServerSideProps({ params, req, query }) {
           filterErrors: true,
         })
       : [];
-    const files = analysisSet.files
-      ? await request.getMultipleObjects(analysisSet.files, null, {
-          filterErrors: true,
-        })
-      : [];
-    const samples = analysisSet.samples
-      ? await request.getMultipleObjects(analysisSet.samples, null, {
-          filterErrors: true,
-        })
-      : [];
+    const filePaths = analysisSet.files.map((file) => file["@id"]);
+    const files =
+      filePaths.length > 0
+        ? await request.getMultipleObjects(filePaths, null, {
+            filterErrors: true,
+          })
+        : [];
     let donors = [];
     if (analysisSet.donors) {
       const donorPaths = analysisSet.donors.map((donor) => donor["@id"]);
@@ -179,7 +173,6 @@ export async function getServerSideProps({ params, req, query }) {
         documents,
         donors,
         files,
-        samples,
         pageContext: { title: analysisSet.accession },
         breadcrumbs,
         attribution,

--- a/pages/curated-sets/[id].js
+++ b/pages/curated-sets/[id].js
@@ -31,7 +31,6 @@ export default function CuratedSet({
   documents,
   donors,
   files,
-  samples,
   attribution = null,
   isJson,
 }) {
@@ -74,13 +73,13 @@ export default function CuratedSet({
                   </DataItemValue>
                 </>
               )}
-              {samples.length > 0 && (
+              {curatedSet.samples?.length > 0 && (
                 <>
                   <DataItemLabel>Samples</DataItemLabel>
                   <DataItemValue>
                     <SeparatedList>
-                      {samples.map((sample) => (
-                        <Link href={sample["@id"]} key={sample.uuid}>
+                      {curatedSet.samples.map((sample) => (
+                        <Link href={sample["@id"]} key={sample["@id"]}>
                           {sample.accession}
                         </Link>
                       ))}
@@ -116,8 +115,6 @@ CuratedSet.propTypes = {
   donors: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Files to display
   files: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Samples to display
-  samples: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Documents associated with this curated set
   documents: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Attribution for this curated set
@@ -136,21 +133,18 @@ export async function getServerSideProps({ params, req, query }) {
           filterErrors: true,
         })
       : [];
-    const samples = curatedSet.samples
-      ? await request.getMultipleObjects(curatedSet.samples, null, {
-          filterErrors: true,
-        })
-      : [];
     const donors = curatedSet.donors
       ? await request.getMultipleObjects(curatedSet.donors, null, {
           filterErrors: true,
         })
       : [];
-    const files = curatedSet.files
-      ? await request.getMultipleObjects(curatedSet.files, null, {
-          filterErrors: true,
-        })
-      : [];
+    const filePaths = curatedSet.files.map((file) => file["@id"]);
+    const files =
+      filePaths.length > 0
+        ? await request.getMultipleObjects(filePaths, null, {
+            filterErrors: true,
+          })
+        : [];
     const breadcrumbs = await buildBreadcrumbs(
       curatedSet,
       "accession",
@@ -163,7 +157,6 @@ export async function getServerSideProps({ params, req, query }) {
         documents,
         donors,
         files,
-        samples,
         pageContext: { title: curatedSet.accession },
         breadcrumbs,
         attribution,

--- a/pages/measurement-sets/[id].js
+++ b/pages/measurement-sets/[id].js
@@ -126,7 +126,6 @@ export default function MeasurementSet({
   donors,
   files,
   sequencingPlatforms,
-  samples,
   attribution = null,
   isJson,
 }) {
@@ -193,13 +192,13 @@ export default function MeasurementSet({
                   </DataItemValue>
                 </>
               )}
-              {samples.length > 0 && (
+              {measurementSet.samples?.length > 0 && (
                 <>
                   <DataItemLabel>Samples</DataItemLabel>
                   <DataItemValue>
                     <SeparatedList>
-                      {samples.map((sample) => (
-                        <Link href={sample["@id"]} key={sample.uuid}>
+                      {measurementSet.samples.map((sample) => (
+                        <Link href={sample["@id"]} key={sample["@id"]}>
                           {sample.accession}
                         </Link>
                       ))}
@@ -253,8 +252,6 @@ MeasurementSet.propTypes = {
   files: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Sequencing platform objects associated with `files`
   sequencingPlatforms: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Samples to display
-  samples: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Documents associated with this measurement set
   documents: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Attribution for this measurement set
@@ -279,11 +276,6 @@ export async function getServerSideProps({ params, req, query }) {
           filterErrors: true,
         })
       : [];
-    const samples = measurementSet.samples
-      ? await request.getMultipleObjects(measurementSet.samples, null, {
-          filterErrors: true,
-        })
-      : [];
     let donors = [];
     if (measurementSet.donors) {
       const donorPaths = measurementSet.donors.map((donor) => donor["@id"]);
@@ -291,11 +283,13 @@ export async function getServerSideProps({ params, req, query }) {
         filterErrors: true,
       });
     }
-    const files = measurementSet.files
-      ? await request.getMultipleObjects(measurementSet.files, null, {
-          filterErrors: true,
-        })
-      : [];
+    const filePaths = measurementSet.files.map((file) => file["@id"]);
+    const files =
+      filePaths.length > 0
+        ? await request.getMultipleObjects(filePaths, null, {
+            filterErrors: true,
+          })
+        : [];
 
     // Use the files to retrieve all the sequencing platform objects they link to.
     const sequencingPlatformPaths = files
@@ -328,7 +322,6 @@ export async function getServerSideProps({ params, req, query }) {
         donors,
         files,
         sequencingPlatforms,
-        samples,
         pageContext: { title: measurementSet.accession },
         breadcrumbs,
         attribution,

--- a/pages/models/[id].js
+++ b/pages/models/[id].js
@@ -169,11 +169,13 @@ export async function getServerSideProps({ params, req, query }) {
           filterErrors: true,
         })
       : [];
-    const files = model.files
-      ? await request.getMultipleObjects(model.files, null, {
-          filterErrors: true,
-        })
-      : [];
+    const filePaths = model.files.map((file) => file["@id"]);
+    const files =
+      filePaths.length > 0
+        ? await request.getMultipleObjects(filePaths, null, {
+            filterErrors: true,
+          })
+        : [];
 
     const breadcrumbs = await buildBreadcrumbs(
       model,


### PR DESCRIPTION
This affects FileSet object pages that have defined rendering pages, which includes:
* AnalysisSet
* CuratedSet
* MeasurementSet
* Model

The sample objects that we used to retrieve from their paths now exist as embedded properties in FileSet objects. This ticket changes the above four object pages to not retrieve sample objects, and instead display the embedded sample objects.

In addition, FileSet objects now embed the File objects in the `files` array. These do not embed enough properties to render the file table on the FileSet object pages, so I still request these file objects from igvfd, but now based on the embedded file-object `@id` instead of the paths that used to exist.