### PR TITLE
IGVF-999 Handle boolean facets

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ In addition, you might have a better experience if you set these in your Visual 
   "emmet.includeLanguages": {
     "javascript": "javascriptreact"
   },
+  "prettier.configPath": "./prettier.config.js",
+  "prettier.useEditorConfig": false,
   "tailwindCSS.classAttributes": ["class", "className"],
   "tailwindCSS.emmetCompletions": true,
   "tailwindCSS.includeLanguages": {

--- a/components/facets/custom-facets/standard-term-label.js
+++ b/components/facets/custom-facets/standard-term-label.js
@@ -8,7 +8,7 @@ import PropTypes from "prop-types";
 export default function StandardTermLabel({ term }) {
   return (
     <div className="flex grow items-center justify-between gap-2 text-sm font-normal leading-[1.1]">
-      <div>{term.key}</div>
+      <div>{term.key_as_string || term.key}</div>
       <div>{term.doc_count}</div>
     </div>
   );
@@ -21,5 +21,7 @@ StandardTermLabel.propTypes = {
     key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     // Number of times the term appears in the search results
     doc_count: PropTypes.number.isRequired,
+    // Term name as a string when available
+    key_as_string: PropTypes.string,
   }).isRequired,
 };

--- a/components/facets/custom-facets/standard-terms.js
+++ b/components/facets/custom-facets/standard-terms.js
@@ -22,10 +22,11 @@ export default function StandardTerms({ searchResults, facet, updateQuery }) {
    */
   function onTermClick(field, term) {
     const matchingTerms = query.getKeyValues(field);
-    if (matchingTerms.includes(term.key)) {
-      query.deleteKeyValue(field, term.key);
+    const key = term.key_as_string || term.key;
+    if (matchingTerms.includes(key)) {
+      query.deleteKeyValue(field, key);
     } else {
-      query.addKeyValue(field, term.key);
+      query.addKeyValue(field, key);
     }
     query.deleteKeyValue("from");
     updateQuery(query.format());
@@ -34,7 +35,7 @@ export default function StandardTerms({ searchResults, facet, updateQuery }) {
   return (
     <ul>
       {facet.terms.map((term) => {
-        const isChecked = fieldTerms.includes(term.key);
+        const isChecked = fieldTerms.includes(term.key_as_string || term.key);
         return (
           <FacetTerm
             key={term.key}
@@ -62,9 +63,12 @@ StandardTerms.propTypes = {
     terms: PropTypes.arrayOf(
       PropTypes.shape({
         // Label for the facet term
-        key: PropTypes.string.isRequired,
+        key: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+          .isRequired,
         // Number of results for the facet term
         doc_count: PropTypes.number.isRequired,
+        // Label for the facet term as a string when available
+        key_as_string: PropTypes.string,
       })
     ).isRequired,
   }).isRequired,

--- a/components/facets/facet-term.js
+++ b/components/facets/facet-term.js
@@ -15,7 +15,7 @@ export default function FacetTerm({ field, term, isChecked, onClick }) {
     <li data-testid={`facetterm-${term.key}`}>
       <Checkbox
         checked={isChecked}
-        name={`${term.key} with ${term.doc_count} result${
+        name={`${term.key_as_string || term.key} with ${term.doc_count} result${
           term.doc_count > 1 ? "s" : ""
         }`}
         onChange={() => onClick(field, term)}
@@ -32,8 +32,9 @@ FacetTerm.propTypes = {
   field: PropTypes.string.isRequired,
   // Term to display in the checkbox
   term: PropTypes.shape({
-    key: PropTypes.string.isRequired,
+    key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     doc_count: PropTypes.number.isRequired,
+    key_as_string: PropTypes.string,
   }).isRequired,
   // True if the checkbox is checked
   isChecked: PropTypes.bool.isRequired,

--- a/components/facets/facet.js
+++ b/components/facets/facet.js
@@ -28,8 +28,10 @@ Facet.propTypes = {
     title: PropTypes.string.isRequired,
     terms: PropTypes.arrayOf(
       PropTypes.shape({
-        key: PropTypes.string.isRequired,
+        key: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+          .isRequired,
         doc_count: PropTypes.number.isRequired,
+        key_as_string: PropTypes.string,
       })
     ).isRequired,
   }).isRequired,

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,8 +50,8 @@
         "jest": "^29.6.2",
         "jest-environment-jsdom": "^29.0.2",
         "postcss": "^8.4.14",
-        "prettier": "^3.0.0",
-        "prettier-plugin-tailwindcss": "^0.5.2",
+        "prettier": "^3.0.3",
+        "prettier-plugin-tailwindcss": "^0.5.3",
         "pretty-format": "^29.5.0",
         "tailwindcss": "^3.1.8"
       }
@@ -112,12 +112,12 @@
       "integrity": "sha512-xdA65Z/U7++Y7L9Uwh8Q8OVOs6qgFz+fb7GAzHFjpr1icO37B//xdzLXm7ZRgA19RWrsNe1nme3h896igJSvvw=="
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
-      "integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.10",
+        "@babel/highlight": "^7.22.13",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -429,9 +429,9 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
-      "integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
+      "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.5",
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.11.tgz",
-      "integrity": "sha512-R5zb8eJIBPJriQtbH/htEQy4k7E2dHWlD2Y2VT07JCzwYZHBxV5ZYtM0UhXSNMT74LyxuM+b1jdL7pSesXbC/g==",
+      "version": "7.22.14",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.14.tgz",
+      "integrity": "sha512-1KucTHgOvaw/LzCVrEOAyXkr9rQlp0A1HiHRYnSUE9dmb8PvPW7o5sscg+5169r54n3vGlbx6GevTE/Iw/P3AQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -881,9 +881,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.7.0.tgz",
-      "integrity": "sha512-+HencqxU7CFJnQb7IKtuNBqS6Yx3Tz4kOL8BJXo+JyeiBm5MEX6pO8onXDkjrkCRlfYXS1Axro15ZjVFe9YgsA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -927,9 +927,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.47.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.47.0.tgz",
-      "integrity": "sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
+      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -958,9 +958,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
+      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -1986,9 +1986,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.4.tgz",
-      "integrity": "sha512-Y9vbIAoM31djQZrPYjpTLo0XlaSwOIsrlfE3LpulZeRblttsLQRFRlBAppW0LOxyT3ALj2M5vU1ucQQayQH3jA=="
+      "version": "20.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
+      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -2019,9 +2019,9 @@
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "node_modules/@types/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw=="
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg=="
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -2078,15 +2078,15 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.1.tgz",
-      "integrity": "sha512-3F5PtBzUW0dYlq77Lcqo13fv+58KDwUib3BddilE8ajPJT+faGgxmI9Sw+I8ZS22BYwoir9ZhNXcLi+S+I2bkw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.5.0.tgz",
+      "integrity": "sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==",
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.4.1",
-        "@typescript-eslint/type-utils": "6.4.1",
-        "@typescript-eslint/utils": "6.4.1",
-        "@typescript-eslint/visitor-keys": "6.4.1",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/type-utils": "6.5.0",
+        "@typescript-eslint/utils": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -2112,14 +2112,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.1.tgz",
-      "integrity": "sha512-610G6KHymg9V7EqOaNBMtD1GgpAmGROsmfHJPXNLCU9bfIuLrkdOygltK784F6Crboyd5tBFayPB7Sf0McrQwg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.5.0.tgz",
+      "integrity": "sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.4.1",
-        "@typescript-eslint/types": "6.4.1",
-        "@typescript-eslint/typescript-estree": "6.4.1",
-        "@typescript-eslint/visitor-keys": "6.4.1",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2139,12 +2139,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.1.tgz",
-      "integrity": "sha512-p/OavqOQfm4/Hdrr7kvacOSFjwQ2rrDVJRPxt/o0TOWdFnjJptnjnZ+sYDR7fi4OimvIuKp+2LCkc+rt9fIW+A==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.5.0.tgz",
+      "integrity": "sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==",
       "dependencies": {
-        "@typescript-eslint/types": "6.4.1",
-        "@typescript-eslint/visitor-keys": "6.4.1"
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2155,12 +2155,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.1.tgz",
-      "integrity": "sha512-7ON8M8NXh73SGZ5XvIqWHjgX2f+vvaOarNliGhjrJnv1vdjG0LVIz+ToYfPirOoBi56jxAKLfsLm40+RvxVVXA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.5.0.tgz",
+      "integrity": "sha512-f7OcZOkRivtujIBQ4yrJNIuwyCQO1OjocVqntl9dgSIZAdKqicj3xFDqDOzHDlGCZX990LqhLQXWRnQvsapq8A==",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.4.1",
-        "@typescript-eslint/utils": "6.4.1",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/utils": "6.5.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -2181,9 +2181,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.1.tgz",
-      "integrity": "sha512-zAAopbNuYu++ijY1GV2ylCsQsi3B8QvfPHVqhGdDcbx/NK5lkqMnCGU53amAjccSpk+LfeONxwzUhDzArSfZJg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.5.0.tgz",
+      "integrity": "sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==",
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
       },
@@ -2193,12 +2193,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.1.tgz",
-      "integrity": "sha512-xF6Y7SatVE/OyV93h1xGgfOkHr2iXuo8ip0gbfzaKeGGuKiAnzS+HtVhSPx8Www243bwlW8IF7X0/B62SzFftg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.5.0.tgz",
+      "integrity": "sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==",
       "dependencies": {
-        "@typescript-eslint/types": "6.4.1",
-        "@typescript-eslint/visitor-keys": "6.4.1",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2219,16 +2219,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.1.tgz",
-      "integrity": "sha512-F/6r2RieNeorU0zhqZNv89s9bDZSovv3bZQpUNOmmQK1L80/cV4KEu95YUJWi75u5PhboFoKUJBnZ4FQcoqhDw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.5.0.tgz",
+      "integrity": "sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.4.1",
-        "@typescript-eslint/types": "6.4.1",
-        "@typescript-eslint/typescript-estree": "6.4.1",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -2243,11 +2243,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.1.tgz",
-      "integrity": "sha512-y/TyRJsbZPkJIZQXrHfdnxVnxyKegnpEvnRGNam7s3TRR2ykGefEWOhaef00/UUN3IZxizS7BTO3svd3lCOJRQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.5.0.tgz",
+      "integrity": "sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==",
       "dependencies": {
-        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/types": "6.5.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -2512,16 +2512,16 @@
       }
     },
     "node_modules/array.prototype.findlastindex": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.2.tgz",
-      "integrity": "sha512-tb5thFFlUcp7NdNF6/MpDk/1r/4awWG1FIz3YqDf+/zJSTezBb+/5WViH41obXULHVpDzoiCLpJ/ZO9YbJMsdw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.3.tgz",
+      "integrity": "sha512-LzLoiOMAxvy+Gd3BAq3B7VeIgPdo+Q8hthvKtXybMvRV0jrXfJM/t8mw7nNlpEcVlVUnCnM2KSX4XU5HmpodOA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
         "es-shim-unscopables": "^1.0.0",
-        "get-intrinsic": "^1.1.3"
+        "get-intrinsic": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3110,9 +3110,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001522",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz",
-      "integrity": "sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==",
+      "version": "1.0.30001524",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
+      "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
       "funding": [
         {
           "type": "opencollective",
@@ -3634,9 +3634,9 @@
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
-      "version": "16.18.44",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.44.tgz",
-      "integrity": "sha512-PZXtT+wqSMHnLPVExTh+tMt1VK+GvjRLsGZMbcQ4Mb/cG63xJig/TUmgrDa9aborl2i22UnpIzHYNu7s97NbBQ==",
+      "version": "16.18.46",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.46.tgz",
+      "integrity": "sha512-Mnq3O9Xz52exs3mlxMcQuA7/9VFe/dXcrgAyfjLkABIqxXKOgBRjyazTxUbjsxDa4BP7hhPliyjVTP9RDP14xg==",
       "dev": true
     },
     "node_modules/cypress/node_modules/chalk": {
@@ -3941,9 +3941,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.500",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.500.tgz",
-      "integrity": "sha512-P38NO8eOuWOKY1sQk5yE0crNtrjgjJj6r3NrbIKtG18KzCHmHE2Bt+aQA7/y0w3uYsHWxDa6icOohzjLJ4vJ4A==",
+      "version": "1.4.505",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.505.tgz",
+      "integrity": "sha512-0A50eL5BCCKdxig2SsCXhpuztnB9PfUgRMojj5tMvt8O54lbwz3t6wNgnpiTRosw5QjlJB7ixhVyeg8daLQwSQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4101,15 +4101,15 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.13.tgz",
-      "integrity": "sha512-LK3VGwzvaPWobO8xzXXGRUOGw8Dcjyfk62CsY/wfHN75CwsJPbuypOYJxK6g5RyEL8YDjIWcl6jgd8foO6mmrA==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.14.tgz",
+      "integrity": "sha512-JgtVnwiuoRuzLvqelrvN3Xu7H9bu2ap/kQ2CrM62iidP8SKuD99rWU3CJy++s7IVL2qb/AjXPGR/E7i9ngd/Cw==",
       "dev": true,
       "dependencies": {
         "asynciterator.prototype": "^1.0.0",
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
-        "es-abstract": "^1.21.3",
+        "es-abstract": "^1.22.1",
         "es-set-tostringtag": "^2.0.1",
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.2.1",
@@ -4210,14 +4210,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.47.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.47.0.tgz",
-      "integrity": "sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
+      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "^8.47.0",
+        "@eslint/js": "8.48.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -5100,15 +5100,16 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
+      "integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
       "dependencies": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.2.7",
+        "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/flatted": {
@@ -5164,22 +5165,22 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.1.tgz",
-      "integrity": "sha512-/KxoyCnPM0GwYI4NN0Iag38Tqt+od3/mLuguepLgCAKPn0ZhC544nssAW0tG2/00zXEYl9W+7hwAIpLHo6Oc7Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.1.tgz",
+      "integrity": "sha512-nx0cki48JBA6ThPeUpeKCNpdhEl/9bRS+dAEYnRUod+Z1jhFfC3K/mBLorZZntqHM+GTH3/dkkpfoT3QITYe7g==",
       "dev": true,
       "engines": {
         "node": "*"
       },
       "funding": {
         "type": "patreon",
-        "url": "https://www.patreon.com/infusion"
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/framer-motion": {
-      "version": "10.16.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.1.tgz",
-      "integrity": "sha512-K6TXr5mZtitC/dxQCBdg7xzdN0d5IAIrlaqCPKtIQVdzVPGC0qBuJKXggHX1vjnP5gPOFwB1KbCCTWcnFc3kWg==",
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.2.tgz",
+      "integrity": "sha512-aY6L9YMvqMWtfOQptaUvvr8dp97jskXY5UYLQM0vOPxKeERrG/Z034EIQZ/52u7MeCT0HlCQy3/l0HdUZCB9Tw==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -5238,15 +5239,15 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "functions-have-names": "^1.2.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7404,6 +7405,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -7490,6 +7496,14 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
       "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
+    "node_modules/keyv": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
     },
     "node_modules/kleur": {
       "version": "3.0.3",
@@ -7795,9 +7809,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-7.0.4.tgz",
-      "integrity": "sha512-t8eP0dXRJMtMvBojtkcsA7n48BkauktUKzfkPSCq85ZMTJ0v76Rke4DYz01omYpPTUh4p/f7HePgRo3ebG8+QQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-7.0.5.tgz",
+      "integrity": "sha512-lwNAFTfXgqpt/XvK17a/8wY9/q6fcSPZT1aP6QW0u74VwaJF/Z9KbRcX23sWE4tODM+AolJNcUtErTkgOeFP/Q==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -8143,28 +8157,28 @@
       }
     },
     "node_modules/object.entries": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
-      "integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.7.tgz",
+      "integrity": "sha512-jCBs/0plmPsOnrKAfFQXRG2NFjlhZgjjcBLSmTnEhU8U6vVTsVe8ANeQJCHTl3gSsI4J+0emOoCgoKlmQPMgmA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.fromentries": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
-      "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.7.tgz",
+      "integrity": "sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8174,39 +8188,39 @@
       }
     },
     "node_modules/object.groupby": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.0.tgz",
-      "integrity": "sha512-70MWG6NfRH9GnbZOikuhPPYzpUpof9iW2J9E4dW7FXTqPNb6rllE6u39SKwwiNh8lCwX3DDb5OgcKGiEBrTTyw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.1.tgz",
+      "integrity": "sha512-HqaQtqLnp/8Bn4GL16cj+CUYbnpe1bh0TtEaWvybszDG4tgxCJuRpV8VGuvNaI1fAnI4lUJzDG55MXcOH4JZcQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
-        "es-abstract": "^1.21.2",
+        "es-abstract": "^1.22.1",
         "get-intrinsic": "^1.2.1"
       }
     },
     "node_modules/object.hasown": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
-      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.3.tgz",
+      "integrity": "sha512-fFI4VcYpRHvSLXxP7yiZOMAd331cPfd2p7PFDVbgUsYOfCT3tICVqXWngbjr4m49OvsBwUBQ6O2uQoJvy3RexA==",
       "dev": true,
       "dependencies": {
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
-      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.7.tgz",
+      "integrity": "sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8498,9 +8512,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.28",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
-      "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
+      "version": "8.4.29",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.29.tgz",
+      "integrity": "sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==",
       "funding": [
         {
           "type": "opencollective",
@@ -8643,9 +8657,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
-      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -9614,18 +9628,18 @@
       "dev": true
     },
     "node_modules/string.prototype.matchall": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
-      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.9.tgz",
+      "integrity": "sha512-6i5hL3MqG/K2G43mWXWgP+qizFW/QH/7kCNN13JrJS5q48FN5IKksLDscexKP3dnmB6cdm9jlNgAsWNLpSykmA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "get-intrinsic": "^1.1.3",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.4.3",
+        "internal-slot": "^1.0.5",
+        "regexp.prototype.flags": "^1.5.0",
         "side-channel": "^1.0.4"
       },
       "funding": {
@@ -10690,9 +10704,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
       "engines": {
         "node": ">= 14"
       }

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "jest": "^29.6.2",
     "jest-environment-jsdom": "^29.0.2",
     "postcss": "^8.4.14",
-    "prettier": "^3.0.0",
-    "prettier-plugin-tailwindcss": "^0.5.2",
+    "prettier": "^3.0.3",
+    "prettier-plugin-tailwindcss": "^0.5.3",
     "pretty-format": "^29.5.0",
     "tailwindcss": "^3.1.8"
   }

--- a/pages/construct-libraries/[id].js
+++ b/pages/construct-libraries/[id].js
@@ -314,8 +314,8 @@ export default function ConstructLibrary({
                 <DataItemValue>
                   <ChromosomeLocations locations={displayableTargetedLoci} />
                   {isTargetedLociTruncated && (
-                    <div className="flex items-center h-6">
-                      <Icon.EllipsisHorizontal className="h-1 ml-1" />
+                    <div className="flex h-6 items-center">
+                      <Icon.EllipsisHorizontal className="ml-1 h-1" />
                     </div>
                   )}
                 </DataItemValue>
@@ -340,7 +340,7 @@ export default function ConstructLibrary({
                     ))}
                   </SeparatedList>
                   {isTargetedGenesTruncated && (
-                    <Icon.EllipsisHorizontal className="h-1 mt-2" />
+                    <Icon.EllipsisHorizontal className="mt-2 h-1" />
                   )}
                 </DataItemValue>
               </>

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["prettier-plugin-tailwindcss"],
+};


### PR DESCRIPTION
The prettier Tailwind CSS reordering mechanism stopped working, so I added the npm plugin for it. Adding it to the .prettierrc file causes pre-commit to look for it, which works locally but not on CircleCI. So I instead put it in the new prettier.config.js file that pre-commit doesn’t read. But you have to configure VSCode to use that, so I added some config to the README to do that.

The meat of this branch is to use the `key_as_string` property of boolean facets when it’s available. If no `key_as_string` exists (which is the case for the vast majority of facets), use `key` instead.