### PR TITLE
IGVF-936 Don’t display mismatched config/schema columns as manually entered columns

### DIFF
--- a/lib/__tests__/report.test.js
+++ b/lib/__tests__/report.test.js
@@ -360,6 +360,62 @@ describe("Test `getVisibleReportColumnSpecs()`", () => {
 
     expect(columnSpecs).toEqual([]);
   });
+
+  it("should filter out search config columns that don't exist in the schema", () => {
+    const searchResults = {
+      "@context": "/terms/",
+      "@graph": [
+        {
+          "@id": "/tissues/IGVFSM003DDD/",
+          "@type": ["Tissue", "Biosample", "Sample", "Item"],
+          accession: "IGVFSM003DDD",
+          award: "/awards/HG012012/",
+          biosample_term: "/sample-terms/UBERON_0002048/",
+          donors: ["/rodent-donors/IGVFDO820DHC/"],
+          lab: "/labs/j-michael-cherry/",
+          status: "released",
+          taxa: "Homo sapiens",
+          uuid: "fd5524f2-0303-11ed-b939-0242ac120002",
+        },
+      ],
+      "@id": "/search?type=Biosample",
+      "@type": ["Search"],
+      clear_filters: "/search?type=Biosample",
+      columns: {
+        "@id": {
+          title: "ID",
+        },
+        uuid: {
+          title: "UUID",
+        },
+        accessions: {
+          title: "Accession",
+        },
+      },
+      filters: [
+        {
+          field: "type",
+          term: "Biosample",
+          remove: "/search",
+        },
+      ],
+      title: "Search",
+      total: 1,
+    };
+
+    const columnSpecs = getVisibleReportColumnSpecs(searchResults, profiles);
+
+    expect(columnSpecs).toEqual([
+      {
+        id: "@id",
+        title: "ID",
+      },
+      {
+        id: "uuid",
+        title: "UUID",
+      },
+    ]);
+  });
 });
 
 describe("Test `getSortColumn()`", () => {

--- a/lib/report.js
+++ b/lib/report.js
@@ -88,6 +88,12 @@ export function getVisibleReportColumnSpecs(searchResults, profiles) {
       // No "field=" parameters exist in the query string, so all visible columns come from the search
       // result `columns` property.
       columnIds = Object.keys(searchResults.columns);
+
+      // Filter the columnIDs to only those that exist in the schema, in case the search config columns
+      // don't match the schema columns.
+      columnIds = columnIds.filter((columnId) =>
+        Object.keys(schema.properties).includes(columnId)
+      );
     }
 
     // Collect all properties from the schema. This represents all possible columns for the report.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1919,9 +1919,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.54.tgz",
-      "integrity": "sha512-uq7O52wvo2Lggsx1x21tKZgqkJpvwCseBBPtX/nKQfpVlEsLOb11zZ1CRsWUKvJF0+lzuA9jwvA7Pr2Wt7i3xw==",
+      "version": "16.18.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.39.tgz",
+      "integrity": "sha512-8q9ZexmdYYyc5/cfujaXb4YOucpQxAV4RMG0himLyDUOEr8Mr79VrqsFI+cQ2M2h89YIuy95lbxuYjxT4Hk4kQ==",
       "dev": true
     },
     "node_modules/@types/prop-types": {
@@ -3385,15 +3385,15 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.17.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.2.tgz",
-      "integrity": "sha512-hxWAaWbqQBzzMuadSGSuQg5PDvIGOovm6xm0hIfpCVcORsCAj/gF2p0EvfnJ4f+jK2PCiDgP6D2eeE9/FK4Mjg==",
+      "version": "12.17.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.3.tgz",
+      "integrity": "sha512-/R4+xdIDjUSLYkiQfwJd630S81KIgicmQOLXotFxVXkl+eTeVO+3bHXxdi5KBh/OgC33HWN33kHX+0tQR/ZWpg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^2.88.11",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^14.14.31",
+        "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",


### PR DESCRIPTION
* Update npm packages.
* Filter out search config columns that don’t exist in the schema. Update the Jest tests to update their coverage.
* Update package-lock.json after rebasing on dev.