### PR TITLE
IGVF-856 Improve page-request performance

### DIFF
--- a/components/attribution.js
+++ b/components/attribution.js
@@ -38,7 +38,7 @@ export default function Attribution({ attribution = null }) {
                 <DataItemValue>
                   <SeparatedList>
                     {attribution.pis.map((pi) => (
-                      <Link href={pi["@id"]} key={pi.uuid}>
+                      <Link href={pi["@id"]} key={pi["@id"]}>
                         {pi.title}
                       </Link>
                     ))}

--- a/components/common-data-items.js
+++ b/components/common-data-items.js
@@ -26,7 +26,7 @@ import { truthyOrZero } from "../lib/general";
 /**
  * Display the data items common to all donor-derived objects.
  */
-export function DonorDataItems({ item, parents = null, children }) {
+export function DonorDataItems({ item, children }) {
   return (
     <>
       {item.taxa && (
@@ -51,24 +51,6 @@ export function DonorDataItems({ item, parents = null, children }) {
         <>
           <DataItemLabel>Virtual</DataItemLabel>
           <DataItemValue>True</DataItemValue>
-        </>
-      )}
-      {parents?.length > 0 && (
-        <>
-          <DataItemLabel>Parents</DataItemLabel>
-          <DataItemValue>
-            <SeparatedList>
-              {parents.map((parent) => (
-                <Link
-                  href={parent["@id"]}
-                  key={parent.uuid}
-                  aria-label={`Parent Donor ${parent.accession}`}
-                >
-                  {parent.accession}
-                </Link>
-              ))}
-            </SeparatedList>
-          </DataItemValue>
         </>
       )}
       {children}
@@ -115,8 +97,6 @@ export function DonorDataItems({ item, parents = null, children }) {
 DonorDataItems.propTypes = {
   // Object derived from donor.json schema
   item: PropTypes.object.isRequired,
-  // Parents of this donor
-  parents: PropTypes.arrayOf(PropTypes.object),
 };
 
 DonorDataItems.commonProperties = [
@@ -318,7 +298,7 @@ export function BiosampleDataItems({
           <DataItemValue>
             <SeparatedList>
               {pooledFrom.map((biosample) => (
-                <Link href={biosample["@id"]} key={biosample.uuid}>
+                <Link href={biosample["@id"]} key={biosample["@id"]}>
                   {biosample.accession}
                 </Link>
               ))}

--- a/components/search/__tests__/list-renderer.test.js
+++ b/components/search/__tests__/list-renderer.test.js
@@ -215,7 +215,13 @@ describe("Test Award component", () => {
     expect(status).toHaveTextContent("current");
 
     const paths = Award.getAccessoryDataPaths([item]);
-    expect(paths).toEqual(["/users/04e6e85d-3737-454e-8a3b-6f8cb2317f00/"]);
+    expect(paths).toEqual([
+      {
+        type: "User",
+        paths: ["/users/04e6e85d-3737-454e-8a3b-6f8cb2317f00/"],
+        fields: ["title"],
+      },
+    ]);
   });
 });
 
@@ -489,13 +495,17 @@ describe("Test the HumanDonor component", () => {
     expect(status).toHaveTextContent("released");
 
     const paths = HumanDonor.getAccessoryDataPaths([item]);
-    expect(paths.sort()).toEqual(
-      [
-        "/phenotypic-features/123/",
-        "/phenotypic-features/456/",
-        "/phenotypic-features/111/",
-      ].sort()
-    );
+    expect(paths.sort()).toEqual([
+      {
+        type: "PhenotypicFeature",
+        paths: [
+          "/phenotypic-features/123/",
+          "/phenotypic-features/456/",
+          "/phenotypic-features/111/",
+        ],
+        fields: ["quantity", "quantity_units", "feature"],
+      },
+    ]);
   });
 
   it("renders a human donor item without accessory data", () => {
@@ -792,13 +802,17 @@ describe("Test the RodentDonor component", () => {
     expect(status).toHaveTextContent("released");
 
     const paths = RodentDonor.getAccessoryDataPaths([item]);
-    expect(paths.sort()).toEqual(
-      [
-        "/phenotypic-features/abc123/",
-        "/phenotypic-features/123abc",
-        "/phenotypic-features/999",
-      ].sort()
-    );
+    expect(paths).toEqual([
+      {
+        type: "PhenotypicFeature",
+        paths: [
+          "/phenotypic-features/abc123/",
+          "/phenotypic-features/123abc",
+          "/phenotypic-features/999",
+        ],
+        fields: ["quantity", "quantity_units", "feature"],
+      },
+    ]);
   });
 
   it("rodent donor without collection", () => {
@@ -909,7 +923,13 @@ describe("Test User component", () => {
     expect(meta).toHaveTextContent("Christina Leslie, MSKCC");
 
     const paths = User.getAccessoryDataPaths([item]);
-    expect(paths).toEqual(["/labs/christina-leslie/"]);
+    expect(paths).toEqual([
+      {
+        type: "Lab",
+        paths: ["/labs/christina-leslie/"],
+        fields: ["title"],
+      },
+    ]);
   });
 
   it("renders a User item without accessory data", () => {

--- a/components/search/list-renderer/award.js
+++ b/components/search/list-renderer/award.js
@@ -41,5 +41,11 @@ Award.propTypes = {
 };
 
 Award.getAccessoryDataPaths = (items) => {
-  return items.map((item) => item.contact_pi).filter(Boolean);
+  return [
+    {
+      type: "User",
+      paths: items.map((item) => item.contact_pi).filter(Boolean),
+      fields: ["title"],
+    },
+  ];
 };

--- a/components/search/list-renderer/human-donor.js
+++ b/components/search/list-renderer/human-donor.js
@@ -73,5 +73,11 @@ HumanDonor.getAccessoryDataPaths = (humanDonors) => {
     .map((humanDonor) => humanDonor.phenotypic_features)
     .filter(Boolean)
     .flat(1);
-  return phenotypicFeatures;
+  return [
+    {
+      type: "PhenotypicFeature",
+      paths: phenotypicFeatures,
+      fields: ["quantity", "quantity_units", "feature"],
+    },
+  ];
 };

--- a/components/search/list-renderer/index.js
+++ b/components/search/list-renderer/index.js
@@ -347,10 +347,11 @@ export async function getAccessoryData(itemListsByType, cookie) {
     const accessoryDataTypes = Object.keys(accessoryDataPaths);
     if (accessoryDataTypes.length > 0) {
       const requests = accessoryDataTypes.map(async (type) => {
+        // Get the objects for this type. Any network errors get returned as an empty array.
         const request = new FetchRequest({ cookie });
         const objects = await request.getMultipleObjectsBulk(
           accessoryDataPaths[type].paths,
-          null,
+          [],
           accessoryDataPaths[type].fields
         );
 

--- a/components/search/list-renderer/rodent-donor.js
+++ b/components/search/list-renderer/rodent-donor.js
@@ -72,5 +72,11 @@ RodentDonor.getAccessoryDataPaths = (rodentDonors) => {
     .map((rodentDonor) => rodentDonor.phenotypic_features)
     .filter(Boolean)
     .flat(1);
-  return phenotypicFeatures;
+  return [
+    {
+      type: "PhenotypicFeature",
+      paths: phenotypicFeatures,
+      fields: ["quantity", "quantity_units", "feature"],
+    },
+  ];
 };

--- a/components/search/list-renderer/user.js
+++ b/components/search/list-renderer/user.js
@@ -41,5 +41,12 @@ User.propTypes = {
 };
 
 User.getAccessoryDataPaths = (items) => {
-  return items.map((item) => item.lab).filter(Boolean);
+  const labs = items.map((item) => item.lab).filter(Boolean);
+  return [
+    {
+      type: "Lab",
+      paths: labs,
+      fields: ["title"],
+    },
+  ];
 };

--- a/lib/__tests__/fetch-request.test.js
+++ b/lib/__tests__/fetch-request.test.js
@@ -152,58 +152,6 @@ describe("Test GET requests to the data provider", () => {
     expect(_.isEqual(labCollection, mockData)).toBeTruthy();
   });
 
-  it("requests a list of objects with embedded properties", async () => {
-    const mockData = {
-      "/labs/j-michael-cherry/": {
-        name: "j-michael-cherry",
-        "@id": "/labs/j-michael-cherry/",
-        "@type": ["Lab", "Item"],
-        title: "J. Michael Cherry, Stanford",
-      },
-      "/labs/jesse-engreitz/": {
-        name: "jesse-engreitz",
-        "@id": "/labs/jesse-engreitz/",
-        "@type": ["Lab", "Item"],
-        title: "Jesse Engreitz, Stanford University",
-      },
-    };
-    window.fetch = jest.fn().mockImplementation((url) => {
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve(mockData[url]),
-      });
-    });
-
-    const items = [
-      {
-        "@id": "/users/986b362f-4eb6-4a9c-8173-3ab267307e3b/",
-        "@type": ["User", "Item"],
-        lab: "/labs/j-michael-cherry/",
-        title: "Ben Hitz",
-      },
-      {
-        "@id": "/users/627eedbc-7cb3-4de3-9743-a86266e435a6/",
-        "@type": ["User", "Item"],
-        lab: "/labs/jesse-engreitz/",
-        title: "Forrest Tanaka",
-      },
-      {
-        "@id": "/users/24d01e13-37ef-4521-975b-a2f49533d19b",
-        "@type": ["User", "Item"],
-        lab: "/labs/anshul-kundaje/",
-        title: "Anshul Kundaje",
-      },
-    ];
-
-    const request = new FetchRequest();
-    await request.getAndEmbedCollectionObjects(items, "lab");
-    expect(typeof items[0].lab).toEqual("object");
-    expect(items[0].lab["@id"]).toEqual("/labs/j-michael-cherry/");
-    expect(typeof items[1].lab).toEqual("object");
-    expect(items[1].lab["@id"]).toEqual("/labs/jesse-engreitz/");
-    expect(items[2].lab).toBeNull();
-  });
-
   it("receives a network error object when fetch throws an error", async () => {
     window.fetch = jest.fn().mockImplementation(() => {
       throw "Mock request error";
@@ -570,5 +518,117 @@ describe("PATCH fetch requests", () => {
       );
       expect(awardProfiles).toEqual(mockData);
     });
+  });
+});
+
+describe("Test getMultipleObjectsBulk()", () => {
+  it("retrieves a small number of items from the server correctly", async () => {
+    const mockData = {
+      "@graph": [
+        {
+          "@id": "/labs/j-michael-cherry/",
+          "@type": ["Lab", "Item"],
+          name: "j-michael-cherry",
+        },
+        {
+          "@id": "/labs/jesse-engreitz/",
+          "@type": ["Lab", "Item"],
+          name: "jesse-engreitz",
+        },
+      ],
+      "@id":
+        "/search/?field=name&@id=/labs/j-michael-cherry/&@id=/labs/jesse-engreitz/&@id=/labs/unknown/&limit=3",
+      "@type": ["Search"],
+    };
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      })
+    );
+
+    const request = new FetchRequest({ session: { _csfrt_: "mocktoken" } });
+    const labItems = await request.getMultipleObjectsBulk(
+      ["/labs/j-michael-cherry/", "/labs/jesse-engreitz/", "/labs/unknown/"],
+      null,
+      ["name"]
+    );
+    expect(labItems).toBeTruthy();
+    expect(labItems).toHaveLength(2);
+  });
+
+  it("retrieves a large number of items from the server correctly", async () => {
+    // Generate an array of 100 unique paths.
+    const paths = [];
+    for (let i = 0; i < 100; i++) {
+      paths.push(`/labs/${i}`);
+    }
+
+    const mockData = paths.map((path) => ({
+      "@id": path,
+      "@type": ["Lab", "Item"],
+      name: path,
+    }));
+
+    const mockResults0 = {
+      "@graph": mockData.slice(0, 80),
+      "@id": `/search/?field=name&${paths.map(
+        (path) => `@id=${path.slice(0, 80)}&`
+      )}limit=80`,
+      "@type": ["Search"],
+    };
+
+    const mockResults1 = {
+      "@graph": mockData.slice(80),
+      "@id": `/search/?field=name&${paths.map(
+        (path) => `@id=${path.slice(80)}&`
+      )}limit=20`,
+      "@type": ["Search"],
+    };
+
+    let requestNumber = 0;
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: true,
+        json: () => {
+          return Promise.resolve(
+            requestNumber++ === 0 ? mockResults0 : mockResults1
+          );
+        },
+      });
+    });
+
+    const request = new FetchRequest({ session: { _csfrt_: "mocktoken" } });
+    const labItems = await request.getMultipleObjectsBulk(paths, null, [
+      "name",
+    ]);
+    expect(labItems).toBeTruthy();
+    expect(labItems).toHaveLength(100);
+  });
+
+  it("retrieves an empty array on a network error", async () => {
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve(null),
+      });
+    });
+
+    const request = new FetchRequest({ session: { _csfrt_: "mocktoken" } });
+    const labItems = await request.getMultipleObjectsBulk(
+      ["/labs/j-michael-cherry/", "/labs/jesse-engreitz/", "/labs/unknown/"],
+      null,
+      ["name"]
+    );
+    expect(labItems).toBeTruthy();
+    expect(labItems).toHaveLength(0);
+  });
+
+  it("retrieves no items from an empty array", async () => {
+    // Make sure passing an empty array returns an empty array.
+    const request = new FetchRequest({ session: { _csfrt_: "mocktoken" } });
+    const noLabItems = await request.getMultipleObjectsBulk([], null, ["name"]);
+    expect(noLabItems).toBeTruthy();
+    expect(noLabItems).toHaveLength(0);
   });
 });

--- a/lib/__tests__/fetch-request.test.js
+++ b/lib/__tests__/fetch-request.test.js
@@ -557,6 +557,41 @@ describe("Test getMultipleObjectsBulk()", () => {
     expect(labItems).toHaveLength(2);
   });
 
+  it("retrieves a small number of items from the server correctly with no fields requested", async () => {
+    const mockData = {
+      "@graph": [
+        {
+          "@id": "/labs/j-michael-cherry/",
+          "@type": ["Lab", "Item"],
+          name: "j-michael-cherry",
+        },
+        {
+          "@id": "/labs/jesse-engreitz/",
+          "@type": ["Lab", "Item"],
+          name: "jesse-engreitz",
+        },
+      ],
+      "@id":
+        "/search/?field=name&@id=/labs/j-michael-cherry/&@id=/labs/jesse-engreitz/&@id=/labs/unknown/&limit=3",
+      "@type": ["Search"],
+    };
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      })
+    );
+
+    const request = new FetchRequest({ session: { _csfrt_: "mocktoken" } });
+    const labItems = await request.getMultipleObjectsBulk(
+      ["/labs/j-michael-cherry/", "/labs/jesse-engreitz/", "/labs/unknown/"],
+      null,
+      []
+    );
+    expect(labItems).toBeTruthy();
+    expect(labItems).toHaveLength(2);
+  });
+
   it("retrieves a large number of items from the server correctly", async () => {
     // Generate an array of 100 unique paths.
     const paths = [];
@@ -606,7 +641,7 @@ describe("Test getMultipleObjectsBulk()", () => {
     expect(labItems).toHaveLength(100);
   });
 
-  it("retrieves an empty array on a network error", async () => {
+  it("detects a network error", async () => {
     window.fetch = jest.fn().mockImplementation(() => {
       return Promise.resolve({
         ok: false,
@@ -620,8 +655,7 @@ describe("Test getMultipleObjectsBulk()", () => {
       null,
       ["name"]
     );
-    expect(labItems).toBeTruthy();
-    expect(labItems).toHaveLength(0);
+    expect(labItems).toBeFalsy();
   });
 
   it("retrieves no items from an empty array", async () => {

--- a/lib/attribution.js
+++ b/lib/attribution.js
@@ -1,5 +1,6 @@
 // lib
 import FetchRequest from "./fetch-request";
+import { requestUsers } from "./common-requests";
 
 /**
  * Generate the attribution data for an object page.
@@ -32,11 +33,7 @@ export default async function buildAttribution(obj, cookie) {
       if (contactPi) {
         attribution.contactPi = contactPi;
       }
-      const pis = award.pis
-        ? await request.getMultipleObjects(award.pis, null, {
-            filterErrors: true,
-          })
-        : null;
+      const pis = award.pis ? await requestUsers(award.pis, request) : null;
       if (pis) {
         attribution.pis = pis;
       }

--- a/lib/common-requests.js
+++ b/lib/common-requests.js
@@ -6,7 +6,7 @@
  */
 export async function requestAwards(paths, request) {
   return paths.length > 0
-    ? request.getMultipleObjectsBulk(paths, null, ["name", "url"])
+    ? request.getMultipleObjectsBulk(paths, [], ["name", "url"])
     : [];
 }
 
@@ -18,13 +18,11 @@ export async function requestAwards(paths, request) {
  */
 export async function requestBiomarkers(paths, request) {
   return paths.length > 0
-    ? request.getMultipleObjectsBulk(paths, null, [
-        "aliases",
-        "classification",
-        "name",
-        "qualification",
-        "synonyms",
-      ])
+    ? request.getMultipleObjectsBulk(
+        paths,
+        [],
+        ["aliases", "classification", "name", "qualification", "synonyms"]
+      )
     : [];
 }
 
@@ -36,7 +34,7 @@ export async function requestBiomarkers(paths, request) {
  */
 export async function requestBiosamples(paths, request) {
   return paths.length > 0
-    ? request.getMultipleObjectsBulk(paths, null, ["accession"])
+    ? request.getMultipleObjectsBulk(paths, [], ["accession"])
     : [];
 }
 
@@ -48,21 +46,25 @@ export async function requestBiosamples(paths, request) {
  */
 export async function requestFiles(paths, request) {
   return paths.length > 0
-    ? request.getMultipleObjectsBulk(paths, null, [
-        "accession",
-        "content_type",
-        "file_format",
-        "file_size",
-        "flowcell_id",
-        "href",
-        "illumina_read_type",
-        "lab.title",
-        "lane",
-        "sequencing_platform",
-        "sequencing_run",
-        "status",
-        "upload_status",
-      ])
+    ? request.getMultipleObjectsBulk(
+        paths,
+        [],
+        [
+          "accession",
+          "content_type",
+          "file_format",
+          "file_size",
+          "flowcell_id",
+          "href",
+          "illumina_read_type",
+          "lab.title",
+          "lane",
+          "sequencing_platform",
+          "sequencing_run",
+          "status",
+          "upload_status",
+        ]
+      )
     : [];
 }
 
@@ -74,7 +76,7 @@ export async function requestFiles(paths, request) {
  */
 export async function requestFileSets(paths, request) {
   return paths.length > 0
-    ? request.getMultipleObjectsBulk(paths, null, ["accession"])
+    ? request.getMultipleObjectsBulk(paths, [], ["accession"])
     : [];
 }
 
@@ -86,12 +88,11 @@ export async function requestFileSets(paths, request) {
  */
 export async function requestDocuments(paths, request) {
   return paths.length > 0
-    ? request.getMultipleObjectsBulk(paths, null, [
-        "attachment",
-        "description",
-        "document_type",
-        "uuid",
-      ])
+    ? request.getMultipleObjectsBulk(
+        paths,
+        [],
+        ["attachment", "description", "document_type", "uuid"]
+      )
     : [];
 }
 
@@ -103,7 +104,7 @@ export async function requestDocuments(paths, request) {
  */
 export async function requestDonors(paths, request) {
   return paths.length > 0
-    ? request.getMultipleObjectsBulk(paths, null, ["accession", "uuid"])
+    ? request.getMultipleObjectsBulk(paths, [], ["accession", "uuid"])
     : [];
 }
 
@@ -115,7 +116,7 @@ export async function requestDonors(paths, request) {
  */
 export async function requestOntologyTerms(paths, request) {
   return paths.length > 0
-    ? request.getMultipleObjectsBulk(paths, null, ["term_id", "term_name"])
+    ? request.getMultipleObjectsBulk(paths, [], ["term_id", "term_name"])
     : [];
 }
 
@@ -128,12 +129,11 @@ export async function requestOntologyTerms(paths, request) {
  */
 export async function requestPhenotypicFeatures(paths, request) {
   return paths.length > 0
-    ? request.getMultipleObjectsBulk(paths, null, [
-        "feature",
-        "observation_date",
-        "quantity",
-        "quantity_units",
-      ])
+    ? request.getMultipleObjectsBulk(
+        paths,
+        [],
+        ["feature", "observation_date", "quantity", "quantity_units"]
+      )
     : [];
 }
 
@@ -146,7 +146,7 @@ export async function requestPhenotypicFeatures(paths, request) {
  */
 export async function requestSoftwareVersions(paths, request) {
   return paths.length > 0
-    ? request.getMultipleObjectsBulk(paths, null, ["version", "downloaded_url"])
+    ? request.getMultipleObjectsBulk(paths, [], ["version", "downloaded_url"])
     : [];
 }
 
@@ -158,14 +158,18 @@ export async function requestSoftwareVersions(paths, request) {
  */
 export async function requestTreatments(paths, request) {
   return paths.length > 0
-    ? request.getMultipleObjectsBulk(paths, null, [
-        "amount",
-        "duration",
-        "purpose",
-        "treatment_term_id",
-        "treatment_term_name",
-        "treatment_type",
-      ])
+    ? request.getMultipleObjectsBulk(
+        paths,
+        [],
+        [
+          "amount",
+          "duration",
+          "purpose",
+          "treatment_term_id",
+          "treatment_term_name",
+          "treatment_type",
+        ]
+      )
     : [];
 }
 
@@ -177,6 +181,6 @@ export async function requestTreatments(paths, request) {
  */
 export async function requestUsers(paths, request) {
   return paths.length > 0
-    ? request.getMultipleObjectsBulk(paths, null, ["title"])
+    ? request.getMultipleObjectsBulk(paths, [], ["title"])
     : [];
 }

--- a/lib/common-requests.js
+++ b/lib/common-requests.js
@@ -1,0 +1,182 @@
+/**
+ * Retrieve the award objects for the given award paths from the data provider.
+ * @param {Array<string>} paths Paths to the award objects to request
+ * @param {object} request The request object to use to make the request
+ * @returns {Array<object>} The award objects requested
+ */
+export async function requestAwards(paths, request) {
+  return paths.length > 0
+    ? request.getMultipleObjectsBulk(paths, null, ["name", "url"])
+    : [];
+}
+
+/**
+ * Retrieve the biomarker objects for the given biosample paths from the data provider.
+ * @param {Array<string>} paths Paths to the biomarker objects to request
+ * @param {object} request The request object to use to make the request
+ * @returns {Array<object>} The biomarker objects requested
+ */
+export async function requestBiomarkers(paths, request) {
+  return paths.length > 0
+    ? request.getMultipleObjectsBulk(paths, null, [
+        "aliases",
+        "classification",
+        "name",
+        "qualification",
+        "synonyms",
+      ])
+    : [];
+}
+
+/**
+ * Retrieve the biosample objects for the given biosample paths from the data provider.
+ * @param {Array<string>} paths Paths to the biosample objects to request
+ * @param {object} request The request object to use to make the request
+ * @returns {Array<object>} The biosample objects requested
+ */
+export async function requestBiosamples(paths, request) {
+  return paths.length > 0
+    ? request.getMultipleObjectsBulk(paths, null, ["accession"])
+    : [];
+}
+
+/**
+ * Retrieve the file objects for the given file paths from the data provider.
+ * @param {Array<string>} paths Paths to the file objects to request
+ * @param {object} request The request object to use to make the request
+ * @returns {Array<object>} The file objects requested
+ */
+export async function requestFiles(paths, request) {
+  return paths.length > 0
+    ? request.getMultipleObjectsBulk(paths, null, [
+        "accession",
+        "content_type",
+        "file_format",
+        "file_size",
+        "flowcell_id",
+        "href",
+        "illumina_read_type",
+        "lab.title",
+        "lane",
+        "sequencing_platform",
+        "sequencing_run",
+        "status",
+        "upload_status",
+      ])
+    : [];
+}
+
+/**
+ * Retrieve the FileSet objects for the given FileSet paths from the data provider.
+ * @param {Array<string>} paths Paths to the FileSet objects to request
+ * @param {object} request The request object to use to make the request
+ * @returns {Array<object>} The file-set objects requested
+ */
+export async function requestFileSets(paths, request) {
+  return paths.length > 0
+    ? request.getMultipleObjectsBulk(paths, null, ["accession"])
+    : [];
+}
+
+/**
+ * Retrieve the document objects for the given document paths from the data provider.
+ * @param {Array<string>} paths Paths to the document objects to request
+ * @param {object} request The request object to use to make the request
+ * @returns {Array<object>} The document objects requested
+ */
+export async function requestDocuments(paths, request) {
+  return paths.length > 0
+    ? request.getMultipleObjectsBulk(paths, null, [
+        "attachment",
+        "description",
+        "document_type",
+        "uuid",
+      ])
+    : [];
+}
+
+/**
+ * Retrieve the donor objects for the given donor paths from the data provider.
+ * @param {Array<string>} paths Paths to the donor objects to request
+ * @param {object} request The request object to use to make the request
+ * @returns {Array<object>} The donor objects requested
+ */
+export async function requestDonors(paths, request) {
+  return paths.length > 0
+    ? request.getMultipleObjectsBulk(paths, null, ["accession", "uuid"])
+    : [];
+}
+
+/**
+ * Retrieve the ontology-term objects for the given donor paths from the data provider.
+ * @param {Array<string>} paths Paths to the ontology-term objects to request
+ * @param {object} request The request object to use to make the request
+ * @returns {Array<object>} The ontology term objects requested
+ */
+export async function requestOntologyTerms(paths, request) {
+  return paths.length > 0
+    ? request.getMultipleObjectsBulk(paths, null, ["term_id", "term_name"])
+    : [];
+}
+
+/**
+ * Retrieve the phenotypic-feature objects for the given phenotypic-feature paths from the data
+ * provider.
+ * @param {Array<string>} paths Paths to the phenotypic-feature objects to request
+ * @param {object} request The request object to use to make the request
+ * @returns {Array<object>} The phenotypic features objects requested
+ */
+export async function requestPhenotypicFeatures(paths, request) {
+  return paths.length > 0
+    ? request.getMultipleObjectsBulk(paths, null, [
+        "feature",
+        "observation_date",
+        "quantity",
+        "quantity_units",
+      ])
+    : [];
+}
+
+/**
+ * Retrieve the software-version objects for the given software-version paths from the data
+ * provider.
+ * @param {Array<string>} paths Paths to the software-version objects to request
+ * @param {object} request The request object to use to make the request
+ * @returns {Array<object>} The software version objects requested
+ */
+export async function requestSoftwareVersions(paths, request) {
+  return paths.length > 0
+    ? request.getMultipleObjectsBulk(paths, null, ["version", "downloaded_url"])
+    : [];
+}
+
+/**
+ * Retrieve the treatment objects for the given treatment paths from the data provider.
+ * @param {Array<string>} paths Paths to the treatment objects to request
+ * @param {object} request The request object to use to make the request
+ * @returns {Array<object>} The treatment objects requested
+ */
+export async function requestTreatments(paths, request) {
+  return paths.length > 0
+    ? request.getMultipleObjectsBulk(paths, null, [
+        "amount",
+        "duration",
+        "purpose",
+        "treatment_term_id",
+        "treatment_term_name",
+        "treatment_type",
+      ])
+    : [];
+}
+
+/**
+ * Retrieve the user objects for the given user paths from the data provider.
+ * @param {Array<string>} paths Paths to the user objects to request
+ * @param {object} request The request object to use to make the request
+ * @returns {Array<object>} The user objects requested
+ */
+export async function requestUsers(paths, request) {
+  return paths.length > 0
+    ? request.getMultipleObjectsBulk(paths, null, ["title"])
+    : [];
+}

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -49,3 +49,6 @@ export const KC = {
   ESC: 27,
   SPACE: 32,
 };
+
+// Maximum number of characters in the URL, minus an arbitrary amount for the domain name.
+export const MAX_URL_LENGTH = 4000;

--- a/lib/fetch-request.js
+++ b/lib/fetch-request.js
@@ -380,7 +380,7 @@ export default class FetchRequest {
    * parallel, it instead requests a `/search`, passing in the `@id` of every requested object, as
    * well as the fields needed for each object.
    * @param {Array<string>} paths Path of each object to request
-   * @param {<any> defaultErrorValue Value to return if the request fails; error object if not given
+   * @param {<any>} defaultErrorValue Value to return if the request fails; error object if not given
    * @param {Array<string>} fields Properties of each object to retrieve
    * @returns {Array<object>} Array of requested objects
    */
@@ -401,7 +401,7 @@ export default class FetchRequest {
       const results = await Promise.all(
         pathGroups.map(async (group) => {
           const pathQuery = group.map((path) => `@id=${path}`).join("&");
-          const query = `${fieldQuery}&${pathQuery}`;
+          const query = `${fieldQuery ? `${fieldQuery}&` : ""}${pathQuery}`;
           const response = await this.getObject(
             `/search/?${query}&limit=${group.length}`,
             null
@@ -413,12 +413,15 @@ export default class FetchRequest {
 
           // The response was an error. Add an empty array to the path groups, so that segment of
           // results gets skipped.
-          return [];
+          return null;
         })
       );
 
       // Flatten the results array of arrays into a single array.
-      return results.flat();
+      const flattenedResults = results.flat();
+      return flattenedResults.includes(null)
+        ? defaultErrorValue
+        : flattenedResults;
     }
     return [];
   }

--- a/lib/fetch-request.js
+++ b/lib/fetch-request.js
@@ -25,10 +25,8 @@
  * `defaultErrorValue`.
  */
 
-// node_modules
-import _ from "lodash";
 // lib
-import { API_URL, SERVER_URL, BACKEND_URL } from "./constants";
+import { API_URL, SERVER_URL, BACKEND_URL, MAX_URL_LENGTH } from "./constants";
 
 const FETCH_METHOD = {
   GET: "GET",
@@ -125,6 +123,11 @@ const NETWORK_ERROR_RESPONSE = {
 Object.freeze(NETWORK_ERROR_RESPONSE);
 
 /**
+ * Estimate of the maximum size of an @id=path query-string element.
+ */
+const MAX_PATH_QUERY_LENGTH_ESTIMATE = 50;
+
+/**
  * Log a request from the NextJS server to igvfd.
  * @param {string} method FetchRequest method that performs the request
  * @param {string} path Path or paths to requested resource
@@ -193,6 +196,41 @@ export default class FetchRequest {
     if (backend) {
       this.#backend = true;
     }
+  }
+
+  /**
+   * Take an array of paths to database objects, and break it into groups of paths to fit within
+   * the maximum size of a query string -- each group an array of paths with a maximum calculated
+   * size. This function returns an array of these groups -- an array of arrays of paths, with no
+   * sub-array having a length greater than the amount that would fit within a URL.
+   * @param {Array<string>} paths Path of each object to request
+   * @param {number} adjustment Number of characters to subtract from the URL length for other
+   *     query-string elements
+   * @returns {Array<Array<string>>} Array of arrays (groups) of paths
+   */
+  #pathsIntoPathGroups(paths, adjustment) {
+    // Calculate the maximum number of paths that can fit into a query string.
+    const maxGroupSize = Math.floor(
+      (MAX_URL_LENGTH - adjustment) / MAX_PATH_QUERY_LENGTH_ESTIMATE
+    );
+
+    // Break the paths into groups of maxGroupSize. Each group gets converted to a query string
+    // and sent as a single request.
+    const pathGroups = paths.reduce(
+      (groups, path) => {
+        const lastGroup = groups[groups.length - 1];
+        if (lastGroup.length < maxGroupSize) {
+          // The last group in the array of groups still has room for a new path.
+          lastGroup.push(path);
+          return groups;
+        }
+
+        // No room for another path in the last group. Make a new last group at the end.
+        return [...groups, [path]];
+      },
+      [[]]
+    );
+    return pathGroups;
   }
 
   /**
@@ -338,44 +376,51 @@ export default class FetchRequest {
   }
 
   /**
-   * Given an array of objects containing paths to other objects, request all these objects from
-   * the server and embed them in place of the paths, mutating the objects in `items`. Any
-   * requested objects that fail to get retrieved don't get embedded, and its property in the
-   * corresponding item gets set to null. If you need to embed multiple properties, call this
-   * method once for each property.
-   * @param {array} items Objects containing non-embedded properties to fetch and embed
-   * @param {string} embedProp Property of each item to fetch and embed
-   * @returns {array} Array of objects with embedded properties
+   * Same as the `getMultipleObjects()` method, but instead of requesting each individual object in
+   * parallel, it instead requests a `/search`, passing in the `@id` of every requested object, as
+   * well as the fields needed for each object.
+   * @param {Array<string>} paths Path of each object to request
+   * @param {<any> defaultErrorValue Value to return if the request fails; error object if not given
+   * @param {Array<string>} fields Properties of each object to retrieve
+   * @returns {Array<object>} Array of requested objects
    */
-  async getAndEmbedCollectionObjects(items, embedProp) {
-    // Retrieve the specified non-embedded objects from the server. Any objects that return an
-    // error get filtered out.
-    const paths = _.uniq(items.map((item) => item[embedProp]));
-    const objects = await this.getMultipleObjects(paths, null);
-    const successfulObjects = objects.filter((object) => object);
+  async getMultipleObjectsBulk(paths, defaultErrorValue, fields) {
+    logRequest("getMultipleObjectsBulk", `[${paths.join(", ")}]`);
 
-    // Embed the retrieved objects in the given items. Use a simple cache using the embedded
-    // property path as a key to reduce the number of searches through the fetched objects.
-    const cache = {};
-    items.forEach((item) => {
-      const objectPath = item[embedProp];
-      let cachedObject = cache[objectPath];
-      if (!cachedObject) {
-        // Cache miss: add requested object to the cache with its path as key. Any objects
-        // containing fetch errors won't have an @id, so they don't get cached nor embedded.
-        const matchingObject = successfulObjects.find(
-          (object) => object["@id"] === objectPath
-        );
-        if (matchingObject) {
-          cache[objectPath] = matchingObject;
-          cachedObject = cache[objectPath];
-        }
-      }
+    if (paths.length > 0) {
+      // Generate the query string for the needed fields of each object.
+      const fieldQuery = fields.map((field) => `field=${field}`).join("&");
 
-      // Set the embedded property to the (possibly newly) cached object, or null if we couldn't
-      // retrieve the corresponding object.
-      item[embedProp] = cachedObject || null;
-    });
+      // Break the paths into groups of MAX_PATH_GROUP_SIZE, each group mapping to a data-provider
+      // request. This reduces the lengths of the query strings to fit within the data provider's
+      // limits.
+      const pathGroups = this.#pathsIntoPathGroups(paths, fieldQuery.length);
+
+      // For each group of paths, request the objects as search results. Send these requests in
+      // parallel.
+      const results = await Promise.all(
+        pathGroups.map(async (group) => {
+          const pathQuery = group.map((path) => `@id=${path}`).join("&");
+          const query = `${fieldQuery}&${pathQuery}`;
+          const response = await this.getObject(
+            `/search/?${query}&limit=${group.length}`,
+            null
+          );
+          if (response?.["@graph"]) {
+            // Add the results to the array of results.
+            return response["@graph"];
+          }
+
+          // The response was an error. Add an empty array to the path groups, so that segment of
+          // results gets skipped.
+          return [];
+        })
+      );
+
+      // Flatten the results array of arrays into a single array.
+      return results.flat();
+    }
+    return [];
   }
 
   /**

--- a/lib/search-results.js
+++ b/lib/search-results.js
@@ -1,5 +1,7 @@
 // node_modules
 import _ from "lodash";
+// lib
+import { getQueryStringFromServerQuery } from "./query-utils";
 
 /**
  * Gets an array of item `@type` values from the search results, sorted (case sensitive) and with
@@ -37,5 +39,31 @@ export function composeSearchResultsPageTitle(searchResults, profiles) {
         }`
       : title;
   }
+  return "";
+}
+
+/**
+ * Determines whether the search-results query string contains a limit= query parameter with a
+ * value > 1000, with more than one value, or with a non-numeric value. If so, return a query
+ * string to redirect to search without the limit= query parameter; otherwise return an empty
+ * string to indicate no redirect needed.
+ * @param {object} query Query object from the server
+ * @returns {string} Query string to redirect to search without the limit= query parameter; empty
+ *   string if no redirect needed
+ */
+export function stripLimitQueryIfNeeded(query) {
+  if (query.limit) {
+    // Multiple limit= query parameters, or a non-numeric ones, get unconditionally stripped.
+    const limit =
+      Array.isArray(query.limit) || isNaN(query.limit)
+        ? -1
+        : Number(query.limit);
+    if (limit === -1 || limit > 1000) {
+      delete query.limit;
+      return getQueryStringFromServerQuery(query);
+    }
+  }
+
+  // Return an empty string to indicate we don't need a redirect.
   return "";
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1919,9 +1919,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.54.tgz",
-      "integrity": "sha512-uq7O52wvo2Lggsx1x21tKZgqkJpvwCseBBPtX/nKQfpVlEsLOb11zZ1CRsWUKvJF0+lzuA9jwvA7Pr2Wt7i3xw==",
+      "version": "16.18.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.39.tgz",
+      "integrity": "sha512-8q9ZexmdYYyc5/cfujaXb4YOucpQxAV4RMG0himLyDUOEr8Mr79VrqsFI+cQ2M2h89YIuy95lbxuYjxT4Hk4kQ==",
       "dev": true
     },
     "node_modules/@types/prop-types": {
@@ -3385,15 +3385,15 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.17.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.2.tgz",
-      "integrity": "sha512-hxWAaWbqQBzzMuadSGSuQg5PDvIGOovm6xm0hIfpCVcORsCAj/gF2p0EvfnJ4f+jK2PCiDgP6D2eeE9/FK4Mjg==",
+      "version": "12.17.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.3.tgz",
+      "integrity": "sha512-/R4+xdIDjUSLYkiQfwJd630S81KIgicmQOLXotFxVXkl+eTeVO+3bHXxdi5KBh/OgC33HWN33kHX+0tQR/ZWpg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^2.88.11",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^14.14.31",
+        "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -3906,9 +3906,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.480",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.480.tgz",
-      "integrity": "sha512-IXTgg+bITkQv/FLP9FjX6f9KFCs5hQWeh5uNSKxB9mqYj/JXhHDbu+ekS43LVvbkL3eW6/oZy4+r9Om6lan1Uw==",
+      "version": "1.4.481",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.481.tgz",
+      "integrity": "sha512-25DitMKGaWUPjv3kCt2H3UqgMhmdN+ufG+PoSjnQtheR64Dvo75RbojLPzUmnwrEuLEzR5YrbTzOUq9DtnTUUw==",
       "dev": true
     },
     "node_modules/emittery": {

--- a/pages/alignment-files/[id].js
+++ b/pages/alignment-files/[id].js
@@ -22,6 +22,7 @@ import SeparatedList from "../../components/separated-list";
 // lib
 import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import { requestDocuments, requestFiles } from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -57,7 +58,7 @@ export default function AlignmentFile({
                     <DataItemValue>
                       <SeparatedList>
                         {referenceFiles.map((file) => (
-                          <Link href={file["@id"]} key={file.uuid}>
+                          <Link href={file["@id"]} key={file["@id"]}>
                             {file.accession}
                           </Link>
                         ))}
@@ -119,17 +120,13 @@ export async function getServerSideProps({ params, req, query }) {
   if (FetchRequest.isResponseSuccess(alignmentFile)) {
     const fileSet = await request.getObject(alignmentFile.file_set, null);
     const documents = alignmentFile.documents
-      ? await request.getMultipleObjects(alignmentFile.documents, null, {
-          filterErrors: true,
-        })
+      ? await requestDocuments(alignmentFile.documents, request)
       : [];
     const derivedFrom = alignmentFile.derived_from
-      ? await request.getMultipleObjects(alignmentFile.derived_from, null, {
-          filterErrors: true,
-        })
+      ? await requestFiles(alignmentFile.derived_from, request)
       : [];
     const referenceFiles = alignmentFile.reference_files
-      ? await request.getMultipleObjects(alignmentFile.reference_files, null)
+      ? await requestFiles(alignmentFile.reference_files, request)
       : [];
     const breadcrumbs = await buildBreadcrumbs(
       alignmentFile,

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -22,6 +22,11 @@ import SeparatedList from "../../components/separated-list";
 // lib
 import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import {
+  requestDocuments,
+  requestDonors,
+  requestFiles,
+} from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -134,23 +139,15 @@ export async function getServerSideProps({ params, req, query }) {
   const analysisSet = await request.getObject(`/analysis-sets/${params.id}/`);
   if (FetchRequest.isResponseSuccess(analysisSet)) {
     const documents = analysisSet.documents
-      ? await request.getMultipleObjects(analysisSet.documents, null, {
-          filterErrors: true,
-        })
+      ? await requestDocuments(analysisSet.documents, request)
       : [];
     const filePaths = analysisSet.files.map((file) => file["@id"]);
     const files =
-      filePaths.length > 0
-        ? await request.getMultipleObjects(filePaths, null, {
-            filterErrors: true,
-          })
-        : [];
+      filePaths.length > 0 ? await requestFiles(filePaths, request) : [];
     let donors = [];
     if (analysisSet.donors) {
       const donorPaths = analysisSet.donors.map((donor) => donor["@id"]);
-      donors = await request.getMultipleObjects(donorPaths, null, {
-        filterErrors: true,
-      });
+      donors = await requestDonors(donorPaths, request);
     }
     const breadcrumbs = await buildBreadcrumbs(
       analysisSet,

--- a/pages/assay-terms/[name].js
+++ b/pages/assay-terms/[name].js
@@ -15,6 +15,7 @@ import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import { requestOntologyTerms } from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -64,9 +65,7 @@ export async function getServerSideProps({ params, req, query }) {
   );
   if (FetchRequest.isResponseSuccess(assayOntologyTerm)) {
     const isA = assayOntologyTerm.is_a
-      ? await request.getMultipleObjects(assayOntologyTerm.is_a, null, {
-          filterErrors: true,
-        })
+      ? await requestOntologyTerms(assayOntologyTerm.is_a, request)
       : [];
     const breadcrumbs = await buildBreadcrumbs(
       assayOntologyTerm,

--- a/pages/awards/[name].js
+++ b/pages/awards/[name].js
@@ -15,6 +15,7 @@ import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import { requestUsers } from "../../lib/common-requests";
 import { formatDateRange } from "../../lib/dates";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
@@ -45,7 +46,7 @@ export default function Award({ award, pis, contactPi, isJson }) {
                   <DataItemValue>
                     <SeparatedList>
                       {pis.map((pi) => (
-                        <Link href={pi["@id"]} key={pi.uuid}>
+                        <Link href={pi["@id"]} key={pi["@id"]}>
                           {pi.title}
                         </Link>
                       ))}
@@ -120,11 +121,7 @@ export async function getServerSideProps({ params, req, query }) {
   const award = await request.getObject(`/awards/${params.name}/`);
   if (FetchRequest.isResponseSuccess(award)) {
     const pis =
-      award.pis?.length > 0
-        ? await request.getMultipleObjects(award.pis, null, {
-            filterErrors: true,
-          })
-        : [];
+      award.pis?.length > 0 ? await requestUsers(award.pis, request) : [];
     const contactPi = award.contact_pi
       ? await request.getObject(award.contact_pi, null)
       : null;

--- a/pages/curated-sets/[id].js
+++ b/pages/curated-sets/[id].js
@@ -22,6 +22,11 @@ import SeparatedList from "../../components/separated-list";
 import AliasList from "../../components/alias-list";
 import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import {
+  requestDocuments,
+  requestDonors,
+  requestFiles,
+} from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -129,22 +134,14 @@ export async function getServerSideProps({ params, req, query }) {
   const curatedSet = await request.getObject(`/curated-sets/${params.id}/`);
   if (FetchRequest.isResponseSuccess(curatedSet)) {
     const documents = curatedSet.documents
-      ? await request.getMultipleObjects(curatedSet.documents, null, {
-          filterErrors: true,
-        })
+      ? await requestDocuments(curatedSet.documents, request)
       : [];
     const donors = curatedSet.donors
-      ? await request.getMultipleObjects(curatedSet.donors, null, {
-          filterErrors: true,
-        })
+      ? await requestDonors(curatedSet.donors, request)
       : [];
     const filePaths = curatedSet.files.map((file) => file["@id"]);
     const files =
-      filePaths.length > 0
-        ? await request.getMultipleObjects(filePaths, null, {
-            filterErrors: true,
-          })
-        : [];
+      filePaths.length > 0 ? await requestFiles(filePaths, request) : [];
     const breadcrumbs = await buildBreadcrumbs(
       curatedSet,
       "accession",

--- a/pages/in-vitro-systems/[id].js
+++ b/pages/in-vitro-systems/[id].js
@@ -22,6 +22,14 @@ import TreatmentTable from "../../components/treatment-table";
 // lib
 import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import {
+  requestBiomarkers,
+  requestBiosamples,
+  requestDocuments,
+  requestDonors,
+  requestOntologyTerms,
+  requestTreatments,
+} from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { truthyOrZero } from "../../lib/general";
@@ -131,7 +139,7 @@ InVitroSystem.propTypes = {
   biomarkers: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Part of Biosample
   partOf: PropTypes.object,
-  // The targeted endpoint biosample resulting from differentation or reprogramming
+  // The targeted endpoint biosample resulting from differentiation or reprogramming
   targetedSampleTerm: PropTypes.object,
   // Attribution for this sample
   attribution: PropTypes.object,
@@ -154,19 +162,13 @@ export async function getServerSideProps({ params, req, query }) {
       const diseaseTermPaths = inVitroSystem.disease_terms.map(
         (diseaseTerm) => diseaseTerm["@id"]
       );
-      diseaseTerms = await request.getMultipleObjects(diseaseTermPaths, null, {
-        filterErrors: true,
-      });
+      diseaseTerms = await requestOntologyTerms(diseaseTermPaths, request);
     }
     const documents = inVitroSystem.documents
-      ? await request.getMultipleObjects(inVitroSystem.documents, null, {
-          filterErrors: true,
-        })
+      ? await requestDocuments(inVitroSystem.documents, request)
       : [];
     const donors = inVitroSystem.donors
-      ? await request.getMultipleObjects(inVitroSystem.donors, null, {
-          filterErrors: true,
-        })
+      ? await requestDonors(inVitroSystem.donors, request)
       : [];
     const source = await request.getObject(inVitroSystem.source["@id"], null);
     let treatments = [];
@@ -174,15 +176,11 @@ export async function getServerSideProps({ params, req, query }) {
       const treatmentPaths = inVitroSystem.treatments.map(
         (treatment) => treatment["@id"]
       );
-      treatments = await request.getMultipleObjects(treatmentPaths, null, {
-        filterErrors: true,
-      });
+      treatments = await requestTreatments(treatmentPaths, request);
     }
     const pooledFrom =
       inVitroSystem.pooled_from?.length > 0
-        ? await request.getMultipleObjects(inVitroSystem.pooled_from, null, {
-            filterErrors: true,
-          })
+        ? await requestBiosamples(inVitroSystem.pooled_from, request)
         : [];
     const partOf = inVitroSystem.part_of
       ? await request.getObject(inVitroSystem.part_of, null)
@@ -192,9 +190,7 @@ export async function getServerSideProps({ params, req, query }) {
       : null;
     const biomarkers =
       inVitroSystem.biomarkers?.length > 0
-        ? await request.getMultipleObjects(inVitroSystem.biomarkers, null, {
-            filterErrors: true,
-          })
+        ? await requestBiomarkers(inVitroSystem.biomarkers, request)
         : [];
     const breadcrumbs = await buildBreadcrumbs(
       inVitroSystem,

--- a/pages/labs/[name].js
+++ b/pages/labs/[name].js
@@ -16,6 +16,7 @@ import PagePreamble from "../../components/page-preamble";
 import SeparatedList from "../../components/separated-list";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import { requestAwards } from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -97,9 +98,7 @@ export async function getServerSideProps({ params, req, query }) {
     let awards = [];
     if (lab.awards?.length > 0) {
       const awardPaths = lab.awards.map((award) => award["@id"]);
-      awards = await request.getMultipleObjects(awardPaths, null, {
-        filterErrors: true,
-      });
+      awards = await requestAwards(awardPaths, request);
     }
     const pi = await request.getObject(lab.pi, null);
     const breadcrumbs = await buildBreadcrumbs(

--- a/pages/models/[id].js
+++ b/pages/models/[id].js
@@ -23,6 +23,7 @@ import SeparatedList from "../../components/separated-list";
 // lib
 import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import { requestDocuments, requestFiles } from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -157,17 +158,11 @@ export async function getServerSideProps({ params, req, query }) {
       ? await request.getObject(model.software_version, null)
       : null;
     const documents = model.documents
-      ? await request.getMultipleObjects(model.documents, null, {
-          filterErrors: true,
-        })
+      ? await requestDocuments(model.documents, request)
       : [];
     const filePaths = model.files.map((file) => file["@id"]);
     const files =
-      filePaths.length > 0
-        ? await request.getMultipleObjects(filePaths, null, {
-            filterErrors: true,
-          })
-        : [];
+      filePaths.length > 0 ? await requestFiles(filePaths, request) : [];
 
     const breadcrumbs = await buildBreadcrumbs(
       model,

--- a/pages/primary-cells/[uuid].js
+++ b/pages/primary-cells/[uuid].js
@@ -21,6 +21,14 @@ import TreatmentTable from "../../components/treatment-table";
 // lib
 import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import {
+  requestBiomarkers,
+  requestBiosamples,
+  requestDocuments,
+  requestDonors,
+  requestOntologyTerms,
+  requestTreatments,
+} from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { truthyOrZero } from "../../lib/general";
@@ -135,40 +143,28 @@ export async function getServerSideProps({ params, req, query }) {
       const diseaseTermPaths = primaryCell.disease_terms.map(
         (diseaseTerm) => diseaseTerm["@id"]
       );
-      diseaseTerms = await request.getMultipleObjects(diseaseTermPaths, null, {
-        filterErrors: true,
-      });
+      diseaseTerms = await requestOntologyTerms(diseaseTermPaths, request);
     }
     const documents = primaryCell.documents
-      ? await request.getMultipleObjects(primaryCell.documents, null, {
-          filterErrors: true,
-        })
+      ? await requestDocuments(primaryCell.documents, request)
       : [];
     const donors = primaryCell.donors
-      ? await request.getMultipleObjects(primaryCell.donors, null, {
-          filterErrors: true,
-        })
+      ? await requestDonors(primaryCell.donors, request)
       : [];
     const source = await request.getObject(primaryCell.source["@id"], null);
     const treatments = primaryCell.treatments
-      ? await request.getMultipleObjects(primaryCell.treatments, null, {
-          filterErrors: true,
-        })
+      ? await requestTreatments(primaryCell.treatments, request)
       : [];
     const pooledFrom =
       primaryCell.pooled_from?.length > 0
-        ? await request.getMultipleObjects(primaryCell.pooled_from, null, {
-            filterErrors: true,
-          })
+        ? await requestBiosamples(primaryCell.pooled_from, request)
         : [];
     const partOf = primaryCell.part_of
       ? await request.getObject(primaryCell.part_of, null)
       : null;
     const biomarkers =
       primaryCell.biomarkers?.length > 0
-        ? await request.getMultipleObjects(primaryCell.biomarkers, null, {
-            filterErrors: true,
-          })
+        ? await requestBiomarkers(primaryCell.biomarkers, request)
         : [];
     const breadcrumbs = await buildBreadcrumbs(
       primaryCell,

--- a/pages/reference-files/[id].js
+++ b/pages/reference-files/[id].js
@@ -21,6 +21,7 @@ import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import { requestDocuments, requestFiles } from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -108,14 +109,10 @@ export async function getServerSideProps({ params, req, query }) {
   if (FetchRequest.isResponseSuccess(referenceFile)) {
     const fileSet = await request.getObject(referenceFile.file_set, null);
     const documents = referenceFile.documents
-      ? await request.getMultipleObjects(referenceFile.documents, null, {
-          filterErrors: true,
-        })
+      ? await requestDocuments(referenceFile.documents, request)
       : [];
     const derivedFrom = referenceFile.derived_from
-      ? await request.getMultipleObjects(referenceFile.derived_from, null, {
-          filterErrors: true,
-        })
+      ? await requestFiles(referenceFile.derived_from, request)
       : [];
     const breadcrumbs = await buildBreadcrumbs(
       referenceFile,

--- a/pages/report.js
+++ b/pages/report.js
@@ -36,7 +36,10 @@ import {
   getSortColumn,
   schemaColumnsToColumnSpecs,
 } from "../lib/report";
-import { composeSearchResultsPageTitle } from "../lib/search-results";
+import {
+  composeSearchResultsPageTitle,
+  stripLimitQueryIfNeeded,
+} from "../lib/search-results";
 
 /**
  * Update the given query string to show or hide a column.
@@ -240,6 +243,18 @@ Report.propTypes = {
 };
 
 export async function getServerSideProps({ req, query }) {
+  // if the limit= query parameter exists, redirect to this page without it if its value is > 1000
+  // or if it has more than one value.
+  const limitlessRedirect = stripLimitQueryIfNeeded(query);
+  if (limitlessRedirect) {
+    return {
+      redirect: {
+        destination: `/report/?${limitlessRedirect}`,
+        permanent: true,
+      },
+    };
+  }
+
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const queryParams = getQueryStringFromServerQuery(query);
   const searchResults = await request.getObject(`/report/?${queryParams}`);

--- a/pages/sequence-files/[id].js
+++ b/pages/sequence-files/[id].js
@@ -20,6 +20,7 @@ import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import { requestDocuments, requestFiles } from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { truthyOrZero } from "../../lib/general";
@@ -103,14 +104,10 @@ export async function getServerSideProps({ params, req, query }) {
   if (FetchRequest.isResponseSuccess(sequenceFile)) {
     const fileSet = await request.getObject(sequenceFile.file_set, null);
     const documents = sequenceFile.documents
-      ? await request.getMultipleObjects(sequenceFile.documents, null, {
-          filterErrors: true,
-        })
+      ? await requestDocuments(sequenceFile.documents, request)
       : [];
     const derivedFrom = sequenceFile.derived_from
-      ? await request.getMultipleObjects(sequenceFile.derived_from, null, {
-          filterErrors: true,
-        })
+      ? await requestFiles(sequenceFile.derived_from, request)
       : [];
     const breadcrumbs = await buildBreadcrumbs(
       sequenceFile,

--- a/pages/signal-files/[id].js
+++ b/pages/signal-files/[id].js
@@ -22,6 +22,7 @@ import SeparatedList from "../../components/separated-list";
 // lib
 import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import { requestDocuments, requestFiles } from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -57,7 +58,7 @@ export default function SignalFile({
                     <DataItemValue>
                       <SeparatedList>
                         {referenceFiles.map((file) => (
-                          <Link href={file["@id"]} key={file.uuid}>
+                          <Link href={file["@id"]} key={file["@id"]}>
                             {file.accession}
                           </Link>
                         ))}
@@ -135,17 +136,13 @@ export async function getServerSideProps({ params, req, query }) {
   if (FetchRequest.isResponseSuccess(signalFile)) {
     const fileSet = await request.getObject(signalFile.file_set, null);
     const documents = signalFile.documents
-      ? await request.getMultipleObjects(signalFile.documents, null, {
-          filterErrors: true,
-        })
+      ? await requestDocuments(signalFile.documents, request)
       : [];
     const derivedFrom = signalFile.derived_from
-      ? await request.getMultipleObjects(signalFile.derived_from, null, {
-          filterErrors: true,
-        })
+      ? await requestFiles(signalFile.derived_from, request)
       : [];
     const referenceFiles = signalFile.reference_files
-      ? await request.getMultipleObjects(signalFile.reference_files, null)
+      ? await requestFiles(signalFile.reference_files, request)
       : [];
     const breadcrumbs = await buildBreadcrumbs(
       signalFile,

--- a/pages/software/[id].js
+++ b/pages/software/[id].js
@@ -17,6 +17,7 @@ import PagePreamble from "../../components/page-preamble";
 import SoftwareVersionTable from "../../components/software-version-table";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import { requestSoftwareVersions } from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import AliasList from "../../components/alias-list";
@@ -92,9 +93,7 @@ export async function getServerSideProps({ params, req, query }) {
     const lab = await request.getObject(software.lab["@id"], null);
     const versions =
       software.versions.length > 0
-        ? await request.getMultipleObjects(software.versions, null, {
-            filterErrors: true,
-          })
+        ? await requestSoftwareVersions(software.versions, request)
         : [];
     const breadcrumbs = await buildBreadcrumbs(
       software,

--- a/pages/technical-samples/[uuid].js
+++ b/pages/technical-samples/[uuid].js
@@ -20,6 +20,7 @@ import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import { requestDocuments } from "../../lib/common-requests";
 import { formatDate } from "../../lib/dates";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
@@ -91,9 +92,7 @@ export async function getServerSideProps({ params, req, query }) {
   const sample = await request.getObject(`/technical-samples/${params.uuid}/`);
   if (FetchRequest.isResponseSuccess(sample)) {
     const documents = sample.documents
-      ? await request.getMultipleObjects(sample.documents, null, {
-          filterErrors: true,
-        })
+      ? await requestDocuments(sample.documents, request)
       : [];
     const source = await request.getObject(sample.source["@id"], null);
     const breadcrumbs = await buildBreadcrumbs(

--- a/pages/tissues/[uuid].js
+++ b/pages/tissues/[uuid].js
@@ -21,6 +21,14 @@ import TreatmentTable from "../../components/treatment-table";
 // lib
 import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import {
+  requestBiomarkers,
+  requestBiosamples,
+  requestDocuments,
+  requestDonors,
+  requestOntologyTerms,
+  requestTreatments,
+} from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -149,42 +157,28 @@ export async function getServerSideProps({ params, req, query }) {
     let diseaseTerms = [];
     if (tissue.disease_terms?.length > 0) {
       const diseaseTermPaths = tissue.disease_terms.map((term) => term["@id"]);
-      diseaseTerms = tissue.disease_terms
-        ? await request.getMultipleObjects(diseaseTermPaths, null, {
-            filterErrors: true,
-          })
-        : [];
+      diseaseTerms = await requestOntologyTerms(diseaseTermPaths, request);
     }
     const documents = tissue.documents
-      ? await request.getMultipleObjects(tissue.documents, null, {
-          filterErrors: true,
-        })
+      ? await requestDocuments(tissue.documents, request)
       : [];
     const donors = tissue.donors
-      ? await request.getMultipleObjects(tissue.donors, null, {
-          filterErrors: true,
-        })
+      ? await requestDonors(tissue.donors, request)
       : [];
     const source = await request.getObject(tissue.source["@id"], null);
     const treatments = tissue.treatments
-      ? await request.getMultipleObjects(tissue.treatments, null, {
-          filterErrors: true,
-        })
+      ? await requestTreatments(tissue.treatments, request)
       : [];
     const pooledFrom =
       tissue.pooled_from?.length > 0
-        ? await request.getMultipleObjects(tissue.pooled_from, null, {
-            filterErrors: true,
-          })
+        ? await requestBiosamples(tissue.pooled_from, request)
         : [];
     const partOf = tissue.part_of
       ? await request.getObject(tissue.part_of, null)
       : null;
     const biomarkers =
       tissue.biomarkers?.length > 0
-        ? await request.getMultipleObjects(tissue.biomarkers, null, {
-            filterErrors: true,
-          })
+        ? await requestBiomarkers(tissue.biomarkers, request)
         : [];
     const breadcrumbs = await buildBreadcrumbs(
       tissue,

--- a/pages/treatments/[uuid].js
+++ b/pages/treatments/[uuid].js
@@ -17,6 +17,7 @@ import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import { requestDocuments } from "../../lib/common-requests";
 import { UC } from "../../lib/constants";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
@@ -126,9 +127,7 @@ export async function getServerSideProps({ params, req, query }) {
   const treatment = await request.getObject(`/treatments/${params.uuid}/`);
   if (FetchRequest.isResponseSuccess(treatment)) {
     const documents = treatment.documents
-      ? await request.getMultipleObjects(treatment.documents, null, {
-          filterErrors: true,
-        })
+      ? await requestDocuments(treatment.documents, request)
       : [];
     const breadcrumbs = await buildBreadcrumbs(
       treatment,

--- a/pages/whole-organisms/[id].js
+++ b/pages/whole-organisms/[id].js
@@ -15,6 +15,14 @@ import TreatmentTable from "../../components/treatment-table";
 // lib
 import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
+import {
+  requestBiomarkers,
+  requestBiosamples,
+  requestDocuments,
+  requestDonors,
+  requestOntologyTerms,
+  requestTreatments,
+} from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -121,19 +129,13 @@ export async function getServerSideProps({ params, req, query }) {
       const diseaseTermPaths = sample.disease_terms.map(
         (diseaseTerm) => diseaseTerm["@id"]
       );
-      diseaseTerms = await request.getMultipleObjects(diseaseTermPaths, null, {
-        filterErrors: true,
-      });
+      diseaseTerms = await requestOntologyTerms(diseaseTermPaths, request);
     }
     const documents = sample.documents
-      ? await request.getMultipleObjects(sample.documents, null, {
-          filterErrors: true,
-        })
+      ? await requestDocuments(sample.documents, request)
       : [];
     const donors = sample.donors
-      ? await request.getMultipleObjects(sample.donors, null, {
-          filterErrors: true,
-        })
+      ? await requestDonors(sample.donors, request)
       : [];
     const source = await request.getObject(sample.source["@id"], null);
     let treatments = [];
@@ -141,26 +143,19 @@ export async function getServerSideProps({ params, req, query }) {
       const treatmentPaths = sample.treatments.map(
         (treatment) => treatment["@id"]
       );
-      treatments = await request.getMultipleObjects(treatmentPaths, null, {
-        filterErrors: true,
-      });
+      treatments = await requestTreatments(treatmentPaths, request);
     }
     const pooledFrom =
       sample.pooled_from?.length > 0
-        ? await request.getMultipleObjects(sample.pooled_from, null, {
-            filterErrors: true,
-          })
+        ? await requestBiosamples(sample.pooled_from, request)
         : [];
     const biomarkers =
       sample.biomarkers?.length > 0
-        ? await request.getMultipleObjects(
+        ? await requestBiomarkers(
             // Biomarkers are embedded in whole organism, so we map
             // to get as a list of IDs for the request
             sample.biomarkers.map((m) => m["@id"]),
-            null,
-            {
-              filterErrors: true,
-            }
+            request
           )
         : [];
     const partOf = sample.part_of


### PR DESCRIPTION
The `getMultipleObjectsBulk()` method of the `FetchRequest` class comprises the main change in this branch. This method replaces `getMultipleObjects()` in most cases for performance. Instead of making individual requests for multiple objects, it instead performs a `/search` request and specifies the `@id`s of each requested object, as well as the fields we want. Because this can result in _very_ long search URLs, these requests can get broken up into multiple parallel requests that fit into the 4094-character URL limit by a generous margin.

This applies mostly to object pages that need an array of objects, like an array of documents or samples. It also applies to search-list pages that might need several objects to render several search-list items that need linked objects. This caused a rewrite to the `getAccessoryDataPaths()` mechanism.

This branch also fixes the case where the user makes a large search or report request by manually editing the `limit=x` query-string parameter. If the user sets the limit to greater than 1000, we redirect to a search page without the `limit=x` parameter. Limits of 1000 or less get retained.

* I’ve moved many bulk requests to their own request functions in the new common-requests.js library file. This lets us have only once place to change the requested fields for particular objects.
* I often replace `uuid` with `@id` as the keys to rendering loops to avoid requesting the uuid in the new bulk requests — not really an issue to request `uuid`, but might as well avoid requesting a field just to use as a key when we can already use the `@id`.
* I removed the `getAndEmbedCollectionObjects()` method from FetchRequest, because we no longer use it.
* I removed the `parent` property of donor objects because they no longer exist in the schemas.
* With `getMultipleObjectsBulk()`, instead of individual objects potentially failing and needing to get filtered out, entire ranges of objects can fail to get retrieved, so keep that in mind.
