### PR TITLE
IGVF-822 Update MeasurementSet pages

### DIFF
--- a/components/__tests__/data-area.test.js
+++ b/components/__tests__/data-area.test.js
@@ -5,9 +5,12 @@ import {
   DataItemLabel,
   DataItemValue,
   DataItemValueUrl,
-  DataItemValueExpandButton,
+  DataItemValueCollapseControl,
+  DataItemValueControlLabel,
   DataPanel,
+  useDataAreaCollapser,
 } from "../data-area";
+import SeparatedList from "../separated-list";
 import Status from "../status";
 
 describe("Test the DataArea component", () => {
@@ -82,59 +85,140 @@ describe("Test the DataArea component", () => {
   });
 });
 
-describe("Test the DataItemValueExpandButton component", () => {
-  it("renders the collapsed button and calls the onClick handler", () => {
-    const onClick = jest.fn();
-    render(
-      <DataItemValueExpandButton
-        isExpandable={true}
-        isExpanded={false}
-        onClick={onClick}
-      />
-    );
+describe("Test the useDataAreaCollapser hook", () => {
+  it("properly collapses and expands the data area", () => {
+    const data = [
+      "IGVFFS0001AAAA",
+      "IGVFFS0002AAAA",
+      "IGVFFS0003AAAA",
+      "IGVFFS0004AAAA",
+      "IGVFFS0005AAAA",
+      "IGVFFS0006AAAA",
+    ];
 
+    function TestComponent() {
+      const collapser = useDataAreaCollapser(data);
+      return (
+        <>
+          <DataPanel>
+            <DataArea>
+              <DataItemLabel>Status</DataItemLabel>
+              <DataItemValue>
+                <SeparatedList>
+                  {collapser.displayedData.map((item) => (
+                    <div key={item} data-testid={`displayed-item-${item}`}>
+                      {item}
+                    </div>
+                  ))}
+                </SeparatedList>
+                <DataItemValueCollapseControl collapser={collapser}>
+                  <DataItemValueControlLabel collapser={collapser} />
+                </DataItemValueCollapseControl>
+              </DataItemValue>
+            </DataArea>
+          </DataPanel>
+        </>
+      );
+    }
+
+    render(<TestComponent />);
+
+    // Get the SVG within the button and check its data-testid attribute
     const button = screen.getByRole("button");
-    expect(button).toBeInTheDocument();
     expect(button.firstChild).toHaveAttribute(
       "data-testid",
       "data-item-value-expand-icon"
     );
 
+    // Only the first 3 items should be displayed
+    expect(
+      screen.queryByTestId("displayed-item-IGVFFS0001AAAA")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("displayed-item-IGVFFS0002AAAA")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("displayed-item-IGVFFS0003AAAA")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("displayed-item-IGVFFS0004AAAA")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("displayed-item-IGVFFS0005AAAA")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("displayed-item-IGVFFS0006AAAA")
+    ).not.toBeInTheDocument();
+
     fireEvent.click(button);
-    expect(onClick).toHaveBeenCalled();
-  });
-
-  it("renders the expanded button and calls the onClick handler", () => {
-    const onClick = jest.fn();
-    render(
-      <DataItemValueExpandButton
-        isExpandable={true}
-        isExpanded={true}
-        onClick={onClick}
-      />
-    );
-
-    const button = screen.getByRole("button");
-    expect(button).toBeInTheDocument();
     expect(button.firstChild).toHaveAttribute(
       "data-testid",
       "data-item-value-collapse-icon"
     );
 
-    fireEvent.click(button);
-    expect(onClick).toHaveBeenCalled();
+    // All items should be displayed
+    expect(
+      screen.queryByTestId("displayed-item-IGVFFS0001AAAA")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("displayed-item-IGVFFS0002AAAA")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("displayed-item-IGVFFS0003AAAA")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("displayed-item-IGVFFS0004AAAA")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("displayed-item-IGVFFS0005AAAA")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("displayed-item-IGVFFS0006AAAA")
+    ).toBeInTheDocument();
   });
 
-  it("renders nothing if the item is not expandable", () => {
-    render(
-      <DataItemValueExpandButton
-        isExpandable={false}
-        isExpanded={true}
-        onClick={jest.fn()}
-      />
-    );
+  it("does not render the collapse button if there are no items to collapse", () => {
+    const data = ["IGVFFS0001AAAA", "IGVFFS0002AAAA", "IGVFFS0003AAAA"];
+
+    function TestComponent() {
+      const collapser = useDataAreaCollapser(data);
+      return (
+        <>
+          <DataPanel>
+            <DataArea>
+              <DataItemLabel>Status</DataItemLabel>
+              <DataItemValue>
+                <SeparatedList>
+                  {collapser.displayedData.map((item) => (
+                    <div key={item} data-testid={`displayed-item-${item}`}>
+                      {item}
+                    </div>
+                  ))}
+                </SeparatedList>
+                <DataItemValueCollapseControl collapser={collapser}>
+                  <DataItemValueControlLabel collapser={collapser} />
+                </DataItemValueCollapseControl>
+              </DataItemValue>
+            </DataArea>
+          </DataPanel>
+        </>
+      );
+    }
+
+    render(<TestComponent />);
 
     const button = screen.queryByRole("button");
     expect(button).not.toBeInTheDocument();
+
+    // All items should be displayed
+    expect(
+      screen.queryByTestId("displayed-item-IGVFFS0001AAAA")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("displayed-item-IGVFFS0002AAAA")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("displayed-item-IGVFFS0003AAAA")
+    ).toBeInTheDocument();
   });
 });

--- a/components/data-area.js
+++ b/components/data-area.js
@@ -13,6 +13,7 @@
 // node_modules
 import { BarsArrowDownIcon, BarsArrowUpIcon } from "@heroicons/react/20/solid";
 import PropTypes from "prop-types";
+import { useState } from "react";
 // components
 import { Button } from "./form-elements";
 
@@ -119,46 +120,146 @@ DataItemValueUrl.propTypes = {
 };
 
 /**
- * Displays a button to expand or collapse a data item value. This button only appears if `isExpandable`
- * holds true. Place this button within a <DataItemLabel> element, just after the label text.
+ * Default number of items to display in a collapsible/expandable data area before considering it
+ * collapsible. A data area with fewer than this number of items will not appear collapsible.
  */
-export function DataItemValueExpandButton({
-  isExpandable,
-  isExpanded,
-  onClick,
+const DEFAULT_COLLAPSE_LIMIT = 3;
+
+/**
+ * Hook to manage the collapsed/expanded state of a data area value. We have chosen certain array
+ * data items to appear with fewer than their full number of items, with a button to expand them to
+ * their full number. This hook manages the state of the data area, including whether it appears
+ * collapsed or expanded, and whether it has enough items to collapse at all. Here's an example
+ * where we want to display a collapsible list of samples, and display a button to expand or
+ * collapse the list. The last item of the list is the button to expand or collapse the list (which
+ * just one way to handle this):
+ *
+ * const samplesCollapser = useDataAreaCollapser(samples || []);
+ * {samplesCollapser.displayedData.length > 0 && (
+ *   <>
+ *     <DataItemLabel className="flex items-baseline">Samples</DataItemLabel>
+ *     <DataItemValue>
+ *       <SeparatedList>
+ *         {samplesCollapser.displayedData.map((sample, index) => (
+ *            <Fragment key={sample.accession}>{sample.accession}</Fragment>
+ *         ))}
+ *         {index === samplesCollapser.displayedData.length - 1 && (
+ *           <DataItemValueCollapseControl key="collapse" collapser={samplesCollapser} />
+ *         )}
+ *       </SeparatedList>
+ *     </DataItemValue>
+ *   </>
+ * )}
+ *
+ * For consistency, the object `useDataAreaCollapser` returns we often call a "collapser" preceded
+ * by the name of the property it controls.
+ *
+ * @param {Array<any>} data Data to display as either a collapsed or full list
+ * @param {number} collapseLimit Number of items to display when collapsed
+ * @param {boolean} defaultIsCollapsed True if the data should appear collapsed by default
+ * @returns {object} Contains the following properties:
+ *   isCollapsed: True if the data is collapsed; invalid if `isCollapsible` is false
+ *   setIsCollapsed: Function to set the collapsed/expanded states
+ *   isCollapsible: True if the data has more than `collapseLimit` items
+ *   isDataTruncated: True if `displayedData` has been truncated to `collapseLimit` items
+ *   displayedData: The data to display -- either the full or truncated list
+ *   hiddenDataCount: Number of items hidden when `isDataTruncated` is true
+ */
+export function useDataAreaCollapser(
+  data,
+  collapseLimit = DEFAULT_COLLAPSE_LIMIT,
+  defaultIsCollapsed = true
+) {
+  const [isCollapsed, setIsCollapsed] = useState(defaultIsCollapsed);
+  const isCollapsible = data.length > collapseLimit;
+  const isDataTruncated = isCollapsible && isCollapsed;
+  const displayedData = isDataTruncated ? data.slice(0, collapseLimit) : data;
+  const hiddenDataCount = isDataTruncated ? data.length - collapseLimit : 0;
+
+  return {
+    isCollapsed,
+    setIsCollapsed,
+    isCollapsible,
+    isDataTruncated,
+    displayedData,
+    hiddenDataCount,
+  };
+}
+
+/**
+ * Displays a button to expand or collapse a data item value. This button only appears if the
+ * `isExpandable` property of the given collapser object holds true. Place this button within a
+ * <DataItemValue> element. This takes an optional child element to display next to the button, and
+ * typically you would use <DataItemValueControlLabel> for this.
+ */
+export function DataItemValueCollapseControl({
+  collapser,
+  className = null,
+  children,
 }) {
   return (
     <>
-      {isExpandable && (
-        <Button
-          type="secondary"
-          size="sm"
-          hasIconOnly
-          className="ml-1"
-          onClick={() => onClick(!isExpanded)}
-        >
-          {isExpanded ? (
-            <BarsArrowUpIcon
-              data-testid="data-item-value-collapse-icon"
-              className="h-4 w-4"
-            />
-          ) : (
-            <BarsArrowDownIcon
-              data-testid="data-item-value-expand-icon"
-              className="h-4 w-4"
-            />
-          )}
-        </Button>
+      {collapser.isCollapsible && (
+        <div className={className}>
+          <Button
+            type="secondary"
+            size="sm"
+            hasIconOnly
+            onClick={() => collapser.setIsCollapsed(!collapser.isCollapsed)}
+          >
+            {collapser.isCollapsed ? (
+              <BarsArrowDownIcon
+                data-testid="data-item-value-expand-icon"
+                className="h-4 w-4"
+              />
+            ) : (
+              <BarsArrowUpIcon
+                data-testid="data-item-value-collapse-icon"
+                className="h-4 w-4"
+              />
+            )}
+            {children}
+          </Button>
+        </div>
       )}
     </>
   );
 }
 
-DataItemValueExpandButton.propTypes = {
-  // True if the data area is expandable
-  isExpandable: PropTypes.bool.isRequired,
-  // True if the data area is expanded
-  isExpanded: PropTypes.bool.isRequired,
-  // Function called when the user clicks the expand/collapse button
-  onClick: PropTypes.func.isRequired,
+DataItemValueCollapseControl.propTypes = {
+  // Object returned by `useDataAreaCollapser`
+  collapser: PropTypes.shape({
+    isCollapsed: PropTypes.bool.isRequired,
+    setIsCollapsed: PropTypes.func.isRequired,
+    isCollapsible: PropTypes.bool.isRequired,
+  }).isRequired,
+  // Additional Tailwind CSS classes to apply to the wrapping div
+  className: PropTypes.string,
+};
+
+/**
+ * You can place this component as a child of <DataItemValueCollapseControl> to display a label
+ * indicating how many items are hidden while the data is collapsed, or just the word "fewer"
+ * while the data is expanded.
+ */
+export function DataItemValueControlLabel({ collapser }) {
+  return (
+    <div className="ml-1 text-xs">
+      {collapser.hiddenDataCount > 0 ? (
+        <>{`${collapser.hiddenDataCount} more`}</>
+      ) : (
+        <>fewer</>
+      )}
+    </div>
+  );
+}
+
+DataItemValueControlLabel.propTypes = {
+  // Collapser object returned by `useDataAreaCollapser`
+  collapser: PropTypes.shape({
+    isCollapsed: PropTypes.bool.isRequired,
+    setIsCollapsed: PropTypes.func.isRequired,
+    isCollapsible: PropTypes.bool.isRequired,
+    hiddenDataCount: PropTypes.number.isRequired,
+  }).isRequired,
 };

--- a/components/search/__tests__/list-renderer.test.js
+++ b/components/search/__tests__/list-renderer.test.js
@@ -1411,7 +1411,7 @@ describe("Test the CuratedSet component", () => {
 });
 
 describe("Test the MeasurementSet component", () => {
-  it("renders a MeasurementSet item", () => {
+  it("renders a MeasurementSet item with one sample", () => {
     const item = {
       "@id": "/measurement-sets/IGVFDS6408BFHD/",
       "@type": ["MeasurementSet", "FileSet", "Item"],
@@ -1422,8 +1422,27 @@ describe("Test the MeasurementSet component", () => {
       lab: {
         title: "J. Michael Cherry, Stanford",
       },
+      samples: [
+        {
+          "@id": "/primary-cells/IGVFSM0000EEEE/",
+          accession: "IGVFSM0000EEEE",
+          aliases: ["igvf:alias10"],
+          donors: [
+            {
+              "@id": "/human-donors/IGVFDO6569ZRDK/",
+              accession: "IGVFDO6569ZRDK",
+              aliases: ["igvf:alias_human_donor2"],
+              summary: "IGVFDO6569ZRDK",
+              taxa: "Homo sapiens",
+            },
+          ],
+          sample_terms: ["/sample-terms/CL_0011001/"],
+          summary: "motor neuron primary cell, Homo sapiens (40-45 years)",
+          taxa: "Homo sapiens",
+        },
+      ],
       status: "released",
-      summary: "IGVFDS6408BFHD",
+      summary: "imaging assay (yN2H)",
       uuid: "67380d9f-06da-f9fe-9569-d31ce0607eae",
       assay_term: {
         term_name: "STARR-seq",
@@ -1441,7 +1460,7 @@ describe("Test the MeasurementSet component", () => {
     expect(uniqueId).toHaveTextContent(/IGVFDS6408BFHD$/);
 
     const title = screen.getByTestId("search-list-item-title");
-    expect(title).toHaveTextContent(/^STARR-seq$/);
+    expect(title).toHaveTextContent(/^imaging assay \(yN2H\)$/);
 
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
@@ -1450,7 +1469,7 @@ describe("Test the MeasurementSet component", () => {
     expect(status).toHaveTextContent("released");
   });
 
-  it("renders a MeasurementSet item without summary", () => {
+  it("renders a MeasurementSet item with more than one sample", () => {
     const item = {
       "@id": "/measurement-sets/IGVFDS6408BFHD/",
       "@type": ["MeasurementSet", "FileSet", "Item"],
@@ -1461,7 +1480,47 @@ describe("Test the MeasurementSet component", () => {
       lab: {
         title: "J. Michael Cherry, Stanford",
       },
+      samples: [
+        {
+          "@id": "/tissues/IGVFSM0001DDDD/",
+          accession: "IGVFSM0001DDDD",
+          aliases: ["igvf:treated_tissue"],
+          donors: [
+            {
+              "@id": "/rodent-donors/IGVFDO1668BXAE/",
+              accession: "IGVFDO1668BXAE",
+              aliases: [
+                "igvf:alias_rodent_donor_1",
+                "igvf:rodent_donor_with_arterial_blood_pressure_trait",
+              ],
+              summary: "IGVFDO1668BXAE",
+              taxa: "Mus musculus",
+            },
+          ],
+          sample_terms: ["/sample-terms/UBERON_0002048/"],
+          summary: "lung tissue, Mus musculus (10-20 weeks)",
+          taxa: "Mus musculus",
+        },
+        {
+          "@id": "/tissues/IGVFSM0003DDDD/",
+          accession: "IGVFSM0003DDDD",
+          aliases: ["igvf:tissue_part_of_tissue"],
+          donors: [
+            {
+              "@id": "/rodent-donors/IGVFDO5425ETYH/",
+              accession: "IGVFDO5425ETYH",
+              aliases: ["igvf:alias_rodent_donor_2"],
+              summary: "IGVFDO5425ETYH",
+              taxa: "Mus musculus",
+            },
+          ],
+          sample_terms: ["/sample-terms/UBERON_0002048/"],
+          summary: "lung tissue, Mus musculus (10-20 months)",
+          taxa: "Mus musculus",
+        },
+      ],
       status: "released",
+      summary: "imaging assay (yN2H)",
       uuid: "67380d9f-06da-f9fe-9569-d31ce0607eae",
       assay_term: {
         term_name: "STARR-seq",
@@ -1479,9 +1538,48 @@ describe("Test the MeasurementSet component", () => {
     expect(uniqueId).toHaveTextContent(/IGVFDS6408BFHD$/);
 
     const title = screen.getByTestId("search-list-item-title");
-    expect(title).toHaveTextContent(/^STARR-seq$/);
+    expect(title).toHaveTextContent(/^imaging assay \(yN2H\)$/);
 
-    const meta = screen.queryByTestId("search-list-item-meta");
+    const meta = screen.getByTestId("search-list-item-meta");
+    expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
+
+    const status = screen.getByTestId("search-list-item-quality");
+    expect(status).toHaveTextContent("released");
+  });
+
+  it("renders a MeasurementSet item without samples", () => {
+    const item = {
+      "@id": "/measurement-sets/IGVFDS6408BFHD/",
+      "@type": ["MeasurementSet", "FileSet", "Item"],
+      accession: "IGVFDS6408BFHD",
+      alternate_accessions: ["IGVFDS6408BFHE"],
+      aliases: ["igvf:basic_measurement_set"],
+      award: "/awards/HG012012/",
+      lab: {
+        title: "J. Michael Cherry, Stanford",
+      },
+      status: "released",
+      summary: "imaging assay (yN2H)",
+      uuid: "67380d9f-06da-f9fe-9569-d31ce0607eae",
+      assay_term: {
+        term_name: "STARR-seq",
+      },
+    };
+
+    render(
+      <SessionContext.Provider value={{ profiles }}>
+        <MeasurementSet item={item} />
+      </SessionContext.Provider>
+    );
+
+    const uniqueId = screen.getByTestId("search-list-item-unique-id");
+    expect(uniqueId).toHaveTextContent(/^Measurement Set/);
+    expect(uniqueId).toHaveTextContent(/IGVFDS6408BFHD$/);
+
+    const title = screen.getByTestId("search-list-item-title");
+    expect(title).toHaveTextContent(/^imaging assay \(yN2H\)$/);
+
+    const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
 
     const status = screen.getByTestId("search-list-item-quality");

--- a/components/search/list-renderer/measurement-set.js
+++ b/components/search/list-renderer/measurement-set.js
@@ -13,6 +13,17 @@ import {
 } from "./search-list-item";
 
 export default function MeasurementSet({ item: measurementSet }) {
+  // Collect the summaries of all samples in the measurement set and use the first one as the
+  // representative sample summary.
+  const sampleSummaries =
+    measurementSet.samples?.length > 0
+      ? measurementSet.samples.map((sample) => sample.summary)
+      : [];
+  const representativeSampleSummary =
+    sampleSummaries.length > 0 ? sampleSummaries[0] : null;
+  const hiddenSampleSummaryCount =
+    sampleSummaries.length > 1 ? sampleSummaries.length - 1 : 0;
+
   return (
     <SearchListItemContent>
       <SearchListItemMain>
@@ -20,9 +31,7 @@ export default function MeasurementSet({ item: measurementSet }) {
           <SearchListItemType item={measurementSet} />
           {measurementSet.accession}
         </SearchListItemUniqueId>
-        <SearchListItemTitle>
-          {measurementSet.assay_term.term_name}
-        </SearchListItemTitle>
+        <SearchListItemTitle>{measurementSet.summary}</SearchListItemTitle>
         <SearchListItemMeta>
           <div key="lab">{measurementSet.lab.title}</div>
           {measurementSet.summary && (
@@ -32,6 +41,14 @@ export default function MeasurementSet({ item: measurementSet }) {
             <AlternateAccessions
               alternateAccessions={measurementSet.alternate_accessions}
             />
+          )}
+          {representativeSampleSummary && (
+            <div key="representative-sample-summary">
+              {representativeSampleSummary}
+              {hiddenSampleSummaryCount > 0 && (
+                <i> ({hiddenSampleSummaryCount} more)</i>
+              )}
+            </div>
           )}
         </SearchListItemMeta>
       </SearchListItemMain>

--- a/components/sequencing-file-table.js
+++ b/components/sequencing-file-table.js
@@ -1,4 +1,5 @@
 // node_modules
+import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import { DataGridContainer } from "./data-grid";
@@ -32,6 +33,20 @@ const filesColumns = [
   {
     id: "sequencing_run",
     title: "Sequencing Run",
+  },
+  {
+    id: "seqspec",
+    title: "Associated seqspec File",
+    display: ({ source }, meta) => {
+      const matchingSeqspec = meta.seqspecFiles.find(
+        (seqspec) => seqspec["@id"] === source.seqspec
+      );
+      return (
+        matchingSeqspec && (
+          <Link href={matchingSeqspec.href}>{matchingSeqspec.accession}</Link>
+        )
+      );
+    },
   },
   {
     id: "sequencing_platform",
@@ -79,6 +94,7 @@ const filesColumns = [
 export default function SequencingFileTable({
   files,
   sequencingPlatforms,
+  seqspecFiles = [],
   hasReadType = false,
 }) {
   return (
@@ -86,7 +102,7 @@ export default function SequencingFileTable({
       <SortableGrid
         data={files}
         columns={filesColumns}
-        meta={{ sequencingPlatforms, hasReadType }}
+        meta={{ seqspecFiles, sequencingPlatforms, hasReadType }}
         keyProp="@id"
       />
     </DataGridContainer>
@@ -98,6 +114,8 @@ SequencingFileTable.propTypes = {
   files: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Sequencing platform objects associated with `files`
   sequencingPlatforms: PropTypes.arrayOf(PropTypes.object).isRequired,
+  // seqspec files associated with `files`
+  seqspecFiles: PropTypes.arrayOf(PropTypes.object),
   // True if files have illumina_read_type
   hasReadType: PropTypes.bool,
 };

--- a/components/sequencing-file-table.js
+++ b/components/sequencing-file-table.js
@@ -47,6 +47,7 @@ const filesColumns = [
         )
       );
     },
+    hide: (data, columns, meta) => meta.isSeqspecHidden,
   },
   {
     id: "sequencing_platform",
@@ -96,13 +97,19 @@ export default function SequencingFileTable({
   sequencingPlatforms,
   seqspecFiles = [],
   hasReadType = false,
+  isSeqspecHidden = false,
 }) {
   return (
     <DataGridContainer>
       <SortableGrid
         data={files}
         columns={filesColumns}
-        meta={{ seqspecFiles, sequencingPlatforms, hasReadType }}
+        meta={{
+          seqspecFiles,
+          sequencingPlatforms,
+          hasReadType,
+          isSeqspecHidden,
+        }}
         keyProp="@id"
       />
     </DataGridContainer>
@@ -118,4 +125,6 @@ SequencingFileTable.propTypes = {
   seqspecFiles: PropTypes.arrayOf(PropTypes.object),
   // True if files have illumina_read_type
   hasReadType: PropTypes.bool,
+  // True to hide the seqspec column
+  isSeqspecHidden: PropTypes.bool,
 };

--- a/lib/common-requests.js
+++ b/lib/common-requests.js
@@ -59,6 +59,7 @@ export async function requestFiles(paths, request) {
           "illumina_read_type",
           "lab.title",
           "lane",
+          "seqspec",
           "sequencing_platform",
           "sequencing_run",
           "status",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "jest-environment-jsdom": "^29.0.2",
         "postcss": "^8.4.14",
         "prettier": "^3.0.3",
-        "prettier-plugin-tailwindcss": "^0.5.3",
+        "prettier-plugin-tailwindcss": "^0.5.4",
         "pretty-format": "^29.5.0",
         "tailwindcss": "^3.1.8"
       }
@@ -205,21 +205,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.11.tgz",
-      "integrity": "sha512-lh7RJrtPdhibbxndr6/xx0w8+CVlY5FJZiaSz908Fpy+G0xkBFTvwLcKJFF4PJxVfGhVWNebikpWGnOoC71juQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.15.tgz",
+      "integrity": "sha512-PtZqMmgRrvj8ruoEOIwVA3yoF91O+Hgw9o7DAUTNBA6Mo2jpu31clx9a7Nz/9JznqetTR6zwfC4L3LAjKQXUwA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.10",
-        "@babel/generator": "^7.22.10",
-        "@babel/helper-compilation-targets": "^7.22.10",
-        "@babel/helper-module-transforms": "^7.22.9",
-        "@babel/helpers": "^7.22.11",
-        "@babel/parser": "^7.22.11",
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.11",
-        "@babel/types": "^7.22.11",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.22.15",
+        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/helper-module-transforms": "^7.22.15",
+        "@babel/helpers": "^7.22.15",
+        "@babel/parser": "^7.22.15",
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.22.15",
+        "@babel/types": "^7.22.15",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -250,12 +250,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
-      "integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
+      "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.10",
+        "@babel/types": "^7.22.15",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -265,13 +265,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
-      "integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.5",
+        "@babel/helper-validator-option": "^7.22.15",
         "browserslist": "^4.21.9",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -324,28 +324,28 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
-      "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.9.tgz",
-      "integrity": "sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.15.tgz",
+      "integrity": "sha512-l1UiX4UyHSFsYt17iQ3Se5pQQZZHa22zyIXURmvkmLCD4t/aU+dvNWHatKac/D9Vm9UES7nvIqHs4jZqKviUmQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/helper-module-imports": "^7.22.15",
         "@babel/helper-simple-access": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.5"
+        "@babel/helper-validator-identifier": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -397,32 +397,32 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
+      "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-      "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.11.tgz",
-      "integrity": "sha512-vyOXC8PBWaGc5h7GMsNx68OH33cypkEDJCHvYVVgVbbxJDROYVtexSk0gK5iCF1xNjRIN2s8ai7hwkWDq5szWg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.15.tgz",
+      "integrity": "sha512-7pAjK0aSdxOwR+CcYAqgWOGy5dcfvzsTIfFTb2odQqW47MDfv14UaJDY6eng8ylM2EaeKXdxaSWESbkmaQHTmw==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.11",
-        "@babel/types": "^7.22.11"
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.14",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.14.tgz",
-      "integrity": "sha512-1KucTHgOvaw/LzCVrEOAyXkr9rQlp0A1HiHRYnSUE9dmb8PvPW7o5sscg+5169r54n3vGlbx6GevTE/Iw/P3AQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.15.tgz",
+      "integrity": "sha512-RWmQ/sklUN9BvGGpCDgSubhHWfAx24XDTDObup4ffvxaYsptOg2P3KG0j+1eWKLxpkX0j0uHxmpq2Z1SP/VhxA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -703,9 +703,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.11.tgz",
-      "integrity": "sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
+      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -715,33 +715,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-      "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/parser": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.11.tgz",
-      "integrity": "sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.15.tgz",
+      "integrity": "sha512-DdHPwvJY0sEeN4xJU5uRLmZjgMMDIvMPniLuYzUVXj/GGzysPl0/fwt44JBkyUIzGJPV8QgHMcQdQ34XFuKTYQ==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.10",
-        "@babel/generator": "^7.22.10",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.22.15",
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.11",
-        "@babel/types": "^7.22.11",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -759,13 +759,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.11.tgz",
-      "integrity": "sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.15.tgz",
+      "integrity": "sha512-X+NLXr0N8XXmN5ZsaQdm9U2SSC3UbIYq/doL++sueHOTisgZHoKaQtZxGuV2cUPQHMfjKEfg/g6oy7Hm6SKFtA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.15",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -1986,9 +1986,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
-      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
+      "version": "20.5.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
+      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -2078,15 +2078,15 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.5.0.tgz",
-      "integrity": "sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.6.0.tgz",
+      "integrity": "sha512-CW9YDGTQnNYMIo5lMeuiIG08p4E0cXrXTbcZ2saT/ETE7dWUrNxlijsQeU04qAAKkILiLzdQz+cGFxCJjaZUmA==",
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.5.0",
-        "@typescript-eslint/type-utils": "6.5.0",
-        "@typescript-eslint/utils": "6.5.0",
-        "@typescript-eslint/visitor-keys": "6.5.0",
+        "@typescript-eslint/scope-manager": "6.6.0",
+        "@typescript-eslint/type-utils": "6.6.0",
+        "@typescript-eslint/utils": "6.6.0",
+        "@typescript-eslint/visitor-keys": "6.6.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -2112,14 +2112,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.5.0.tgz",
-      "integrity": "sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.6.0.tgz",
+      "integrity": "sha512-setq5aJgUwtzGrhW177/i+DMLqBaJbdwGj2CPIVFFLE0NCliy5ujIdLHd2D1ysmlmsjdL2GWW+hR85neEfc12w==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.5.0",
-        "@typescript-eslint/types": "6.5.0",
-        "@typescript-eslint/typescript-estree": "6.5.0",
-        "@typescript-eslint/visitor-keys": "6.5.0",
+        "@typescript-eslint/scope-manager": "6.6.0",
+        "@typescript-eslint/types": "6.6.0",
+        "@typescript-eslint/typescript-estree": "6.6.0",
+        "@typescript-eslint/visitor-keys": "6.6.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2139,12 +2139,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.5.0.tgz",
-      "integrity": "sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.6.0.tgz",
+      "integrity": "sha512-pT08u5W/GT4KjPUmEtc2kSYvrH8x89cVzkA0Sy2aaOUIw6YxOIjA8ilwLr/1fLjOedX1QAuBpG9XggWqIIfERw==",
       "dependencies": {
-        "@typescript-eslint/types": "6.5.0",
-        "@typescript-eslint/visitor-keys": "6.5.0"
+        "@typescript-eslint/types": "6.6.0",
+        "@typescript-eslint/visitor-keys": "6.6.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2155,12 +2155,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.5.0.tgz",
-      "integrity": "sha512-f7OcZOkRivtujIBQ4yrJNIuwyCQO1OjocVqntl9dgSIZAdKqicj3xFDqDOzHDlGCZX990LqhLQXWRnQvsapq8A==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.6.0.tgz",
+      "integrity": "sha512-8m16fwAcEnQc69IpeDyokNO+D5spo0w1jepWWY2Q6y5ZKNuj5EhVQXjtVAeDDqvW6Yg7dhclbsz6rTtOvcwpHg==",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.5.0",
-        "@typescript-eslint/utils": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.6.0",
+        "@typescript-eslint/utils": "6.6.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -2181,9 +2181,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.5.0.tgz",
-      "integrity": "sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.6.0.tgz",
+      "integrity": "sha512-CB6QpJQ6BAHlJXdwUmiaXDBmTqIE2bzGTDLADgvqtHWuhfNP3rAOK7kAgRMAET5rDRr9Utt+qAzRBdu3AhR3sg==",
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
       },
@@ -2193,12 +2193,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.5.0.tgz",
-      "integrity": "sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.6.0.tgz",
+      "integrity": "sha512-hMcTQ6Al8MP2E6JKBAaSxSVw5bDhdmbCEhGW/V8QXkb9oNsFkA4SBuOMYVPxD3jbtQ4R/vSODBsr76R6fP3tbA==",
       "dependencies": {
-        "@typescript-eslint/types": "6.5.0",
-        "@typescript-eslint/visitor-keys": "6.5.0",
+        "@typescript-eslint/types": "6.6.0",
+        "@typescript-eslint/visitor-keys": "6.6.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2219,16 +2219,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.5.0.tgz",
-      "integrity": "sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.6.0.tgz",
+      "integrity": "sha512-mPHFoNa2bPIWWglWYdR0QfY9GN0CfvvXX1Sv6DlSTive3jlMTUy+an67//Gysc+0Me9pjitrq0LJp0nGtLgftw==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.5.0",
-        "@typescript-eslint/types": "6.5.0",
-        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/scope-manager": "6.6.0",
+        "@typescript-eslint/types": "6.6.0",
+        "@typescript-eslint/typescript-estree": "6.6.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -2243,11 +2243,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.5.0.tgz",
-      "integrity": "sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.6.0.tgz",
+      "integrity": "sha512-L61uJT26cMOfFQ+lMZKoJNbAEckLe539VhTxiGHrWl5XSKQgA0RTBZJW2HFPy5T0ZvPVSD93QsrTKDkfNwJGyQ==",
       "dependencies": {
-        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/types": "6.6.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -2485,15 +2485,15 @@
       }
     },
     "node_modules/array-includes": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
-      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
+      "integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "get-intrinsic": "^1.1.3",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
         "is-string": "^1.0.7"
       },
       "engines": {
@@ -3110,9 +3110,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001524",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
-      "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
+      "version": "1.0.30001525",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
+      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -3634,9 +3634,9 @@
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
-      "version": "16.18.46",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.46.tgz",
-      "integrity": "sha512-Mnq3O9Xz52exs3mlxMcQuA7/9VFe/dXcrgAyfjLkABIqxXKOgBRjyazTxUbjsxDa4BP7hhPliyjVTP9RDP14xg==",
+      "version": "16.18.48",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.48.tgz",
+      "integrity": "sha512-mlaecDKQ7rIZrYD7iiKNdzFb6e/qD5I9U1rAhq+Fd+DWvYVs+G2kv74UFHmSOlg5+i/vF3XxuR522V4u8BqO+Q==",
       "dev": true
     },
     "node_modules/cypress/node_modules/chalk": {
@@ -3941,9 +3941,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.505",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.505.tgz",
-      "integrity": "sha512-0A50eL5BCCKdxig2SsCXhpuztnB9PfUgRMojj5tMvt8O54lbwz3t6wNgnpiTRosw5QjlJB7ixhVyeg8daLQwSQ==",
+      "version": "1.4.508",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.508.tgz",
+      "integrity": "sha512-FFa8QKjQK/A5QuFr2167myhMesGrhlOBD+3cYNxO9/S4XzHEXesyTD/1/xF644gC8buFPz3ca6G1LOQD0tZrrg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5165,9 +5165,9 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.1.tgz",
-      "integrity": "sha512-nx0cki48JBA6ThPeUpeKCNpdhEl/9bRS+dAEYnRUod+Z1jhFfC3K/mBLorZZntqHM+GTH3/dkkpfoT3QITYe7g==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.6.tgz",
+      "integrity": "sha512-n2aZ9tNfYDwaHhvFTkhFErqOMIb8uyzSQ+vGJBjZyanAKZVbGUQ1sngfk9FdkBw7G26O7AgNjLcecLffD1c7eg==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -5178,9 +5178,9 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "10.16.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.2.tgz",
-      "integrity": "sha512-aY6L9YMvqMWtfOQptaUvvr8dp97jskXY5UYLQM0vOPxKeERrG/Z034EIQZ/52u7MeCT0HlCQy3/l0HdUZCB9Tw==",
+      "version": "10.16.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.3.tgz",
+      "integrity": "sha512-1OMs6wY964hX8YjiCeYQlgrZDbkKvZztnynTUgUZjdzq2au6PZUsodmUY6GAudUgImrWqTrtpSwMbi1ETmIx4A==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -6322,15 +6322,14 @@
       }
     },
     "node_modules/iterator.prototype": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.0.tgz",
-      "integrity": "sha512-rjuhAk1AJ1fssphHD0IFV6TWL40CwRZ53FrztKx43yk2v6rguBYsY4Bj1VU4HmoMmKwZUlx7mfnhDf9cOp4YTw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.1.tgz",
+      "integrity": "sha512-9E+nePc8C9cnQldmNl6bgpTY6zI4OPRZd97fhJ/iVZ1GifIUDVV5F6x1nEDqpe8KaMEZGT4xgrwKQDxXnjOIZQ==",
       "dev": true,
       "dependencies": {
-        "define-properties": "^1.1.4",
-        "get-intrinsic": "^1.1.3",
+        "define-properties": "^1.2.0",
+        "get-intrinsic": "^1.2.1",
         "has-symbols": "^1.0.3",
-        "has-tostringtag": "^1.0.0",
         "reflect.getprototypeof": "^1.0.3"
       }
     },
@@ -8672,9 +8671,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.3.tgz",
-      "integrity": "sha512-M5K80V21yM+CTm/FEFYRv9/9LyInYbCSXpIoPAKMm8zy89IOwdiA2e4JVbcO7tvRtAQWz32zdj7/WKcsmFyAVg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.4.tgz",
+      "integrity": "sha512-QZzzB1bID6qPsKHTeA9qPo1APmmxfFrA5DD3LQ+vbTmAnY40eJI7t9Q1ocqel2EKMWNPLJqdTDWZj1hKYgqSgg==",
       "dev": true,
       "engines": {
         "node": ">=14.21.3"
@@ -9002,15 +9001,15 @@
       }
     },
     "node_modules/reflect.getprototypeof": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.3.tgz",
-      "integrity": "sha512-TTAOZpkJ2YLxl7mVHWrNo3iDMEkYlva/kgFcXndqMgbo/AZUmmavEkdXV+hXtE4P8xdyEKRzalaFqZVuwIk/Nw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
+      "integrity": "sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "get-intrinsic": "^1.1.1",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
         "globalthis": "^1.0.3",
         "which-builtin-type": "^1.1.3"
       },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jest-environment-jsdom": "^29.0.2",
     "postcss": "^8.4.14",
     "prettier": "^3.0.3",
-    "prettier-plugin-tailwindcss": "^0.5.3",
+    "prettier-plugin-tailwindcss": "^0.5.4",
     "pretty-format": "^29.5.0",
     "tailwindcss": "^3.1.8"
   }

--- a/pages/auxiliary-sets/[id].js
+++ b/pages/auxiliary-sets/[id].js
@@ -43,6 +43,7 @@ export default function AuxiliarySet({
   libraryConstructionPlatform = null,
   constructLibraries,
   files,
+  seqspecFiles,
   sequencingPlatforms,
   controlForSets,
   attribution = null,
@@ -150,6 +151,7 @@ export default function AuxiliarySet({
               <DataAreaTitle>Sequencing Results (Illumina)</DataAreaTitle>
               <SequencingFileTable
                 files={filesWithReadType}
+                seqspecFiles={seqspecFiles}
                 sequencingPlatforms={sequencingPlatforms}
                 hasReadType
               />
@@ -160,6 +162,7 @@ export default function AuxiliarySet({
               <DataAreaTitle>Sequencing Results</DataAreaTitle>
               <SequencingFileTable
                 files={filesWithoutReadType}
+                seqspecFiles={seqspecFiles}
                 sequencingPlatforms={sequencingPlatforms}
               />
             </>
@@ -197,6 +200,8 @@ AuxiliarySet.propTypes = {
   constructLibraries: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Files to display
   files: PropTypes.arrayOf(PropTypes.object).isRequired,
+  // seqspec files associated with `files`
+  seqspecFiles: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Sequencing platform objects associated with `files`
   sequencingPlatforms: PropTypes.arrayOf(PropTypes.object).isRequired,
   // File sets controlled by this file set
@@ -251,6 +256,19 @@ export async function getServerSideProps({ params, req, query }) {
         ? await requestOntologyTerms(uniqueSequencingPlatformPaths, request)
         : [];
 
+    // Use the files to retrieve all the seqspec files they might link to.
+    let seqspecFiles = [];
+    if (files.length > 0) {
+      const seqspecPaths = files
+        .map((file) => file.seqspec)
+        .filter((seqspec) => seqspec);
+      const uniqueSeqspecPaths = [...new Set(seqspecPaths)];
+      seqspecFiles =
+        uniqueSeqspecPaths.length > 0
+          ? await requestFiles(uniqueSeqspecPaths, request)
+          : [];
+    }
+
     let controlForSets = [];
     if (auxiliarySet.control_for.length > 0) {
       const controlForPaths = auxiliarySet.control_for.map(
@@ -276,6 +294,7 @@ export async function getServerSideProps({ params, req, query }) {
         libraryConstructionPlatform,
         constructLibraries,
         files,
+        seqspecFiles,
         sequencingPlatforms,
         controlForSets,
         pageContext: { title: auxiliarySet.accession },

--- a/pages/configuration-files/[...id].js
+++ b/pages/configuration-files/[...id].js
@@ -36,7 +36,6 @@ export default function ConfigurationFile({
   configurationFile,
   fileSet = null,
   seqspecOf,
-  seqspecFiles,
   sequencingPlatforms,
   documents,
   derivedFrom,
@@ -70,8 +69,8 @@ export default function ConfigurationFile({
               <DataAreaTitle>seqspec File Of</DataAreaTitle>
               <SequencingFileTable
                 files={seqspecOf}
-                seqspecFiles={seqspecFiles}
                 sequencingPlatforms={sequencingPlatforms}
+                isSeqspecHidden={true}
               />
             </>
           )}
@@ -112,8 +111,6 @@ ConfigurationFile.propTypes = {
   fileSet: PropTypes.object,
   // The file is a seqspec of
   seqspecOf: PropTypes.array.isRequired,
-  // Associated seqspec files to `seqspecOf` files
-  seqspecFiles: PropTypes.array.isRequired,
   // Sequencing platform objects associated with the files it is a seqspec of
   sequencingPlatforms: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Documents set associate with this file
@@ -149,24 +146,9 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
   );
   if (FetchRequest.isResponseSuccess(configurationFile)) {
     const fileSet = await request.getObject(configurationFile.file_set, null);
-
-    // Get any seqspec_of files, as well as their associated seqspec files.
-    let seqspecOf = [];
-    let seqspecFiles = [];
-    if (configurationFile.seqspec_of) {
-      seqspecOf = await requestFiles(configurationFile.seqspec_of, request);
-
-      if (seqspecOf.length > 0) {
-        const seqspecPaths = seqspecOf
-          .map((file) => file.seqspec)
-          .filter((seqspec) => seqspec);
-        const uniqueSeqspecPaths = [...new Set(seqspecPaths)];
-        seqspecFiles =
-          uniqueSeqspecPaths.length > 0
-            ? await requestFiles(uniqueSeqspecPaths, request)
-            : [];
-      }
-    }
+    const seqspecOf = configurationFile.seqspec_of
+      ? await requestFiles(configurationFile.seqspec_of, request)
+      : [];
     const documents = configurationFile.documents
       ? await requestDocuments(configurationFile.documents, request)
       : [];
@@ -211,7 +193,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         configurationFile,
         fileSet,
         seqspecOf,
-        seqspecFiles,
         sequencingPlatforms,
         documents,
         derivedFrom,

--- a/pages/measurement-sets/[id].js
+++ b/pages/measurement-sets/[id].js
@@ -1,6 +1,7 @@
 // node_modules
 import Link from "next/link";
 import PropTypes from "prop-types";
+import { Fragment } from "react";
 // components
 import AlternateAccessions from "../../components/alternate-accessions";
 import AliasList from "../../components/alias-list";
@@ -11,7 +12,11 @@ import {
   DataAreaTitle,
   DataItemLabel,
   DataItemValue,
+  DataItemValueUrl,
+  DataItemValueCollapseControl,
+  DataItemValueControlLabel,
   DataPanel,
+  useDataAreaCollapser,
 } from "../../components/data-area";
 import DbxrefList from "../../components/dbxref-list";
 import DocumentTable from "../../components/document-table";
@@ -41,12 +46,24 @@ export default function MeasurementSet({
   documents,
   donors,
   files,
+  seqspecFiles,
   sequencingPlatforms,
+  libraryConstructionPlatform = null,
   attribution = null,
   isJson,
 }) {
+  const samplesCollapser = useDataAreaCollapser(measurementSet.samples || []);
   const { filesWithReadType, filesWithoutReadType } =
     splitIlluminaSequenceFiles(files);
+
+  // Collect all sample summaries and display them as a collapsible list.
+  const sampleSummaries =
+    measurementSet.samples?.length > 0
+      ? measurementSet.samples.map((sample) => sample.summary)
+      : [];
+  const sampleSummariesCollapser = useDataAreaCollapser([
+    ...new Set(sampleSummaries),
+  ]);
 
   return (
     <>
@@ -61,22 +78,13 @@ export default function MeasurementSet({
         <JsonDisplay item={measurementSet} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>
-              <DataItemLabel>Assay Term</DataItemLabel>
+              <DataItemLabel>Assay Summary</DataItemLabel>
+              <DataItemValue>{measurementSet.summary}</DataItemValue>
               {assayTerm && (
-                <DataItemValue>
-                  <Link href={assayTerm["@id"]}>{assayTerm.term_name}</Link>
-                </DataItemValue>
-              )}
-              {measurementSet.protocol && (
                 <>
-                  <DataItemLabel>Protocol</DataItemLabel>
+                  <DataItemLabel>Assay Term</DataItemLabel>
                   <DataItemValue>
-                    <Link
-                      href={measurementSet.protocol}
-                      key={measurementSet.protocol}
-                    >
-                      {measurementSet.protocol}
-                    </Link>
+                    <Link href={assayTerm["@id"]}>{assayTerm.term_name}</Link>
                   </DataItemValue>
                 </>
               )}
@@ -112,14 +120,100 @@ export default function MeasurementSet({
                   </DataItemValue>
                 </>
               )}
-              {measurementSet.samples?.length > 0 && (
+              {samplesCollapser.displayedData.length > 0 && (
                 <>
                   <DataItemLabel>Samples</DataItemLabel>
                   <DataItemValue>
                     <SeparatedList>
-                      {measurementSet.samples.map((sample) => (
-                        <Link href={sample["@id"]} key={sample["@id"]}>
-                          {sample.accession}
+                      {samplesCollapser.displayedData.map((sample, index) => (
+                        <Fragment key={sample["@id"]}>
+                          <Link href={sample["@id"]}>{sample.accession}</Link>
+                          {index ===
+                            samplesCollapser.displayedData.length - 1 && (
+                            <DataItemValueCollapseControl
+                              key="more-control"
+                              collapser={samplesCollapser}
+                              className="ml-1 inline-block"
+                            >
+                              <DataItemValueControlLabel
+                                collapser={samplesCollapser}
+                              />
+                            </DataItemValueCollapseControl>
+                          )}
+                        </Fragment>
+                      ))}
+                    </SeparatedList>
+                  </DataItemValue>
+                </>
+              )}
+              {sampleSummariesCollapser.displayedData.length > 0 && (
+                <>
+                  <DataItemLabel>Sample Summaries</DataItemLabel>
+                  <DataItemValue>
+                    <>
+                      {sampleSummariesCollapser.displayedData.map((summary) => (
+                        <div
+                          key={summary}
+                          className="my-2 first:mt-0 last:mb-0"
+                        >
+                          {summary}
+                        </div>
+                      ))}
+                      <DataItemValueCollapseControl
+                        collapser={sampleSummariesCollapser}
+                      >
+                        <DataItemValueControlLabel
+                          collapser={sampleSummariesCollapser}
+                        />
+                      </DataItemValueCollapseControl>
+                    </>
+                  </DataItemValue>
+                </>
+              )}
+              {measurementSet.description && (
+                <>
+                  <DataItemLabel>Description</DataItemLabel>
+                  <DataItemValue>{measurementSet.description}</DataItemValue>
+                </>
+              )}
+              {measurementSet.related_multiome_datasets?.length > 0 && (
+                <>
+                  <DataItemLabel>Related Multiome Datasets</DataItemLabel>
+                  <DataItemValue>
+                    <SeparatedList>
+                      {measurementSet.related_multiome_datasets.map(
+                        (dataset) => (
+                          <Link href={dataset["@id"]} key={dataset["@id"]}>
+                            {dataset.accession}
+                          </Link>
+                        )
+                      )}
+                    </SeparatedList>
+                  </DataItemValue>
+                </>
+              )}
+              {measurementSet.auxiliary_sets?.length > 0 && (
+                <>
+                  <DataItemLabel>Auxiliary Sets</DataItemLabel>
+                  <DataItemValue>
+                    <SeparatedList>
+                      {measurementSet.auxiliary_sets.map((set) => (
+                        <Link href={set["@id"]} key={set["@id"]}>
+                          {set.accession}
+                        </Link>
+                      ))}
+                    </SeparatedList>
+                  </DataItemValue>
+                </>
+              )}
+              {measurementSet.control_file_sets?.length > 0 && (
+                <>
+                  <DataItemLabel>Control File Sets</DataItemLabel>
+                  <DataItemValue>
+                    <SeparatedList>
+                      {measurementSet.control_file_sets.map((set) => (
+                        <Link href={set["@id"]} key={set["@id"]}>
+                          {set.accession}
                         </Link>
                       ))}
                     </SeparatedList>
@@ -128,11 +222,47 @@ export default function MeasurementSet({
               )}
             </DataArea>
           </DataPanel>
+          {(libraryConstructionPlatform || measurementSet.protocol) && (
+            <>
+              <DataAreaTitle>Assay Details</DataAreaTitle>
+              <DataPanel>
+                <DataArea>
+                  {libraryConstructionPlatform && (
+                    <>
+                      <DataItemLabel>
+                        Library Construction Platform
+                      </DataItemLabel>
+                      <DataItemValue>
+                        <Link href={libraryConstructionPlatform["@id"]}>
+                          {libraryConstructionPlatform.term_name}
+                        </Link>
+                      </DataItemValue>
+                    </>
+                  )}
+                  {measurementSet.protocol && (
+                    <>
+                      <DataItemLabel>Protocol</DataItemLabel>
+                      <DataItemValueUrl>
+                        <a
+                          href={measurementSet.protocol}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {measurementSet.protocol}
+                        </a>
+                      </DataItemValueUrl>
+                    </>
+                  )}
+                </DataArea>
+              </DataPanel>
+            </>
+          )}
           {filesWithReadType.length > 0 && (
             <>
               <DataAreaTitle>Sequencing Results (Illumina)</DataAreaTitle>
               <SequencingFileTable
                 files={filesWithReadType}
+                seqspecFiles={seqspecFiles}
                 sequencingPlatforms={sequencingPlatforms}
                 hasReadType
               />
@@ -143,6 +273,7 @@ export default function MeasurementSet({
               <DataAreaTitle>Sequencing Results</DataAreaTitle>
               <SequencingFileTable
                 files={filesWithoutReadType}
+                seqspecFiles={seqspecFiles}
                 sequencingPlatforms={sequencingPlatforms}
               />
             </>
@@ -153,7 +284,6 @@ export default function MeasurementSet({
               <DocumentTable documents={documents} />
             </>
           )}
-
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>
@@ -170,10 +300,14 @@ MeasurementSet.propTypes = {
   donors: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Files to display
   files: PropTypes.arrayOf(PropTypes.object).isRequired,
+  // seqspec files associated with `files`
+  seqspecFiles: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Sequencing platform objects associated with `files`
   sequencingPlatforms: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Documents associated with this measurement set
   documents: PropTypes.arrayOf(PropTypes.object).isRequired,
+  // Library construction platform object
+  libraryConstructionPlatform: PropTypes.object,
   // Attribution for this measurement set
   attribution: PropTypes.object,
   // Is the format JSON?
@@ -204,6 +338,26 @@ export async function getServerSideProps({ params, req, query }) {
       const filePaths = measurementSet.files.map((file) => file["@id"]) || [];
       files = await requestFiles(filePaths, request);
     }
+    let libraryConstructionPlatform = null;
+    if (measurementSet.library_construction_platform) {
+      libraryConstructionPlatform = await request.getObject(
+        measurementSet.library_construction_platform,
+        null
+      );
+    }
+
+    // Use the files to retrieve all the seqspec files they might link to.
+    let seqspecFiles = [];
+    if (files.length > 0) {
+      const seqspecPaths = files
+        .map((file) => file.seqspec)
+        .filter((seqspec) => seqspec);
+      const uniqueSeqspecPaths = [...new Set(seqspecPaths)];
+      seqspecFiles =
+        uniqueSeqspecPaths.length > 0
+          ? await requestFiles(uniqueSeqspecPaths, request)
+          : [];
+    }
 
     // Use the files to retrieve all the sequencing platform objects they link to.
     const sequencingPlatformPaths = files
@@ -231,7 +385,9 @@ export async function getServerSideProps({ params, req, query }) {
         documents,
         donors,
         files,
+        seqspecFiles,
         sequencingPlatforms,
+        libraryConstructionPlatform,
         pageContext: { title: measurementSet.accession },
         breadcrumbs,
         attribution,

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,3 +1,4 @@
 module.exports = {
+  trailingComma: "es5",
   plugins: ["prettier-plugin-tailwindcss"],
 };


### PR DESCRIPTION
I had the mechanism to collapse and expand data-area values before, but because we only used it in one place, this mechanism wasn’t very reusable. This ticket uses that mechanism in more places, so I introduced a custom hook and associated components in data-area.js to display these, as well as the concept of a “collapser” object that tracks this state. I also changed the UI to not have the expand/collapse button right after the label, but instead right after the data — which has its own issues but I think people generally prefer it. The label now includes “more” and “fewer” text as well as a count of hidden items, instead of just an ellipsis icon.

Because we now show an “Associated seqspec files” column on sequencing file tables, and some pages already use this column, I had to request seqspec files on these pages as well.