### PR TITLE
IGVF-798-download-button-update

### DIFF
--- a/components/file-download.js
+++ b/components/file-download.js
@@ -1,29 +1,33 @@
 // node_modules
-import { ArrowDownOnSquareIcon } from "@heroicons/react/20/solid";
+import { ArrowDownTrayIcon } from "@heroicons/react/20/solid";
 import Link from "next/link";
 import PropTypes from "prop-types";
 // lib
 import { API_URL } from "../lib/constants";
+import { ButtonLink } from "./form-elements";
 
 /**
  * Display a file-download link and download icon. Only files with an `upload_status` of
  * `validated` show a download link.
  */
-export function FileDownload({ file, className = "h-4 w-4" }) {
-  const fileName = file.href.substr(file.href.lastIndexOf("/") + 1);
+export function FileDownload({
+  file,
+  className = "",
+}) {
 
   return (
     <>
-      {file.upload_status === "validated" && (
-        <a
-          aria-label={`Download file ${file.accession}`}
-          href={`${API_URL}${file.href}`}
-          download={fileName}
-          data-bypass="true"
-        >
-          <ArrowDownOnSquareIcon className={className} />
-        </a>
-      )}
+      <ButtonLink
+        label={`Download file ${file.accession}`}
+        href={`${API_URL}${file.href}`}
+        type="secondary"
+        size="sm"
+        isDisabled={file.upload_status !== "validated"}
+        hasIconOnly
+        className={`${className}`}
+      >
+        <ArrowDownTrayIcon />
+      </ButtonLink>
     </>
   );
 }

--- a/components/file-download.js
+++ b/components/file-download.js
@@ -6,6 +6,8 @@ import PropTypes from "prop-types";
 import { API_URL } from "../lib/constants";
 import { ButtonLink } from "./form-elements";
 
+const FILE_NOT_FOUND = "file not found";
+
 /**
  * Display a file-download link and download icon. Only files with an `upload_status` of
  * `validated` show a download link.
@@ -18,7 +20,7 @@ export function FileDownload({ file, className = "" }) {
         href={`${API_URL}${file.href}`}
         type="secondary"
         size="sm"
-        isDisabled={file.upload_status !== "validated"}
+        isDisabled={file.upload_status === FILE_NOT_FOUND}
         hasIconOnly
         className={`${className}`}
       >

--- a/components/file-download.js
+++ b/components/file-download.js
@@ -9,8 +9,8 @@ import { ButtonLink } from "./form-elements";
 const FILE_NOT_FOUND = "file not found";
 
 /**
- * Display a file-download link and download icon. Only files with an `upload_status` of
- * `validated` show a download link.
+ * Display a file-download link and download icon. Files without an `upload_status` of
+ * `file not found` show a download link.
  */
 export function FileDownload({ file, className = "" }) {
   return (

--- a/components/file-download.js
+++ b/components/file-download.js
@@ -10,11 +10,7 @@ import { ButtonLink } from "./form-elements";
  * Display a file-download link and download icon. Only files with an `upload_status` of
  * `validated` show a download link.
  */
-export function FileDownload({
-  file,
-  className = "",
-}) {
-
+export function FileDownload({ file, className = "" }) {
   return (
     <>
       <ButtonLink

--- a/components/file-download.js
+++ b/components/file-download.js
@@ -7,6 +7,7 @@ import { API_URL } from "../lib/constants";
 import { ButtonLink } from "./form-elements";
 
 const FILE_NOT_FOUND = "file not found";
+const PENDING = "pending";
 
 /**
  * Display a file-download link and download icon. Files without an `upload_status` of
@@ -20,7 +21,7 @@ export function FileDownload({ file, className = "" }) {
         href={`${API_URL}${file.href}`}
         type="secondary"
         size="sm"
-        isDisabled={file.upload_status === FILE_NOT_FOUND}
+        isDisabled={[FILE_NOT_FOUND, PENDING].includes(file.upload_status)}
         hasIconOnly
         className={`${className}`}
       >

--- a/components/form-elements/__tests__/button.test.js
+++ b/components/form-elements/__tests__/button.test.js
@@ -97,6 +97,17 @@ describe("ButtonLink component", () => {
     expect(container.firstChild).toHaveClass("border-button-selected");
     expect(container.firstChild).toHaveClass("text-button-selected");
   });
+
+  it("renders a selected button with the correct classes when disabled", () => {
+    const { container } = render(
+      <ButtonLink href="#" type="selected" isDisabled>
+        Secondary
+      </ButtonLink>
+    );
+    expect(container.firstChild).toHaveClass("bg-button-selected-disabled");
+    expect(container.firstChild).toHaveClass("border-button-selected-disabled");
+    expect(container.firstChild).toHaveClass("text-button-selected-disabled");
+  });
 });
 
 describe("Test the Tailwind CSS classes resulting from using the `hasIconOnly` flag", () => {

--- a/components/form-elements/__tests__/button.test.js
+++ b/components/form-elements/__tests__/button.test.js
@@ -105,7 +105,9 @@ describe("ButtonLink component", () => {
       </ButtonLink>
     );
     expect(container.firstChild).toHaveClass("bg-button-secondary-disabled");
-    expect(container.firstChild).toHaveClass("border-button-secondary-disabled");
+    expect(container.firstChild).toHaveClass(
+      "border-button-secondary-disabled"
+    );
     expect(container.firstChild).toHaveClass("text-button-secondary-disabled");
   });
 });

--- a/components/form-elements/__tests__/button.test.js
+++ b/components/form-elements/__tests__/button.test.js
@@ -98,15 +98,15 @@ describe("ButtonLink component", () => {
     expect(container.firstChild).toHaveClass("text-button-selected");
   });
 
-  it("renders a selected button with the correct classes when disabled", () => {
+  it("renders a secondary button with the correct classes when disabled", () => {
     const { container } = render(
-      <ButtonLink href="#" type="selected" isDisabled>
+      <ButtonLink href="#" type="secondary" isDisabled>
         Secondary
       </ButtonLink>
     );
-    expect(container.firstChild).toHaveClass("bg-button-selected-disabled");
-    expect(container.firstChild).toHaveClass("border-button-selected-disabled");
-    expect(container.firstChild).toHaveClass("text-button-selected-disabled");
+    expect(container.firstChild).toHaveClass("bg-button-secondary-disabled");
+    expect(container.firstChild).toHaveClass("border-button-secondary-disabled");
+    expect(container.firstChild).toHaveClass("text-button-secondary-disabled");
   });
 });
 

--- a/components/form-elements/button.js
+++ b/components/form-elements/button.js
@@ -29,18 +29,36 @@ import React from "react";
 const commonButtonClasses =
   "flex items-center justify-center border font-semibold leading-none";
 
+function enabledButtonTypeClass(bType) {
+  return [
+    `bg-button-${bType}`,
+    `border-button-${bType}`,
+    `text-button-${bType}`,
+    `fill-button-${bType}`,
+  ]; //disabled:bg-button-primary-disabled disabled:border-button-primary-disabled disabled:text-button-primary-disabled disabled:fill-button-primary-disabled`
+}
+
+function disabledButtonTypeClass(bType, pseudoClass = "") {
+  const pc = pseudoClass !== "" ? `${pseudoClass}:` : "";
+  return enabledButtonTypeClass(bType).map((c) => `${pc}${c}-disabled`);
+}
+
 /**
  * Background colors for each of the button types.
  */
 const buttonTypeClasses = {
-  primary:
-    "bg-button-primary border-button-primary text-button-primary fill-button-primary disabled:bg-button-primary-disabled disabled:border-button-primary-disabled disabled:text-button-primary-disabled disabled:fill-button-primary-disabled",
-  secondary:
-    "bg-button-secondary border-button-secondary text-button-secondary fill-button-secondary disabled:bg-button-secondary-disabled disabled:border-button-secondary-disabled disabled:text-button-secondary-disabled disabled:fill-button-secondary-disabled",
-  warning:
-    "bg-button-warning border-button-warning text-button-warning fill-button-warning disabled:bg-button-warning-disabled disabled:border-button-warning-disabled disabled:text-button-warning-disabled disabled:fill-button-warning-disabled",
-  selected:
-    "bg-button-selected border-button-selected text-button-selected fill-button-selected disabled:bg-button-selected-disabled disabled:border-button-selected-disabled disabled:text-button-selected-disabled disabled:fill-button-selected-disabled",
+  primary: `${enabledButtonTypeClass("primary").join(
+    " "
+  )} ${disabledButtonTypeClass("primary", "disabled").join(" ")}`,
+  secondary: `${enabledButtonTypeClass("secondary").join(
+    " "
+  )} ${disabledButtonTypeClass("secondary", "disabled").join(" ")}`,
+  warning: `${enabledButtonTypeClass("warning").join(
+    " "
+  )} ${disabledButtonTypeClass("warning", "disabled").join(" ")}`,
+  selected: `${enabledButtonTypeClass("selected").join(
+    " "
+  )} ${disabledButtonTypeClass("selected", "disabled").join(" ")}`,
 };
 
 /**
@@ -161,8 +179,8 @@ Button.propTypes = {
 Button.displayName = "Button";
 
 /**
- * Displays a button that links to a URL instead of performing an action. You cannot disable these
- * the way you can disable a button. Instead, hide inoperable link buttons.
+ * Displays a button that links to a URL instead of performing an action. When these
+ * are "disabled" they show just the children element using the "disabled" CSS.
  *
  * <ButtonLink href="/path/to/page">
  *   Go Here!
@@ -176,6 +194,7 @@ export function ButtonLink({
   size = "md",
   hasIconOnly = false,
   hasIconCircleOnly = false,
+  isDisabled = false,
   className = "",
   children,
 }) {
@@ -185,7 +204,17 @@ export function ButtonLink({
     hasIconCircleOnly
   );
 
-  return (
+  return isDisabled ? (
+    <div
+      aria-label={label}
+      id={id}
+      className={`text-center no-underline ${commonButtonClasses} ${sizeClasses} ${disabledButtonTypeClass(
+        type
+      ).join(" ")} ${className}`}
+    >
+      {children}
+    </div>
+  ) : (
     <Link
       href={href}
       aria-label={label}
@@ -212,6 +241,8 @@ ButtonLink.propTypes = {
   hasIconOnly: PropTypes.bool,
   // True for buttons that only contain an icon in a circular button
   hasIconCircleOnly: PropTypes.bool,
+  // Is Disabled
+  isDisabled: PropTypes.bool,
   // Additional Tailwind CSS classes to apply to the <button> element
   className: PropTypes.string,
 };

--- a/components/form-elements/button.js
+++ b/components/form-elements/button.js
@@ -29,15 +29,28 @@ import React from "react";
 const commonButtonClasses =
   "flex items-center justify-center border font-semibold leading-none";
 
+/**
+ * Generates a list of tailwind CSS classes for a particular button type when enabled
+ * @param {String} bType Button Type, either primary, secondary, warning, or selected
+ * @returns a list of CSS classes specialized for the button type
+ */
 function enabledButtonTypeClass(bType) {
   return [
     `bg-button-${bType}`,
     `border-button-${bType}`,
     `text-button-${bType}`,
     `fill-button-${bType}`,
-  ]; //disabled:bg-button-primary-disabled disabled:border-button-primary-disabled disabled:text-button-primary-disabled disabled:fill-button-primary-disabled`
+  ];
 }
 
+/**
+ * Like `enabledButtonTypeClass` but switching to the `disabled` variant
+ * @param {String} bType Button Type, either primary, secondary, warning, or selected
+ * @param {String} pseudoClass If specified, then this will be prepended to each class
+ * in the list e.g. for "disabled": "bg-button-secondary-disabled" becomes
+ * "disabled:bg-button-secondary-disabled"`
+ * @returns List of disabled variant of the button tailwind CSS classes
+ */
 function disabledButtonTypeClass(bType, pseudoClass = "") {
   const pc = pseudoClass !== "" ? `${pseudoClass}:` : "";
   return enabledButtonTypeClass(bType).map((c) => `${pc}${c}-disabled`);

--- a/components/form-elements/button.js
+++ b/components/form-elements/button.js
@@ -30,48 +30,23 @@ const commonButtonClasses =
   "flex items-center justify-center border font-semibold leading-none";
 
 /**
- * Generates a list of tailwind CSS classes for a particular button type when enabled
- * @param {String} bType Button Type, either primary, secondary, warning, or selected
- * @returns a list of CSS classes specialized for the button type
- */
-function enabledButtonTypeClass(bType) {
-  return [
-    `bg-button-${bType}`,
-    `border-button-${bType}`,
-    `text-button-${bType}`,
-    `fill-button-${bType}`,
-  ];
-}
-
-/**
- * Like `enabledButtonTypeClass` but switching to the `disabled` variant
- * @param {String} bType Button Type, either primary, secondary, warning, or selected
- * @param {String} pseudoClass If specified, then this will be prepended to each class
- * in the list e.g. for "disabled": "bg-button-secondary-disabled" becomes
- * "disabled:bg-button-secondary-disabled"`
- * @returns List of disabled variant of the button tailwind CSS classes
- */
-function disabledButtonTypeClass(bType, pseudoClass = "") {
-  const pc = pseudoClass !== "" ? `${pseudoClass}:` : "";
-  return enabledButtonTypeClass(bType).map((c) => `${pc}${c}-disabled`);
-}
-
-/**
  * Background colors for each of the button types.
  */
 const buttonTypeClasses = {
-  primary: `${enabledButtonTypeClass("primary").join(
-    " "
-  )} ${disabledButtonTypeClass("primary", "disabled").join(" ")}`,
-  secondary: `${enabledButtonTypeClass("secondary").join(
-    " "
-  )} ${disabledButtonTypeClass("secondary", "disabled").join(" ")}`,
-  warning: `${enabledButtonTypeClass("warning").join(
-    " "
-  )} ${disabledButtonTypeClass("warning", "disabled").join(" ")}`,
-  selected: `${enabledButtonTypeClass("selected").join(
-    " "
-  )} ${disabledButtonTypeClass("selected", "disabled").join(" ")}`,
+  primary:
+    "bg-button-primary border-button-primary text-button-primary fill-button-primary disabled:bg-button-primary-disabled disabled:border-button-primary-disabled disabled:text-button-primary-disabled disabled:fill-button-primary-disabled",
+  secondary:
+    "bg-button-secondary border-button-secondary text-button-secondary fill-button-secondary disabled:bg-button-secondary-disabled disabled:border-button-secondary-disabled disabled:text-button-secondary-disabled disabled:fill-button-secondary-disabled",
+  warning:
+    "bg-button-warning border-button-warning text-button-warning fill-button-warning disabled:bg-button-warning-disabled disabled:border-button-warning-disabled disabled:text-button-warning-disabled disabled:fill-button-warning-disabled",
+  selected:
+    "bg-button-selected border-button-selected text-button-selected fill-button-selected disabled:bg-button-selected-disabled disabled:border-button-selected-disabled disabled:text-button-selected-disabled disabled:fill-button-selected-disabled",
+  primaryDisabled:
+    "bg-button-primary-disabled border-button-primary-disabled text-button-primary-disabled fill-button-primary-disabled",
+  secondaryDisabled:
+    "bg-button-secondary-disabled border-button-secondary-disabled text-button-secondary-disabled fill-button-secondary-disabled",
+  warningDisabled:
+    "bg-button-warning-disabled border-button-warning-disabled text-button-warning-disabled fill-button-warning-disabled",
 };
 
 /**
@@ -217,13 +192,13 @@ export function ButtonLink({
     hasIconCircleOnly
   );
 
+  const disabledType = `${type}Disabled`;
+
   return isDisabled ? (
     <div
       aria-label={label}
       id={id}
-      className={`text-center no-underline ${commonButtonClasses} ${sizeClasses} ${disabledButtonTypeClass(
-        type
-      ).join(" ")} ${className}`}
+      className={`text-center no-underline ${commonButtonClasses} ${sizeClasses} ${buttonTypeClasses[disabledType]} ${className}`}
     >
       {children}
     </div>


### PR DESCRIPTION
* Download button is changed to use `DownloadLink` like in some of our other buttons
* Changes `DownloadLink` to allow a disabled state. This is done by just using the same "disabled" css classes as used in a standard button when disabled, however DownloadLink uses a `<div>` to wrap the children components (so it's not a button). But still appears "greyed" out.