### PR TITLE
IGVF-971 Avoid file downloads from UI instance

### DIFF
--- a/components/file-download.js
+++ b/components/file-download.js
@@ -11,9 +11,12 @@ const PENDING = "pending";
 
 /**
  * Display a file-download link and download icon. Files without an `upload_status` of
- * `file not found` show a download link.
+ * `file not found` or `pending` have a disabled download link. The API_URL environment variable
+ * not having a value also disables the download link.
  */
 export function FileDownload({ file, className = "" }) {
+  const isDownloadDisabled =
+    [FILE_NOT_FOUND, PENDING].includes(file.upload_status) || !API_URL;
   return (
     <>
       <ButtonLink
@@ -21,7 +24,7 @@ export function FileDownload({ file, className = "" }) {
         href={`${API_URL}${file.href}`}
         type="secondary"
         size="sm"
-        isDisabled={[FILE_NOT_FOUND, PENDING].includes(file.upload_status)}
+        isDisabled={isDownloadDisabled}
         hasIconOnly
         className={`${className}`}
       >

--- a/lib/__tests__/files.test.ts
+++ b/lib/__tests__/files.test.ts
@@ -1,4 +1,8 @@
-import { splitIlluminaSequenceFiles } from "../files";
+import {
+  checkForFileDownloadPath,
+  convertFileDownloadPathToFilePagePath,
+  splitIlluminaSequenceFiles,
+} from "../files";
 import type { DatabaseObject } from "../../globals.d";
 
 describe("Test the splitIlluminaSequenceFiles function", () => {
@@ -147,5 +151,41 @@ describe("Test the splitIlluminaSequenceFiles function", () => {
 
     expect(withIlluminaIds).toEqual([]);
     expect(withoutIlluminaIds).toEqual([]);
+  });
+});
+
+describe("Test the checkForFileDownloadPath function", () => {
+  it("returns true when given a file download path", () => {
+    const path =
+      "/sequence-files/IGVFFI0001FSTQ/@@download/IGVFFI0001FSTQ.fastq.gz";
+    const result = checkForFileDownloadPath(path);
+    expect(result).toEqual(true);
+  });
+
+  it("returns false when given a file object path", () => {
+    const path = "/sequence-files/IGVFFI0001FSTQ/";
+    const result = checkForFileDownloadPath(path);
+    expect(result).toEqual(false);
+  });
+
+  it("returns false when given an empty string", () => {
+    const path = "";
+    const result = checkForFileDownloadPath(path);
+    expect(result).toEqual(false);
+  });
+});
+
+describe("Test the convertFileDownloadPathToFilePagePath function", () => {
+  it("returns a file page path when given a file download path", () => {
+    const path =
+      "/sequence-files/IGVFFI0001FSTQ/@@download/IGVFFI0001FSTQ.fastq.gz";
+    const result = convertFileDownloadPathToFilePagePath(path);
+    expect(result).toEqual("/sequence-files/IGVFFI0001FSTQ/");
+  });
+
+  it("returns an empty string when given a file object path", () => {
+    const path = "/sequence-files/IGVFFI0001FSTQ/";
+    const result = convertFileDownloadPathToFilePagePath(path);
+    expect(result).toEqual("");
   });
 });

--- a/lib/files.ts
+++ b/lib/files.ts
@@ -35,3 +35,23 @@ export function splitIlluminaSequenceFiles(
     { filesWithReadType: [], filesWithoutReadType: [] }
   );
 }
+
+/**
+ * Check if a path is a file-download path.
+ * @param {string} path Path to check
+ * @returns {boolean} True if the URL is a file-download link, false otherwise
+ */
+export function checkForFileDownloadPath(path: string): boolean {
+  const matches = path.match(/^\/.+?\/.+?\/@@download\/.+$/);
+  return matches !== null;
+}
+
+/**
+ * Convert a file-download path to a path to the corresponding file-object page.
+ * @param {string} path Path to convert
+ * @returns {string} Path to the file page, or empty string if the path is not a file-download path
+ */
+export function convertFileDownloadPathToFilePagePath(url: string): string {
+  const matches = url.match(/^(\/.+?\/.+?\/)@@download\/.+$/);
+  return matches !== null ? matches[1] : "";
+}

--- a/pages/reference-files/[...id].js
+++ b/pages/reference-files/[...id].js
@@ -1,6 +1,6 @@
 // node_modules
-import PropTypes from "prop-types";
 import Link from "next/link";
+import PropTypes from "prop-types";
 // components
 import AlternateAccessions from "../../components/alternate-accessions";
 import Attribution from "../../components/attribution";
@@ -20,7 +20,6 @@ import { FileHeaderDownload } from "../../components/file-download";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
-import SeparatedList from "../../components/separated-list";
 // lib
 import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -31,73 +30,75 @@ import {
 } from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
+import {
+  checkForFileDownloadPath,
+  convertFileDownloadPathToFilePagePath,
+} from "../../lib/files";
 import { isJsonFormat } from "../../lib/query-utils";
 
-export default function AlignmentFile({
-  attribution,
-  alignmentFile,
-  fileSet = null,
+export default function ReferenceFile({
+  referenceFile,
+  fileSet,
   documents,
   derivedFrom,
   derivedFromFileSets,
   fileFormatSpecifications,
-  referenceFiles,
+  attribution = null,
   isJson,
 }) {
   return (
     <>
       <Breadcrumbs />
-      <EditableItem item={alignmentFile}>
+      <EditableItem item={referenceFile}>
         <PagePreamble>
           <AlternateAccessions
-            alternateAccessions={alignmentFile.alternate_accessions}
+            alternateAccessions={referenceFile.alternate_accessions}
           />
         </PagePreamble>
-        <ObjectPageHeader item={alignmentFile} isJsonFormat={isJson}>
-          <FileHeaderDownload file={alignmentFile} />
+        <ObjectPageHeader item={referenceFile} isJsonFormat={isJson}>
+          <FileHeaderDownload file={referenceFile} />
         </ObjectPageHeader>
-        <JsonDisplay item={alignmentFile} isJsonFormat={isJson}>
+        <JsonDisplay item={referenceFile} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>
               <FileDataItems
-                item={alignmentFile}
+                item={referenceFile}
                 fileSet={fileSet}
               ></FileDataItems>
             </DataArea>
           </DataPanel>
-          <DataAreaTitle>Alignment Details</DataAreaTitle>
-          <DataPanel>
-            <DataArea>
-              {referenceFiles.length > 0 && (
-                <>
-                  <DataItemLabel>Reference Files</DataItemLabel>
-                  <DataItemValue>
-                    <SeparatedList>
-                      {referenceFiles.map((file) => (
-                        <Link href={file["@id"]} key={file["@id"]}>
-                          {file.accession}
+          {(referenceFile.assembly || referenceFile.source_url) && (
+            <>
+              <DataAreaTitle>Reference Details</DataAreaTitle>
+              <DataPanel>
+                <DataArea>
+                  {referenceFile.assembly && (
+                    <>
+                      <DataItemLabel>Genome Assembly</DataItemLabel>
+                      <DataItemValue>{referenceFile.assembly}</DataItemValue>
+                    </>
+                  )}
+                  {referenceFile.source_url && (
+                    <>
+                      <DataItemLabel>Source URL</DataItemLabel>
+                      <DataItemValue>
+                        <Link
+                          href={referenceFile.source_url}
+                          key={referenceFile.source_url}
+                        >
+                          {referenceFile.source_url}
                         </Link>
-                      ))}
-                    </SeparatedList>
-                  </DataItemValue>
-                </>
-              )}
-              <>
-                <DataItemLabel>Redacted</DataItemLabel>
-                <DataItemValue>
-                  {alignmentFile.redacted ? "Yes" : "No"}
-                </DataItemValue>
-              </>
-              <DataItemLabel>Filtered</DataItemLabel>
-              <DataItemValue>
-                {alignmentFile.filtered ? "Yes" : "No"}
-              </DataItemValue>
-            </DataArea>
-          </DataPanel>
+                      </DataItemValue>
+                    </>
+                  )}
+                </DataArea>
+              </DataPanel>
+            </>
+          )}
           {derivedFrom.length > 0 && (
             <>
               <DataAreaTitle>
-                Files {alignmentFile.accession} Derives From
+                Files {referenceFile.accession} Derives From
               </DataAreaTitle>
               <DerivedFromTable
                 derivedFrom={derivedFrom}
@@ -124,40 +125,48 @@ export default function AlignmentFile({
   );
 }
 
-AlignmentFile.propTypes = {
-  // AlignmentFile object to display
-  alignmentFile: PropTypes.object.isRequired,
+ReferenceFile.propTypes = {
+  // ReferenceFile object to display
+  referenceFile: PropTypes.object.isRequired,
   // File set that contains this file
   fileSet: PropTypes.object,
   // Documents set associate with this file
-  documents: PropTypes.array.isRequired,
+  documents: PropTypes.array,
   // The file is derived from
-  derivedFrom: PropTypes.array.isRequired,
+  derivedFrom: PropTypes.array,
   // Filesets derived from files belong to
   derivedFromFileSets: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Set of documents for file specifications
   fileFormatSpecifications: PropTypes.array.isRequired,
-  // Attribution for this file
-  attribution: PropTypes.object.isRequired,
-  // The file is derived from
-  referenceFiles: PropTypes.array.isRequired,
+  // Attribution for this ReferenceFile
+  attribution: PropTypes.object,
   // Is the format JSON?
   isJson: PropTypes.bool.isRequired,
 };
 
-export async function getServerSideProps({ params, req, query }) {
+export async function getServerSideProps({ params, req, query, resolvedUrl }) {
+  // Redirect to the file page if the URL is a file download link.
+  if (checkForFileDownloadPath(resolvedUrl)) {
+    return {
+      redirect: {
+        destination: convertFileDownloadPathToFilePagePath(resolvedUrl),
+        permanent: false,
+      },
+    };
+  }
+
   const isJson = isJsonFormat(query);
   const request = new FetchRequest({ cookie: req.headers.cookie });
-  const alignmentFile = await request.getObject(
-    `/alignment-files/${params.id}/`
+  const referenceFile = await request.getObject(
+    `/reference-files/${params.id}/`
   );
-  if (FetchRequest.isResponseSuccess(alignmentFile)) {
-    const fileSet = await request.getObject(alignmentFile.file_set, null);
-    const documents = alignmentFile.documents
-      ? await requestDocuments(alignmentFile.documents, request)
+  if (FetchRequest.isResponseSuccess(referenceFile)) {
+    const fileSet = await request.getObject(referenceFile.file_set, null);
+    const documents = referenceFile.documents
+      ? await requestDocuments(referenceFile.documents, request)
       : [];
-    const derivedFrom = alignmentFile.derived_from
-      ? await requestFiles(alignmentFile.derived_from, request)
+    const derivedFrom = referenceFile.derived_from
+      ? await requestFiles(referenceFile.derived_from, request)
       : [];
     const derivedFromFileSetPaths = derivedFrom
       .map((file) => file.file_set)
@@ -167,39 +176,35 @@ export async function getServerSideProps({ params, req, query }) {
       uniqueDerivedFromFileSetPaths.length > 0
         ? await requestFileSets(uniqueDerivedFromFileSetPaths, request)
         : [];
-    const fileFormatSpecifications = alignmentFile.file_format_specifications
+    const fileFormatSpecifications = referenceFile.file_format_specifications
       ? await requestDocuments(
-          alignmentFile.file_format_specifications,
+          referenceFile.file_format_specifications,
           request
         )
       : [];
-    const referenceFiles = alignmentFile.reference_files
-      ? await requestFiles(alignmentFile.reference_files, request)
-      : [];
     const breadcrumbs = await buildBreadcrumbs(
-      alignmentFile,
+      referenceFile,
       "accession",
       req.headers.cookie
     );
     const attribution = await buildAttribution(
-      alignmentFile,
+      referenceFile,
       req.headers.cookie
     );
     return {
       props: {
-        alignmentFile,
+        referenceFile,
         fileSet,
         documents,
         derivedFrom,
         derivedFromFileSets,
         fileFormatSpecifications,
-        pageContext: { title: alignmentFile.accession },
+        pageContext: { title: referenceFile.accession },
         breadcrumbs,
         attribution,
-        referenceFiles,
         isJson,
       },
     };
   }
-  return errorObjectToProps(alignmentFile);
+  return errorObjectToProps(referenceFile);
 }

--- a/pages/signal-files/[...id].js
+++ b/pages/signal-files/[...id].js
@@ -1,6 +1,6 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
+import Link from "next/link";
 // components
 import AlternateAccessions from "../../components/alternate-accessions";
 import Attribution from "../../components/attribution";
@@ -20,6 +20,7 @@ import { FileHeaderDownload } from "../../components/file-download";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
+import SeparatedList from "../../components/separated-list";
 // lib
 import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -30,94 +31,86 @@ import {
 } from "../../lib/common-requests";
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import { truthyOrZero } from "../../lib/general";
+import {
+  checkForFileDownloadPath,
+  convertFileDownloadPathToFilePagePath,
+} from "../../lib/files";
 import { isJsonFormat } from "../../lib/query-utils";
 
-export default function SequenceFile({
-  sequenceFile,
-  fileSet,
+export default function SignalFile({
+  attribution,
+  signalFile,
+  fileSet = null,
   documents,
   derivedFrom,
   derivedFromFileSets,
   fileFormatSpecifications,
-  attribution = null,
+  referenceFiles,
   isJson,
-  seqSpec = null,
-  sequencingPlatform = null,
 }) {
   return (
     <>
       <Breadcrumbs />
-      <EditableItem item={sequenceFile}>
+      <EditableItem item={signalFile}>
         <PagePreamble>
           <AlternateAccessions
-            alternateAccessions={sequenceFile.alternate_accessions}
+            alternateAccessions={signalFile.alternate_accessions}
           />
         </PagePreamble>
-        <ObjectPageHeader item={sequenceFile} isJsonFormat={isJson}>
-          <FileHeaderDownload file={sequenceFile} />
+        <ObjectPageHeader item={signalFile} isJsonFormat={isJson}>
+          <FileHeaderDownload file={signalFile} />
         </ObjectPageHeader>
-        <JsonDisplay item={sequenceFile} isJsonFormat={isJson}>
+        <JsonDisplay item={signalFile} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>
               <FileDataItems
-                item={sequenceFile}
+                item={signalFile}
                 fileSet={fileSet}
               ></FileDataItems>
             </DataArea>
           </DataPanel>
-          <DataAreaTitle>Sequencing Details</DataAreaTitle>
+          <DataAreaTitle>Signal Details</DataAreaTitle>
           <DataPanel>
             <DataArea>
-              {sequenceFile.flowcell_id && (
+              {referenceFiles.length > 0 && (
                 <>
-                  <DataItemLabel>Flowcell ID</DataItemLabel>
-                  <DataItemValue>{sequenceFile.flowcell_id}</DataItemValue>
-                </>
-              )}
-              {sequenceFile.illumina_read_type && (
-                <>
-                  <DataItemLabel>Illumina Read Type</DataItemLabel>
+                  <DataItemLabel>Reference Files</DataItemLabel>
                   <DataItemValue>
-                    {sequenceFile.illumina_read_type}
+                    <SeparatedList>
+                      {referenceFiles.map((file) => (
+                        <Link href={file["@id"]} key={file["@id"]}>
+                          {file.accession}
+                        </Link>
+                      ))}
+                    </SeparatedList>
                   </DataItemValue>
                 </>
               )}
-              {truthyOrZero(sequenceFile.read_count) && (
+              <>
+                <DataItemLabel>Strand Specificity</DataItemLabel>
+                <DataItemValue>{signalFile.strand_specificity}</DataItemValue>
+              </>
+              {"filtered" in signalFile && (
                 <>
-                  <DataItemLabel>Read Count</DataItemLabel>
-                  <DataItemValue>{sequenceFile.read_count}</DataItemValue>
-                </>
-              )}
-              {truthyOrZero(sequenceFile.mean_read_length) && (
-                <>
-                  <DataItemLabel>Read Length</DataItemLabel>
-                  <DataItemValue>{sequenceFile.mean_read_length}</DataItemValue>
-                </>
-              )}
-              {sequencingPlatform && (
-                <>
-                  <DataItemLabel>Sequencing Platform</DataItemLabel>
+                  <DataItemLabel>Filtered</DataItemLabel>
                   <DataItemValue>
-                    <Link href={sequencingPlatform["@id"]}>
-                      {sequencingPlatform.term_name}
-                    </Link>
+                    {signalFile.filtered ? "Yes" : "No"}
                   </DataItemValue>
                 </>
               )}
-              <DataItemLabel>Sequencing Run</DataItemLabel>
-              <DataItemValue>{sequenceFile.sequencing_run}</DataItemValue>
-              {sequenceFile.lane && (
+              {"normalized" in signalFile && (
                 <>
-                  <DataItemLabel>Lane</DataItemLabel>
-                  <DataItemValue>{sequenceFile.lane}</DataItemValue>
+                  <DataItemLabel>Normalized</DataItemLabel>
+                  <DataItemValue>
+                    {signalFile.normalized ? "Yes" : "No"}
+                  </DataItemValue>
                 </>
               )}
-              {seqSpec && (
+              {signalFile.start_view_position && (
                 <>
-                  <DataItemLabel>Associated seqspec File</DataItemLabel>
+                  <DataItemLabel>Start View Position</DataItemLabel>
                   <DataItemValue>
-                    <Link href={seqSpec["@id"]}>{seqSpec.accession}</Link>
+                    {signalFile.start_view_position}
                   </DataItemValue>
                 </>
               )}
@@ -126,7 +119,7 @@ export default function SequenceFile({
           {derivedFrom.length > 0 && (
             <>
               <DataAreaTitle>
-                Files {sequenceFile.accession} Derives From
+                Files {signalFile.accession} Derives From
               </DataAreaTitle>
               <DerivedFromTable
                 derivedFrom={derivedFrom}
@@ -153,40 +146,49 @@ export default function SequenceFile({
   );
 }
 
-SequenceFile.propTypes = {
-  // SequenceFile object to display
-  sequenceFile: PropTypes.object.isRequired,
+SignalFile.propTypes = {
+  // SignalFile object to display
+  signalFile: PropTypes.object.isRequired,
   // File set that contains this file
   fileSet: PropTypes.object,
   // Documents set associate with this file
-  documents: PropTypes.array,
+  documents: PropTypes.array.isRequired,
   // The file is derived from
-  derivedFrom: PropTypes.array,
+  derivedFrom: PropTypes.array.isRequired,
   // Filesets derived from files belong to
   derivedFromFileSets: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Set of documents for file specifications
   fileFormatSpecifications: PropTypes.array.isRequired,
   // Attribution for this file
-  attribution: PropTypes.object,
+  attribution: PropTypes.object.isRequired,
+  // The file is derived from
+  referenceFiles: PropTypes.array.isRequired,
   // Is the format JSON?
   isJson: PropTypes.bool.isRequired,
-  // Linked seqspec configuration file
-  seqSpec: PropTypes.object,
-  // Sequencing platform ontology term object
-  sequencingPlatform: PropTypes.object,
 };
 
-export async function getServerSideProps({ params, req, query }) {
+export async function getServerSideProps({ params, req, query, resolvedUrl }) {
+  // Redirect to the file page if the URL is a file download link.
+  const isPathForFileDownload = checkForFileDownloadPath(resolvedUrl);
+  if (isPathForFileDownload) {
+    return {
+      redirect: {
+        destination: convertFileDownloadPathToFilePagePath(resolvedUrl),
+        permanent: false,
+      },
+    };
+  }
+
   const isJson = isJsonFormat(query);
   const request = new FetchRequest({ cookie: req.headers.cookie });
-  const sequenceFile = await request.getObject(`/sequence-files/${params.id}/`);
-  if (FetchRequest.isResponseSuccess(sequenceFile)) {
-    const fileSet = await request.getObject(sequenceFile.file_set, null);
-    const documents = sequenceFile.documents
-      ? await requestDocuments(sequenceFile.documents, request)
+  const signalFile = await request.getObject(`/signal-files/${params.id}/`);
+  if (FetchRequest.isResponseSuccess(signalFile)) {
+    const fileSet = await request.getObject(signalFile.file_set, null);
+    const documents = signalFile.documents
+      ? await requestDocuments(signalFile.documents, request)
       : [];
-    const derivedFrom = sequenceFile.derived_from
-      ? await requestFiles(sequenceFile.derived_from, request)
+    const derivedFrom = signalFile.derived_from
+      ? await requestFiles(signalFile.derived_from, request)
       : [];
     const derivedFromFileSetPaths = derivedFrom
       .map((file) => file.file_set)
@@ -196,40 +198,33 @@ export async function getServerSideProps({ params, req, query }) {
       uniqueDerivedFromFileSetPaths.length > 0
         ? await requestFileSets(uniqueDerivedFromFileSetPaths, request)
         : [];
-    const fileFormatSpecifications = sequenceFile.file_format_specifications
-      ? await requestDocuments(sequenceFile.file_format_specifications, request)
+    const fileFormatSpecifications = signalFile.file_format_specifications
+      ? await requestDocuments(signalFile.file_format_specifications, request)
       : [];
-    const seqSpec = sequenceFile.seqspec
-      ? await request.getObject(sequenceFile.seqspec, null)
-      : null;
-    const sequencingPlatform = sequenceFile.sequencing_platform
-      ? await request.getObject(sequenceFile.sequencing_platform, null)
-      : null;
+    const referenceFiles = signalFile.reference_files
+      ? await requestFiles(signalFile.reference_files, request)
+      : [];
     const breadcrumbs = await buildBreadcrumbs(
-      sequenceFile,
+      signalFile,
       "accession",
       req.headers.cookie
     );
-    const attribution = await buildAttribution(
-      sequenceFile,
-      req.headers.cookie
-    );
+    const attribution = await buildAttribution(signalFile, req.headers.cookie);
     return {
       props: {
-        sequenceFile,
+        signalFile,
         fileSet,
         documents,
         derivedFrom,
         derivedFromFileSets,
         fileFormatSpecifications,
-        pageContext: { title: sequenceFile.accession },
+        pageContext: { title: signalFile.accession },
         breadcrumbs,
         attribution,
+        referenceFiles,
         isJson,
-        seqSpec,
-        sequencingPlatform,
       },
     };
   }
-  return errorObjectToProps(sequenceFile);
+  return errorObjectToProps(signalFile);
 }


### PR DESCRIPTION
All the file pages now do the same check for a file-download path. I had to rename all the file pages from `[id].js` to `[...id].js`. Otherwise, we can’t get any download path after the file path, and so it just tries to download the file from the UI server without us being able to intervene.