### PR TITLE
IGVF-959 Abstract and multiple types for reports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
   "rules": {
     "camelcase": ["error", { "properties": "never" }],
     "comma-dangle": ["error", "always-multiline"],
+    "curly": "error",
     "dot-notation": ["error"],
     "eqeqeq": ["error"],
     "func-style": ["error", "declaration"],

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,7 +53,6 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-igvf-1150-igvf-ui-959.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,7 +53,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'http://igvfd-igvf-1150-igvf-ui-959.demo.igvf.org',
+            'backend_url': 'https://igvfd-igvf-1150-igvf-ui-959.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,6 +53,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
+            'backend_url': 'http://igvfd-igvf-1150-igvf-ui-959.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/components/__mocks__/profile.js
+++ b/components/__mocks__/profile.js
@@ -398,6 +398,10 @@ const profiles = {
       "alternate_accessions",
     ],
     properties: {
+      "@id": {
+        title: "ID",
+        type: "string",
+      },
       accession: {
         title: "Accession",
         type: "string",
@@ -419,6 +423,32 @@ const profiles = {
       lab: {
         title: "Lab",
         type: "string",
+      },
+      loci: {
+        title: "Loci",
+        type: "array",
+        items: {
+          title: "Locus",
+          type: "object",
+          properties: {
+            assembly: {
+              title: "Mapping assembly",
+              type: "string",
+            },
+            chromosome: {
+              title: "Chromosome",
+              type: "string",
+            },
+            start: {
+              title: "Start",
+              type: "integer",
+            },
+            end: {
+              title: "End",
+              type: "integer",
+            },
+          },
+        },
       },
       reporter_library_details: {
         title: "Reporter Library Details",
@@ -649,6 +679,13 @@ const profiles = {
         type: "string",
         format: "uri",
       },
+      ethnicities: {
+        title: "Ethnicity",
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
       external_resources: {
         title: "External Resources",
         description: "A list of external resources associated with the donor.",
@@ -680,38 +717,9 @@ const profiles = {
           },
         },
       },
-      health_status_history: {
-        title: "Health Status History",
-        description: "Relevent health status changes in the donor",
-        type: "array",
-        minItems: 1,
-        items: {
-          title: "Health Status",
-          type: "object",
-          additionalProperties: false,
-          properties: {
-            health_description: {
-              title: "Description of Donor Health",
-              description: "Description of the health status change.",
-              type: "string",
-              pattern: "^(\\S+(\\s|\\S)*\\S+|\\S)$",
-              formInput: "textarea",
-            },
-            date_start: {
-              title: "Date Health Change Started",
-              description: "The date the donor health change started.",
-              type: "string",
-              format: "date",
-            },
-            date_end: {
-              title: "Date Health Change Ended",
-              description:
-                "The date the donor health change ended.  This value is not set if the health status is continuing, or if there is a following health status.",
-              type: "string",
-              format: "date",
-            },
-          },
-        },
+      sex: {
+        title: "Sex",
+        type: "string",
       },
       "@id": {
         title: "ID",
@@ -747,6 +755,10 @@ const profiles = {
       "aliases",
     ],
     properties: {
+      "@id": {
+        title: "ID",
+        type: "string",
+      },
       accession: {
         title: "Accession",
         type: "string",
@@ -758,6 +770,20 @@ const profiles = {
           title: "Treatment",
           type: "string",
           linkTo: "Treatment",
+        },
+      },
+      lab: {
+        title: "Lab",
+        type: "string",
+        linkTo: "Lab",
+      },
+      sample_terms: {
+        title: "Sample Terms",
+        type: "array",
+        items: {
+          title: "Sample Term",
+          type: "string",
+          linkTo: "SampleTerm",
         },
       },
     },

--- a/components/__tests__/pager.test.js
+++ b/components/__tests__/pager.test.js
@@ -1,14 +1,14 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import Pager from "../pager";
 
 describe("Test the pager component in different conditions", () => {
-  it("renders a 9-page pager and reacts to clicks", () => {
+  it("renders a seven-page pager and reacts to clicks", () => {
     const onClick = jest.fn();
-    render(<Pager currentPage={1} totalPages={9} onClick={onClick} />);
+    render(<Pager currentPage={1} totalPages={7} onClick={onClick} />);
 
     // Test conditions for current page 1
     const pagerElements = screen.getAllByRole("button");
-    expect(pagerElements).toHaveLength(11);
+    expect(pagerElements).toHaveLength(9);
     expect(pagerElements[0]).toHaveAttribute("disabled");
     expect(pagerElements[1].textContent).toBe("1");
     expect(pagerElements[1]).toHaveAttribute("aria-current");
@@ -31,11 +31,9 @@ describe("Test the pager component in different conditions", () => {
 
     // Test that the pager has 11 list items but only 10 buttons -- one list element has ellipsis.
     const pagerListElements = screen.getAllByRole("listitem");
-    expect(pagerListElements).toHaveLength(11);
+    expect(pagerListElements).toHaveLength(9);
     const pagerButtonElements = screen.getAllByRole("button");
-    expect(pagerButtonElements).toHaveLength(10);
-    const noButton = within(pagerListElements[8]).queryByRole("button");
-    expect(noButton).toBeNull();
+    expect(pagerButtonElements).toHaveLength(8);
   });
 
   it("renders a pager with enough pages for one ellipsis before the selected page", () => {
@@ -44,26 +42,20 @@ describe("Test the pager component in different conditions", () => {
 
     // Test that the pager has 11 list items but only 10 buttons -- one list element has ellipsis.
     const pagerListElements = screen.getAllByRole("listitem");
-    expect(pagerListElements).toHaveLength(11);
+    expect(pagerListElements).toHaveLength(9);
     const pagerButtonElements = screen.getAllByRole("button");
-    expect(pagerButtonElements).toHaveLength(10);
-    const noButton = within(pagerListElements[2]).queryByRole("button");
-    expect(noButton).toBeNull();
+    expect(pagerButtonElements).toHaveLength(8);
   });
 
-  it("renders a pager with enough pages for one ellipsis, and react to click", () => {
+  it("renders a pager with enough pages for two ellipses, and react to click", () => {
     const onClick = jest.fn();
     render(<Pager currentPage={7} totalPages={20} onClick={onClick} />);
 
     // Go to page 7 to bring up two ellipses.
     const pagerListElements = screen.getAllByRole("listitem");
-    expect(pagerListElements).toHaveLength(11);
+    expect(pagerListElements).toHaveLength(9);
     const pagerButtonElements = screen.getAllByRole("button");
-    expect(pagerButtonElements).toHaveLength(9);
-    let noButton = within(pagerListElements[2]).queryByRole("button");
-    expect(noButton).toBeNull();
-    noButton = within(pagerListElements[8]).queryByRole("button");
-    expect(noButton).toBeNull();
+    expect(pagerButtonElements).toHaveLength(7);
 
     // Clicks on the previous page button should go directly to page 6.
     const previousButton = screen.getByLabelText("Previous page");

--- a/components/facets/__tests__/facet-groups.test.js
+++ b/components/facets/__tests__/facet-groups.test.js
@@ -38,7 +38,7 @@ describe("Test the `<FacetGroupButton>` component", () => {
         {
           field: "type",
           term: "HumanDonor",
-          remove: "/report",
+          remove: "/multireport",
         },
       ],
     };

--- a/components/form-elements/__tests__/select.test.js
+++ b/components/form-elements/__tests__/select.test.js
@@ -20,7 +20,7 @@ describe("Test the Select component", () => {
     const select = screen.getByRole("combobox");
     expect(select).toBeInTheDocument();
     expect(select).toHaveClass(
-      "block w-full appearance-none rounded border border-form-element bg-form-element py-0 pl-1 pr-5 font-medium text-form-element disabled:border-form-element-disabled disabled:text-form-element-disabled text-sm form-element-height-md leading-[180%]"
+      "block w-full appearance-none rounded border border-form-element bg-form-element py-0 pl-1 pr-5 font-medium text-form-element disabled:border-form-element-disabled disabled:text-form-element-disabled text-sm h-8 leading-[180%]"
     );
 
     // Selecting an option should call the onChange handler.

--- a/components/form-elements/button.js
+++ b/components/form-elements/button.js
@@ -62,9 +62,9 @@ const iconSizes = {
  * Tailwind CSS classes for each of the button sizes.
  */
 const buttonSizeClasses = {
-  sm: `px-2 rounded text-xs form-element-height-sm ${iconSizes.sm}`,
-  md: `px-4 rounded text-sm form-element-height-md ${iconSizes.md}`,
-  lg: `px-6 rounded text-base form-element-height-lg ${iconSizes.lg}`,
+  sm: `px-2 rounded text-xs h-6 ${iconSizes.sm}`,
+  md: `px-4 rounded text-sm h-8 ${iconSizes.md}`,
+  lg: `px-6 rounded text-base h-10 ${iconSizes.lg}`,
 };
 
 /**

--- a/components/form-elements/index.js
+++ b/components/form-elements/index.js
@@ -9,11 +9,11 @@ export {
   AttachedButtons,
   Button,
   ButtonLink,
-  TooltipButton,
   FormLabel,
   ListSelect,
   RadioButton,
   Select,
   TextField,
+  TooltipButton,
 };
 /* istanbul ignore file */

--- a/components/form-elements/select.js
+++ b/components/form-elements/select.js
@@ -8,9 +8,9 @@ import FormLabel from "./form-label";
  * Tailwind CSS classes for each of the select sizes.
  */
 const selectSizeClasses = {
-  sm: "text-xs form-element-height-sm",
-  md: "text-sm form-element-height-md leading-[180%]",
-  lg: "text-base form-element-height-lg leading-[220%]",
+  sm: "text-xs h-6",
+  md: "text-sm h-8 leading-[180%]",
+  lg: "text-base h-10 leading-[220%]",
 };
 
 const labelSizeClasses = {

--- a/components/pager.js
+++ b/components/pager.js
@@ -15,45 +15,45 @@ import { Button } from "./form-elements";
  * component allow the user to move to the previous and next page to the current page. We have four
  * cases to consider based on the total page count:
  *
- * Nine or fewer: Straight sequence of pages with no ellipses ([x] indicates current page):
- * <  1   2   3   4   5  [6]  7   8   9  >
+ * Seven or fewer: Straight sequence of pages with no ellipses ([x] indicates current page):
+ * <  1   2   3   4   5  [6]  7  >
  *
- * More than nine with the current page towards the left end ('.' indicates ellipsis):
- * <  1   2  [3]  4   5   6   7   .   20  >
+ * More than seven with the current page towards the left end ('.' indicates ellipsis):
+ * <  1   2  [3]  4   5   .   20  >
  *
- * More than nine with the current page towards the right end:
- * <  1   .   14   15  [16]  17   18   19   20  >
+ * More than seven with the current page towards the right end:
+ * <  1   .   15  [16]  17   19   20  >
  *
- * More than nine with the current page not near either end:
- * <  1   .   11   12  [13]  14   15   .   20  >
+ * More than seven with the current page not near either end:
+ * <  1   .   12  [13]  14   .   20  >
  *
- * For cases with more than nine pages, Pager attempts to keep a cluster of visible page numbers
- * surrounding the current page so that the user can see and select the two preceding and two
- * succeeding page numbers, except when the current page gets to the extreme ends of the page
- * range and fewer than two page numbers exist on one side of the cluster. When the current page
- * approaches the ends of the page range, more than two visible pages appear in the cluster on the
- * side facing the near end of the page range. This allowance keeps the width of the entire Pager
- * component consistent regardless of the current page number, so that the previous/next buttons
- * don't shift around horizontally.
+ * For cases with more than seven pages, Pager attempts to keep a cluster of visible page numbers
+ * surrounding the current page so that the user can see and select the preceding and * succeeding
+ * page numbers, except when the current page gets to the extreme ends of the page range and fewer
+ * than one page number exists on one side of the cluster. When the current page approaches the
+ * ends of the page range, more than one visible page appears in the cluster on the side facing the
+ * near end of the page range. This allowance keeps the width of the entire Pager component
+ * consistent regardless of the current page number, so that the previous/next buttons don't shift
+ * around horizontally.
  */
 export default function Pager({ currentPage, totalPages, onClick, className }) {
   // Create the array of 1-based page numbers, with page 0 to represent an ellipsis before the
   // current page and page -1 to represent an ellipsis after the current page. No real difference
   // between these two ellipsis values, but Pager uses distinct values so we don't have duplicate
-  // React keys. No point memoizing `pageNumbers` as it needs recalculating when any prop changes.
+  // React keys.
   let pageNumbers;
-  if (totalPages <= 9) {
-    // A total page count of nine or fewer has no ellipses -- just a straight array of
+  if (totalPages <= 7) {
+    // A total page count of seven or fewer has no ellipses -- just a straight array of
     // sequential numbers.
     pageNumbers = _.range(1, totalPages + 1); // _.range ends at max - 1
   } else {
-    // With more than nine pages, build a cluster of pages around the current page, first by
+    // With more than seven pages, build a cluster of pages around the current page, first by
     // determining the minimum and maximum page numbers for the cluster. Allow for filling in
     // extra numbers in the cluster for cases where the current page number approaches the ends
-    // of the page range, and cutting off the page numbers when the current page is within two
-    // pages of either end of the page range.
-    const clusterMin = Math.min(Math.max(1, currentPage - 2), totalPages - 6);
-    const clusterMax = Math.max(Math.min(currentPage + 2, totalPages), 7);
+    // of the page range, and cutting off the page numbers when the current page is within a
+    // page of either end of the page range.
+    const clusterMin = Math.min(Math.max(1, currentPage - 1), totalPages - 4);
+    const clusterMax = Math.max(Math.min(currentPage + 1, totalPages), 5);
     const clusterPageNumbers = _.range(clusterMin, clusterMax + 1); // _.range ends at max - 1
 
     // Determine whether we need an ellipsis before the cluster, or continuous page numbers. If
@@ -101,7 +101,7 @@ export default function Pager({ currentPage, totalPages, onClick, className }) {
 
   return (
     <nav aria-label="Pagination" className={className}>
-      <ul className="flex shrink">
+      <ul className="flex shrink sm:gap-2">
         <li>
           <Button
             type="primary"
@@ -138,7 +138,7 @@ export default function Pager({ currentPage, totalPages, onClick, className }) {
             >
               <button
                 type="button"
-                className={`block w-full text-sm${
+                className={`block w-full px-1 text-sm ${
                   isCurrentPage
                     ? " rounded-md bg-gray-300 dark:bg-gray-600"
                     : ""

--- a/components/report/__tests__/cell-renderers.test.js
+++ b/components/report/__tests__/cell-renderers.test.js
@@ -4,17 +4,21 @@ import profiles from "../../__mocks__/profile";
 import { DataGridContainer } from "../../data-grid";
 import SessionContext from "../../session-context";
 import SortableGrid from "../../sortable-grid";
-import { getSortColumn } from "../../../lib/report";
+import {
+  columnsToColumnSpecs,
+  getSelectedTypes,
+  getSortColumn,
+} from "../../../lib/report";
 import generateColumns from "../generate-columns";
 import ReportHeaderCell from "../header-cell";
 
 describe("Test cell renderers in search results", () => {
   describe("@id, simple array, path, path array cell rendering tests", () => {
     const COLUMN_AT_ID = 0;
-    const COLUMN_NUMBER_ARRAY = 2;
-    const COLUMN_OBJECT_ARRAY = 3;
-    const COLUMN_OFFICE_MANAGER = 4;
-    const COLUMN_PI = 5;
+    const COLUMN_NUMBER_ARRAY = 3;
+    const COLUMN_OBJECT_ARRAY = 4;
+    const COLUMN_OFFICE_MANAGER = 5;
+    const COLUMN_PI = 6;
     const COLUMN_PROPOSED_BY = 8;
     const COLUMN_SIMPLE_ARRAY = 9;
     const COLUMN_STUDIED_BY = 11;
@@ -22,6 +26,7 @@ describe("Test cell renderers in search results", () => {
     const COLUMN_TYPE = 14;
     const COLUMN_URL = 15;
     const COLUMN_VERIFIED_BY = 17;
+    const COLUMN_VIRTUAL = 18;
 
     it("renders the @id, simple array, path array columns", () => {
       const searchResults = {
@@ -64,17 +69,21 @@ describe("Test cell renderers in search results", () => {
               "Predictive Modeling of the Functional and Phenotypic Impacts of Genetic Variants",
             submitted_by: "/users/3787a0ac-f13a-40fc-a524-69628b04cd59/",
             uuid: "fd6a3054-a67b-4246-beb2-d01a49880e79",
+            virtual: true,
           },
         ],
-        "@id": "/report?type=Award",
+        "@id": "/multireport?type=Award",
         "@type": ["Report"],
-        clear_filters: "/report?type=Award",
-        columns: {
+        clear_filters: "/multireport?type=Award",
+        result_columns: {
           "@id": {
             title: "ID",
           },
-          "@type": {
-            title: "Type",
+          component: {
+            title: "Component",
+          },
+          name: {
+            title: "Name",
           },
           number_array: {
             title: "Number Array",
@@ -82,47 +91,47 @@ describe("Test cell renderers in search results", () => {
           object_array: {
             title: "Object Array",
           },
-          simple_array: {
-            title: "Simple Array",
-          },
-          uuid: {
-            title: "UUID",
-          },
-          submitted_by: {
-            title: "Submitted By",
-          },
-          proposed_by: {
-            title: "Proposed By",
-          },
-          verified_by: {
-            title: "Verified By",
-          },
-          title: {
-            title: "Title",
-          },
-          studied_by: {
-            title: "Studied By",
+          om: {
+            title: "Office Manager",
           },
           pis: {
             title: "P.I.",
           },
-          om: {
-            title: "Office Manager",
-          },
-          name: {
-            title: "Name",
-          },
           project: {
             title: "Project",
+          },
+          proposed_by: {
+            title: "Proposed By",
+          },
+          simple_array: {
+            title: "Simple Array",
+          },
+          status: {
+            title: "Status",
+          },
+          studied_by: {
+            title: "Studied By",
+          },
+          submitted_by: {
+            title: "Submitted By",
+          },
+          title: {
+            title: "Title",
+          },
+          "@type": {
+            title: "Type",
           },
           url: {
             title: "URL",
           },
-          component: {
-            title: "Component",
+          uuid: {
+            title: "UUID",
           },
-          status: {
-            title: "Status",
+          verified_by: {
+            title: "Verified By",
+          },
+          virtual: {
+            title: "Virtual",
           },
         },
         facet_groups: [],
@@ -130,7 +139,7 @@ describe("Test cell renderers in search results", () => {
           {
             field: "type",
             term: "Award",
-            remove: "/report",
+            remove: "/multireport",
           },
         ],
         non_sortable: ["pipeline_error_detail", "description", "notes"],
@@ -141,7 +150,15 @@ describe("Test cell renderers in search results", () => {
 
       const onHeaderCellClick = jest.fn();
       const sortedColumnId = getSortColumn(searchResults);
-      const columns = generateColumns(searchResults, profiles);
+      const selectedTypes = getSelectedTypes(searchResults);
+      const visibleColumnSpecs = columnsToColumnSpecs(
+        searchResults.result_columns
+      );
+      const columns = generateColumns(
+        selectedTypes,
+        visibleColumnSpecs,
+        profiles.Award.properties
+      );
       render(
         <SessionContext.Provider value={{ profiles }}>
           <DataGridContainer>
@@ -236,6 +253,9 @@ describe("Test cell renderers in search results", () => {
       expect(studiedByLinks[1]).toHaveTextContent(
         "/users/a8390b04-ec45-41bf-b168-7f07d4d15262/"
       );
+
+      // Check boolean properties render as "true" or "false".
+      expect(cells[COLUMN_VIRTUAL]).toHaveTextContent("true");
     });
   });
 });
@@ -246,7 +266,7 @@ describe("Boolean cell-rendering tests", () => {
     const COLUMN_COUNT = 3;
 
     const searchResults = {
-      "@id": "/report?type=WholeOrganism",
+      "@id": "/multireport?type=WholeOrganism",
       "@type": ["Report"],
       "@graph": [
         {
@@ -267,7 +287,7 @@ describe("Boolean cell-rendering tests", () => {
           accession: "IGVFSM001KAS",
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
         },
@@ -282,14 +302,22 @@ describe("Boolean cell-rendering tests", () => {
         {
           field: "type",
           term: "WholeOrganism",
-          remove: "/report",
+          remove: "/multireport",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.WholeOrganism.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -334,7 +362,7 @@ describe("`attachment` cell rendering tests", () => {
 
   it("renders the attachment columns", () => {
     const searchResults = {
-      "@id": "/report?type=Document",
+      "@id": "/multireport?type=Document",
       "@type": ["Report"],
       "@graph": [
         {
@@ -348,7 +376,7 @@ describe("`attachment` cell rendering tests", () => {
           },
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
         },
@@ -360,14 +388,22 @@ describe("`attachment` cell rendering tests", () => {
         {
           field: "type",
           term: "Document",
-          remove: "/report",
+          remove: "/multireport",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.Document.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -395,7 +431,7 @@ describe("`attachment` cell rendering tests", () => {
 
   it("doesn't render missing `attachment` columns", () => {
     const searchResults = {
-      "@id": "/report?type=Document",
+      "@id": "/multireport?type=Document",
       "@type": ["Report"],
       "@graph": [
         {
@@ -403,7 +439,7 @@ describe("`attachment` cell rendering tests", () => {
           "@type": ["Document", "Item"],
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
         },
@@ -415,14 +451,22 @@ describe("`attachment` cell rendering tests", () => {
         {
           field: "type",
           term: "Document",
-          remove: "/report",
+          remove: "/multireport",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.Document.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -452,7 +496,7 @@ describe("`external_resources` cell-rendering tests", () => {
 
   it("renders `external_resources` with a link", () => {
     const searchResults = {
-      "@id": "/report?type=HumanDonor",
+      "@id": "/multireport?type=HumanDonor",
       "@type": ["Report"],
       "@graph": [
         {
@@ -468,7 +512,7 @@ describe("`external_resources` cell-rendering tests", () => {
           ],
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
         },
@@ -480,14 +524,22 @@ describe("`external_resources` cell-rendering tests", () => {
         {
           field: "type",
           term: "HumanDonor",
-          remove: "/report",
+          remove: "/multireport",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.HumanDonor.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -517,7 +569,7 @@ describe("`external_resources` cell-rendering tests", () => {
 
   it("renders `external_resources` without a link", () => {
     const searchResults = {
-      "@id": "/report?type=HumanDonor",
+      "@id": "/multireport?type=HumanDonor",
       "@type": ["Report"],
       "@graph": [
         {
@@ -532,7 +584,7 @@ describe("`external_resources` cell-rendering tests", () => {
           ],
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
         },
@@ -544,14 +596,22 @@ describe("`external_resources` cell-rendering tests", () => {
         {
           field: "type",
           term: "HumanDonor",
-          remove: "/report",
+          remove: "/multireport",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.HumanDonor.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -581,7 +641,7 @@ describe("`external_resources` cell-rendering tests", () => {
 
   it("renders nothing when `external_resources` has an empty array", () => {
     const searchResults = {
-      "@id": "/report?type=HumanDonor",
+      "@id": "/multireport?type=HumanDonor",
       "@type": ["Report"],
       "@graph": [
         {
@@ -590,7 +650,7 @@ describe("`external_resources` cell-rendering tests", () => {
           external_resources: [],
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
         },
@@ -602,14 +662,22 @@ describe("`external_resources` cell-rendering tests", () => {
         {
           field: "type",
           term: "HumanDonor",
-          remove: "/report",
+          remove: "/multireport",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.HumanDonor.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -636,7 +704,7 @@ describe("`external_resources` cell-rendering tests", () => {
 
   it("renders nothing when `external_resources` doesn't exist", () => {
     const searchResults = {
-      "@id": "/report?type=HumanDonor",
+      "@id": "/multireport?type=HumanDonor",
       "@type": ["Report"],
       "@graph": [
         {
@@ -645,7 +713,7 @@ describe("`external_resources` cell-rendering tests", () => {
           external_resources: [],
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
         },
@@ -657,14 +725,22 @@ describe("`external_resources` cell-rendering tests", () => {
         {
           field: "type",
           term: "HumanDonor",
-          remove: "/report",
+          remove: "/multireport",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.HumanDonor.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -696,7 +772,7 @@ describe("Gene `locations` cell-rendering tests", () => {
 
   it("shows `locations` as chromosome coordinate strings", () => {
     const searchResults = {
-      "@id": "/report?type=Gene",
+      "@id": "/multireport?type=Gene",
       "@type": ["Report"],
       "@graph": [
         {
@@ -719,7 +795,7 @@ describe("Gene `locations` cell-rendering tests", () => {
           start: 50282343,
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
         },
@@ -734,14 +810,22 @@ describe("Gene `locations` cell-rendering tests", () => {
         {
           field: "type",
           term: "Gene",
-          remove: "/report",
+          remove: "/multireport",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.Gene.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -777,7 +861,7 @@ describe("Gene `locations` cell-rendering tests", () => {
 
   it("shows nothing when `location` has an empty array", () => {
     const searchResults = {
-      "@id": "/report?type=Gene",
+      "@id": "/multireport?type=Gene",
       "@type": ["Report"],
       "@graph": [
         {
@@ -787,7 +871,7 @@ describe("Gene `locations` cell-rendering tests", () => {
           start: 50282343,
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
         },
@@ -802,14 +886,22 @@ describe("Gene `locations` cell-rendering tests", () => {
         {
           field: "type",
           term: "Gene",
-          remove: "/report",
+          remove: "/multireport",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.Gene.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -842,7 +934,7 @@ describe("Page cell-rendering tests", () => {
 
   it("renders a link for the page's parent and JSON for layout", () => {
     const searchResults = {
-      "@id": "/report?type=Page",
+      "@id": "/multireport?type=Page",
       "@type": ["Report"],
       "@graph": [
         {
@@ -861,7 +953,7 @@ describe("Page cell-rendering tests", () => {
           },
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
         },
@@ -876,14 +968,22 @@ describe("Page cell-rendering tests", () => {
         {
           field: "type",
           term: "Page",
-          remove: "/report",
+          remove: "/multireport",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.Page.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -918,7 +1018,7 @@ describe("Page cell-rendering tests", () => {
 
   it("renders nothing for `parent` when page's parent doesn't exist", () => {
     const searchResults = {
-      "@id": "/report?type=Page",
+      "@id": "/multireport?type=Page",
       "@type": ["Report"],
       "@graph": [
         {
@@ -926,7 +1026,7 @@ describe("Page cell-rendering tests", () => {
           "@type": ["Page", "Item"],
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
         },
@@ -941,14 +1041,22 @@ describe("Page cell-rendering tests", () => {
         {
           field: "type",
           term: "Page",
-          remove: "/report",
+          remove: "/multireport",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.Page.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -978,33 +1086,100 @@ describe("Unknown-field cell-rendering tests", () => {
     const COLUMN_UNKNOWN = 1;
 
     const searchResults = {
-      "@id": "/report?type=HumanDonor&field=%40id&field=unknown_field",
+      "@id": "/multireport?type=HumanDonor&field=%40id&field=sex",
       "@type": ["Report"],
       "@graph": [
         {
           "@id": "/human-donors/IGVFDO499FAP/",
           "@type": ["HumanDonor", "Item"],
-          unknown_field: "Unknown value",
+          sex: "female",
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
+        },
+        sex: {
+          title: "Sex",
         },
       },
       filters: [
         {
           field: "type",
           term: "HumanDonor",
-          remove: "/report",
+          remove: "/multireport",
         },
       ],
     };
 
+    const properties = {
+      "@id": {
+        title: "ID",
+        type: "string",
+      },
+      "@type": {
+        items: {
+          type: "string",
+        },
+        title: "Type",
+        type: "array",
+      },
+      accession: {
+        title: "Accession",
+        type: "string",
+      },
+      ethnicities: {
+        items: {
+          enum: [
+            "African American",
+            "African Caribbean",
+            "Arab",
+            "Asian",
+            "Black",
+            "Black African",
+            "Chinese",
+            "Colombian",
+            "Dai Chinese",
+            "Esan",
+            "Eskimo",
+            "European",
+            "Gambian",
+            "Han Chinese",
+            "Hispanic",
+            "Indian",
+            "Japanese",
+            "Kinh Vietnamese",
+            "Luhya",
+            "Maasai",
+            "Mende",
+            "Native Hawaiian",
+            "Pacific Islander",
+            "Puerto Rican",
+            "Yoruba",
+          ],
+          type: "string",
+        },
+        title: "Ethnicity",
+        type: "array",
+      },
+      sex: {
+        enum: ["male", "female", "unspecified"],
+        title: "Sex",
+        type: "string",
+      },
+    };
+
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -1025,49 +1200,59 @@ describe("Unknown-field cell-rendering tests", () => {
     const cells = screen.getAllByRole("cell");
 
     // Test that the unknown field has the correct contents.
-    expect(cells[COLUMN_UNKNOWN]).toHaveTextContent("Unknown value");
+    expect(cells[COLUMN_UNKNOWN]).toHaveTextContent("female");
   });
 
   it("renders an unknown field containing an array of objects with @ids", () => {
     const COLUMN_UNKNOWN = 1;
 
     const searchResults = {
-      "@id": "/report?type=HumanDonor&field=%40id&field=unknown_field",
+      "@id": "/multireport?type=InVitroSystem&field=%40id&field=sample_terms",
       "@type": ["Report"],
       "@graph": [
         {
-          "@id": "/human-donors/IGVFDO1080XFGV/",
-          "@type": ["HumanDonor", "Item"],
-          unknown_field: [
+          "@id": "/in-vitro-systems/IGVFSM0000AAAZ/",
+          "@type": ["InVitroSystem", "Item"],
+          sample_terms: [
             {
-              "@id": "/human-donors/IGVFDO8315PGTI/",
-              "@type": ["HumanDonor", "Item"],
+              "@id": "/sample-terms/CL_0011001/",
+              term_name: "motor neuron",
             },
             {
-              "@id": "/human-donors/IGVFDO9208RPQQ/",
-              "@type": ["HumanDonor", "Item"],
+              "@id": "/sample-terms/EFO_0007093/",
+              term_name: "HUES8",
             },
           ],
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
+        },
+        sample_terms: {
+          title: "Sample Terms",
         },
       },
       filters: [
         {
           field: "type",
-          term: "HumanDonor",
-          remove: "/report",
+          term: "InVitroSystem",
+          remove: "/multireport/?field=%40id&field=sample_terms",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.InVitroSystem.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -1087,43 +1272,54 @@ describe("Unknown-field cell-rendering tests", () => {
     );
     const cells = screen.getAllByRole("cell");
 
-    // Test that the unknown field has the correct contents.
-    expect(cells[COLUMN_UNKNOWN]).toHaveTextContent(
-      "/human-donors/IGVFDO8315PGTI/, /human-donors/IGVFDO9208RPQQ/"
-    );
+    // Test that the unknown field has two links.
+    const unknownLinks = within(cells[COLUMN_UNKNOWN]).getAllByRole("link");
+    expect(unknownLinks).toHaveLength(2);
+    expect(unknownLinks[0]).toHaveTextContent("/sample-terms/CL_0011001/");
+    expect(unknownLinks[1]).toHaveTextContent("/sample-terms/EFO_0007093/");
   });
 
   it("renders an unknown field containing an array simple objects", () => {
     const COLUMN_UNKNOWN = 1;
 
     const searchResults = {
-      "@id": "/report?type=HumanDonor&field=%40id&field=unknown_field",
+      "@id": "/multireport?type=HumanDonor&field=%40id&field=ethnicities",
       "@type": ["Report"],
       "@graph": [
         {
           "@id": "/human-donors/IGVFDO1080XFGV/",
           "@type": ["HumanDonor", "Item"],
-          unknown_field: ["IGVFDO8315PGTI", "IGVFDO9208RPQQ"],
+          ethnicities: ["Eskimo", "Arab"],
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
+        },
+        ethnicities: {
+          title: "Ethnicities",
         },
       },
       filters: [
         {
           field: "type",
           term: "HumanDonor",
-          remove: "/report",
+          remove: "/multireport/?field=%40id&field=ethnicities",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.HumanDonor.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -1144,45 +1340,53 @@ describe("Unknown-field cell-rendering tests", () => {
     const cells = screen.getAllByRole("cell");
 
     // Test that the unknown field has the correct contents.
-    expect(cells[COLUMN_UNKNOWN]).toHaveTextContent(
-      "IGVFDO8315PGTI, IGVFDO9208RPQQ"
-    );
+    expect(cells[COLUMN_UNKNOWN]).toHaveTextContent("Arab, Eskimo");
   });
 
   it("renders an unknown field containing an object with an @id", () => {
     const COLUMN_UNKNOWN = 1;
 
     const searchResults = {
-      "@id": "/report?type=HumanDonor&field=%40id&field=unknown_field",
+      "@id": "/multireport/?type=InVitroSystem&field=%40id&field=lab",
       "@type": ["Report"],
       "@graph": [
         {
           "@id": "/human-donors/IGVFDO1080XFGV/",
           "@type": ["HumanDonor", "Item"],
-          unknown_field: {
-            "@id": "/human-donors/IGVFDO8315PGTI/",
-            "@type": ["HumanDonor", "Item"],
+          lab: {
+            "@id": "/labs/j-michael-cherry/",
+            title: "J. Michael Cherry, Stanford",
           },
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
+        },
+        lab: {
+          title: "Lab",
         },
       },
       filters: [
         {
           field: "type",
-          term: "HumanDonor",
-          remove: "/report",
+          term: "InVitroSystem",
+          remove: "/multireport/?field=%40id&field=lab",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.HumanDonor.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -1202,46 +1406,62 @@ describe("Unknown-field cell-rendering tests", () => {
     );
     const cells = screen.getAllByRole("cell");
 
-    // Test that the unknown field has the correct contents.
-    expect(cells[COLUMN_UNKNOWN]).toHaveTextContent(
-      "/human-donors/IGVFDO8315PGTI/"
-    );
+    // Test that the unknown field is a link with the correct path.
+    const unknownLink = within(cells[COLUMN_UNKNOWN]).getByRole("link");
+    expect(unknownLink).toHaveAttribute("href", "/labs/j-michael-cherry");
+    expect(unknownLink).toHaveTextContent("/labs/j-michael-cherry");
   });
 
   it("renders an unknown field containing an object with no @id", () => {
     const COLUMN_UNKNOWN = 1;
 
     const searchResults = {
-      "@id": "/report?type=HumanDonor&field=%40id&field=unknown_field",
+      "@id": "/multireport/?type=Page&field=%40id&field=layout",
       "@type": ["Report"],
       "@graph": [
         {
-          "@id": "/human-donors/IGVFDO1080XFGV/",
-          "@type": ["HumanDonor", "Item"],
-          unknown_field: {
-            prop0: "value0",
-            prop1: "value1",
+          "@id": "/help/donors/",
+          "@type": ["Page", "Item"],
+          layout: {
+            blocks: [
+              {
+                "@id": "#block1",
+                "@type": "markdown",
+                body: "# Donor Help",
+                direction: "ltr",
+              },
+            ],
           },
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
+        },
+        layout: {
+          title: "Page Layout",
         },
       },
       filters: [
         {
           field: "type",
-          term: "HumanDonor",
-          remove: "/report",
+          term: "Page",
+          remove: "/multireport/?field=%40id&field=layout",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.HumanDonor.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -1263,7 +1483,7 @@ describe("Unknown-field cell-rendering tests", () => {
 
     // Test that the unknown field has the correct contents.
     expect(cells[COLUMN_UNKNOWN]).toHaveTextContent(
-      `{"prop0":"value0","prop1":"value1"}`
+      `{"blocks":[{"@id":"#block1","@type":"markdown","body":"# Donor Help","direction":"ltr"}]}`
     );
   });
 
@@ -1271,43 +1491,50 @@ describe("Unknown-field cell-rendering tests", () => {
     const COLUMN_UNKNOWN = 1;
 
     const searchResults = {
-      "@id":
-        "/report?type=InVitroSystem&field=%40id&field=introduced_factors.purpose",
+      "@id": "/multireport/?type=ConstructLibrarySet&field=%40id&field=loci",
       "@type": ["Report"],
       "@graph": [
         {
-          "@id": "/in-vitro-system/IGVFSM0000AAAZ/",
-          "@type": ["InVitroSystem", "Biosample", "Sample", "Item"],
-          introduced_factors: [
+          "@id": "/construct-library-sets/IGVFDS0941AYWH/",
+          "@type": ["ConstructLibrarySet", "FileSet", "Item"],
+          loci: [
             {
-              purpose: "selection",
-              "@id": "/treatments/10c05ac0-52a2-11e6-bdf4-0800200c9a66/",
-            },
-            {
-              purpose: "differentiation",
-              "@id": "/treatments/bd2cb34e-c72c-11ec-9d64-0242ac120002/",
+              assembly: "GRCh38",
+              chromosome: "chr1",
+              end: 10,
+              start: 1,
             },
           ],
         },
       ],
-      columns: {
+      result_columns: {
         "@id": {
           title: "ID",
+        },
+        loci: {
+          title: "Loci",
         },
       },
       filters: [
         {
           field: "type",
-          term: "InVitroSystem",
-          remove: "/report",
+          term: "ConstructLibrarySet",
+          remove: "/multireport/?field=%40id&field=loci",
         },
       ],
     };
 
     const onHeaderCellClick = jest.fn();
     const sortedColumnId = getSortColumn(searchResults);
-
-    const columns = generateColumns(searchResults, profiles);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.InVitroSystem.properties
+    );
     render(
       <SessionContext.Provider value={{ profiles }}>
         <DataGridContainer>
@@ -1329,7 +1556,7 @@ describe("Unknown-field cell-rendering tests", () => {
 
     // Test that the unknown field has the correct contents.
     expect(cells[COLUMN_UNKNOWN]).toHaveTextContent(
-      "selection, differentiation"
+      `[{"assembly":"GRCh38","chromosome":"chr1","end":10,"start":1}]`
     );
   });
 });

--- a/components/report/__tests__/cell-renderers.test.js
+++ b/components/report/__tests__/cell-renderers.test.js
@@ -1559,4 +1559,141 @@ describe("Unknown-field cell-rendering tests", () => {
       `[{"assembly":"GRCh38","chromosome":"chr1","end":10,"start":1}]`
     );
   });
+
+  it("renders an unknown embedded field contained within an array of objects", () => {
+    const COLUMN_UNKNOWN = 1;
+
+    const searchResults = {
+      "@context": "/terms/",
+      "@graph": [
+        {
+          "@id": "/in-vitro-systems/IGVFSM0000AAAZ/",
+          "@type": ["InVitroSystem", "Biosample", "Sample", "Item"],
+          sample_terms: [
+            {
+              term_name: "motor neuron",
+            },
+          ],
+        },
+      ],
+      "@id":
+        "/multireport/?type=InVitroSystem&sample_terms.term_name=motor+neuron&field=%40id&field=sample_terms.term_name",
+      "@type": ["Report"],
+      clear_filters: "/multireport/?type=InVitroSystem",
+      columns: {
+        "@id": {
+          title: "ID",
+        },
+        accession: {
+          title: "Accession",
+        },
+        award: {
+          title: "Award",
+        },
+        classification: {
+          title: "Classification",
+        },
+        lab: {
+          title: "Lab",
+        },
+        sample_terms: {
+          title: "Sample Terms",
+        },
+        status: {
+          title: "Status",
+        },
+      },
+      facets: [
+        {
+          appended: false,
+          field: "sample_terms.term_name",
+          open_on_load: false,
+          terms: [
+            {
+              doc_count: 3,
+              key: "motor neuron",
+            },
+            {
+              doc_count: 1,
+              key: "HUES8",
+            },
+          ],
+          title: "Sample Terms",
+          total: 4,
+          type: "terms",
+        },
+      ],
+      filters: [
+        {
+          field: "sample_terms.term_name",
+          remove:
+            "/multireport/?type=InVitroSystem&field=%40id&field=sample_terms.term_name",
+          term: "motor neuron",
+        },
+        {
+          field: "type",
+          remove:
+            "/multireport/?sample_terms.term_name=motor+neuron&field=%40id&field=sample_terms.term_name",
+          term: "InVitroSystem",
+        },
+      ],
+      notification: "Success",
+      result_columns: {
+        "@id": {
+          title: "ID",
+        },
+        "sample_terms.term_name": {
+          title: "sample_terms.term_name",
+        },
+      },
+      sort: {
+        date_created: {
+          order: "desc",
+          unmapped_type: "keyword",
+        },
+        label: {
+          order: "desc",
+          unmapped_type: "keyword",
+        },
+        uuid: {
+          order: "desc",
+          unmapped_type: "keyword",
+        },
+      },
+      title: "Report",
+      total: 3,
+    };
+
+    const onHeaderCellClick = jest.fn();
+    const sortedColumnId = getSortColumn(searchResults);
+    const selectedTypes = getSelectedTypes(searchResults);
+    const visibleColumnSpecs = columnsToColumnSpecs(
+      searchResults.result_columns
+    );
+    const columns = generateColumns(
+      selectedTypes,
+      visibleColumnSpecs,
+      profiles.InVitroSystem.properties
+    );
+    render(
+      <SessionContext.Provider value={{ profiles }}>
+        <DataGridContainer>
+          <SortableGrid
+            data={searchResults["@graph"]}
+            columns={columns}
+            initialSort={{ isSortingSuppressed: true }}
+            meta={{
+              onHeaderCellClick,
+              sortedColumnId,
+              nonSortableColumnIds: searchResults.non_sortable || [],
+            }}
+            CustomHeaderCell={ReportHeaderCell}
+          />
+        </DataGridContainer>
+      </SessionContext.Provider>
+    );
+    const cells = screen.getAllByRole("cell");
+
+    expect(cells[COLUMN_UNKNOWN]).toHaveTextContent("motor neuron");
+  });
 });

--- a/components/report/cell-renderers.js
+++ b/components/report/cell-renderers.js
@@ -300,7 +300,14 @@ function UnknownObject({ id, source }) {
   const components = id.split(".");
   let property = source;
   for (let i = 0; i < components.length; i += 1) {
-    property = property[components[i]];
+    if (Array.isArray(property)) {
+      // Extract the specified property component from each element of the array.
+      const embeddedProperties = property.map((item) => item[components[i]]);
+      property = embeddedProperties.filter((item) => item).join(", ");
+    } else {
+      // Extract the specified property component from the embedded property.
+      property = property[components[i]];
+    }
     if (!property) {
       // A component of the dotted-notation property doesn't exist in the source object, so end
       // the loop early, and display nothing in the cell.

--- a/components/search-results/download-tsv.js
+++ b/components/search-results/download-tsv.js
@@ -7,7 +7,7 @@ import { API_URL } from "../../lib/constants";
 
 export default function DownloadTSV() {
   const currentQuery = window.location.search;
-  const link = new URL(`${API_URL}/report.tsv${currentQuery}`).toString();
+  const link = new URL(`${API_URL}/multireport.tsv${currentQuery}`).toString();
   return (
     <ButtonLink href={link} hasIconOnly={true} label="Download report as TSV">
       <DocumentArrowDownIcon strokeWidth={2} />

--- a/components/search-results/header.js
+++ b/components/search-results/header.js
@@ -1,12 +1,10 @@
 // node_modules
 import PropTypes from "prop-types";
 // components
+import DownloadTSV from "./download-tsv";
 import ItemsPerPageSelector from "./items-per-page-selector";
 import { ColumnSelector } from "../report";
-import useSearchLimits from "./search-limits";
-import SearchPager from "./search-pager";
 import ViewSwitch from "./view-switch";
-import DownloadTSV from "./download-tsv";
 
 /**
  * Displays controls for the search-result list and report views, including the controls to switch
@@ -14,44 +12,48 @@ import DownloadTSV from "./download-tsv";
  */
 export default function SearchResultsHeader({
   searchResults,
-  columnSelectorConfig = null,
+  reportViewExtras = null,
 }) {
-  const { totalPages } = useSearchLimits(searchResults);
-
   return (
-    <>
-      <div className="sm:mb-1 sm:flex sm:items-center sm:justify-between">
-        <div className="mb-1 flex gap-1 sm:mb-0">
-          <ViewSwitch searchResults={searchResults} />
-          {columnSelectorConfig && (
-            <>
+    <div className="relative z-10 w-full @container">
+      <div className="@md:flex @md:items-center @md:justify-between">
+        <div className="flex gap-1">
+          <div className="mb-1 flex gap-1">
+            <ViewSwitch searchResults={searchResults} />
+          </div>
+          {reportViewExtras && (
+            <div className="mb-1 flex gap-1">
               <ColumnSelector
-                searchResults={searchResults}
-                onChange={columnSelectorConfig.onColumnVisibilityChange}
-                onChangeAll={columnSelectorConfig.onAllColumnsVisibilityChange}
+                allColumnSpecs={reportViewExtras.allColumnSpecs}
+                visibleColumnSpecs={reportViewExtras.visibleColumnSpecs}
+                onChange={reportViewExtras.onColumnVisibilityChange}
+                onChangeAll={reportViewExtras.onAllColumnsVisibilityChange}
               />
               <DownloadTSV />
-            </>
+            </div>
           )}
         </div>
 
-        <div className="mb-1 flex items-center gap-1 sm:mb-0">
-          <ItemsPerPageSelector />
+        <div className="mb-1">
+          <ItemsPerPageSelector searchResults={searchResults} />
         </div>
       </div>
-      <div className="mb-1">
-        {totalPages > 1 && <SearchPager searchResults={searchResults} />}
-      </div>
-    </>
+    </div>
   );
 }
 
 SearchResultsHeader.propTypes = {
   // Search results for list or report
   searchResults: PropTypes.object.isRequired,
-  // True to display the report column selector
-  columnSelectorConfig: PropTypes.shape({
+  // Callback functions for when the search header is for the report view; null for the list view
+  reportViewExtras: PropTypes.exact({
+    // All column specs for the current report page
+    allColumnSpecs: PropTypes.arrayOf(PropTypes.object).isRequired,
+    // Visible column specs for the current report page
+    visibleColumnSpecs: PropTypes.arrayOf(PropTypes.object).isRequired,
+    // Callback when the user changes the visibility of a column
     onColumnVisibilityChange: PropTypes.func.isRequired,
+    // Callback when the user changes the visibility of all columns
     onAllColumnsVisibilityChange: PropTypes.func.isRequired,
   }),
 };

--- a/components/search-results/index.js
+++ b/components/search-results/index.js
@@ -5,5 +5,12 @@
 // components/search-results
 import SearchResultsCount from "./count";
 import SearchResultsHeader from "./header";
+import useSearchLimits from "./search-limits";
+import SearchPager from "./search-pager";
 
-export { SearchResultsCount, SearchResultsHeader };
+export {
+  SearchPager,
+  SearchResultsCount,
+  SearchResultsHeader,
+  useSearchLimits,
+};

--- a/components/search-results/items-per-page-selector.js
+++ b/components/search-results/items-per-page-selector.js
@@ -1,5 +1,6 @@
 // node_modules
 import { useRouter } from "next/router";
+import PropTypes from "prop-types";
 // components
 import { Select } from "../form-elements";
 // components/search
@@ -31,7 +32,10 @@ const itemsPerPageOptions = [25, 100, 300];
  * the dropdown, their manually set value disappears from the dropdown, leaving only the options in
  * `itemsPerPageOptions`.
  */
-export default function ItemsPerPageSelector(searchResults) {
+export default function ItemsPerPageSelector({
+  searchResults,
+  className = null,
+}) {
   const router = useRouter();
   const { itemsPerPage } = useSearchLimits(searchResults);
 
@@ -61,17 +65,26 @@ export default function ItemsPerPageSelector(searchResults) {
     : [itemsPerPage, ...itemsPerPageOptions];
 
   return (
-    <Select
-      name="items-per-page"
-      className="flex grow gap-1 [&>div]:w-full"
-      value={itemsPerPage}
-      onChange={onChangeItemsPerPage}
-    >
-      {options.map((option) => (
-        <option key={option} value={option}>
-          {`${option} Items`}
-        </option>
-      ))}
-    </Select>
+    <div className={className}>
+      <Select
+        name="items-per-page"
+        className="flex grow gap-1 [&>div]:w-full"
+        value={itemsPerPage}
+        onChange={onChangeItemsPerPage}
+      >
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {`${option} Items`}
+          </option>
+        ))}
+      </Select>
+    </div>
   );
 }
+
+ItemsPerPageSelector.propTypes = {
+  // The search results object the items-per-page selector is for
+  searchResults: PropTypes.object.isRequired,
+  // CSS class names to apply to the root element of the component
+  className: PropTypes.string,
+};

--- a/components/search-results/search-pager.js
+++ b/components/search-results/search-pager.js
@@ -39,12 +39,11 @@ export default function SearchPager({ searchResults }) {
   return (
     <>
       {totalPages > 1 && (
-        <div className="search-pager">
+        <div className="flex justify-center border-l border-r border-panel bg-gray-100 py-0.5 dark:bg-gray-900">
           <Pager
             currentPage={pageIndex}
             totalPages={totalPages}
             onClick={onPagerClick}
-            className="mb-2 flex justify-center sm:mb-0 sm:justify-end"
           />
         </div>
       )}

--- a/components/search-results/view-switch.js
+++ b/components/search-results/view-switch.js
@@ -16,7 +16,7 @@ const SEARCH_TYPE_REPORT = "Report";
 /**
  * Display the buttons to view the collection as a table or list.
  */
-export default function ViewSwitch({ searchResults }) {
+export default function ViewSwitch({ searchResults, className = null }) {
   // Determine whether the list or report view is selected
   const isListSelected = searchResults["@type"][0] === SEARCH_TYPE_LIST;
   const isReportSelected = searchResults["@type"][0] === SEARCH_TYPE_REPORT;
@@ -29,7 +29,7 @@ export default function ViewSwitch({ searchResults }) {
     const { path, queryString } = splitPathAndQueryString(searchResults["@id"]);
     const query = new QueryString(queryString);
     const types = query.getKeyValues("type", QueryString.ANY);
-    const reportPath = path.replace(/\/search(\/){0,1}/, "/report$1");
+    const reportPath = path.replace(/\/search(\/){0,1}/, "/multireport$1");
 
     // Report view query string always copies the list view query string unless it has multiple or
     // no "type=" query string parameters, in which case no Report view button appears.
@@ -43,14 +43,15 @@ export default function ViewSwitch({ searchResults }) {
     const query = new QueryString(queryString);
     query.deleteKeyValue("field");
     query.deleteKeyValue("sort");
-    const listPath = path.replace(/\/report(\/){0,1}/, "/search$1");
+    query.deleteKeyValue("config");
+    const listPath = path.replace(/\/multireport(\/){0,1}/, "/search$1");
 
     listViewLink = `${listPath}?${query.format()}`;
     reportViewLink = searchResults["@id"];
   }
 
   return (
-    <AttachedButtons testid="search-results-view-switch">
+    <AttachedButtons className={className} testid="search-results-view-switch">
       <ButtonLink
         href={listViewLink}
         type={isListSelected ? "selected" : "secondary"}
@@ -74,4 +75,6 @@ export default function ViewSwitch({ searchResults }) {
 ViewSwitch.propTypes = {
   // The current list or report search results from igvfd
   searchResults: PropTypes.object.isRequired,
+  // Tailwind CSS classes for the button
+  className: PropTypes.string,
 };

--- a/components/search-results/view-switch.js
+++ b/components/search-results/view-switch.js
@@ -28,14 +28,12 @@ export default function ViewSwitch({ searchResults, className = null }) {
     // display a report-view link if exactly one "type=" exists in the query string.
     const { path, queryString } = splitPathAndQueryString(searchResults["@id"]);
     const query = new QueryString(queryString);
-    const types = query.getKeyValues("type", QueryString.ANY);
     const reportPath = path.replace(/\/search(\/){0,1}/, "/multireport$1");
 
     // Report view query string always copies the list view query string unless it has multiple or
     // no "type=" query string parameters, in which case no Report view button appears.
     listViewLink = searchResults["@id"];
-    reportViewLink =
-      types.length === 1 ? `${reportPath}?${query.format()}` : "";
+    reportViewLink = `${reportPath}?${query.format()}`;
   } else {
     // Compose links for the list and report views if the current view is the report view. Remove
     // any "field=" query string parameters from the list-view link.

--- a/cypress/e2e/site-id-search.cy.js
+++ b/cypress/e2e/site-id-search.cy.js
@@ -35,7 +35,10 @@ describe("Test site search", () => {
 
         // Click the list button and make sure it takes us to the list page.
         cy.get(`[aria-label^="View search report for"]`).click();
-        cy.url().should("match", /\/report\/\?type=[a-zA-Z0-9]+&query=cherry$/);
+        cy.url().should(
+          "match",
+          /\/multireport\/\?type=[a-zA-Z0-9]+&query=cherry$/
+        );
       });
   });
 

--- a/lib/__tests__/report.test.js
+++ b/lib/__tests__/report.test.js
@@ -1,11 +1,10 @@
 import {
-  getManuallyEnteredColumnIds,
-  getReportType,
+  getMergedSchemaProperties,
   getReportTypeColumnSpecs,
-  getSchemaForReportType,
+  getSchemasForReportTypes,
+  getSelectedTypes,
   getSortColumn,
-  getVisibleReportColumnSpecs,
-  schemaColumnsToColumnSpecs,
+  columnsToColumnSpecs,
 } from "../report";
 
 const profiles = {
@@ -31,8 +30,25 @@ const profiles = {
       uuid: {},
     },
   },
-  Biosample: {
-    title: "Biosample",
+  Lab: {
+    title: "Lab",
+    properties: {
+      "@id": {
+        title: "ID",
+        type: "string",
+      },
+      uuid: {
+        title: "UUID",
+        type: "string",
+      },
+      name: {
+        title: "Name",
+        type: "string",
+      },
+    },
+  },
+  Tissue: {
+    title: "Tissue",
     properties: {
       "@id": {
         title: "ID",
@@ -48,24 +64,54 @@ const profiles = {
       },
     },
   },
+  _subtypes: {
+    Biosample: ["Tissue"],
+  },
 };
 
-describe("Test `getSchemaForReportType()`", () => {
-  it("should return the correct schema for a report type", () => {
-    const schema = getSchemaForReportType("Biosample", profiles);
-    expect(schema).toEqual(profiles.Biosample);
+describe("Test `getSchemasForReportTypes()`", () => {
+  it("should return the correct schema for a concrete report type", () => {
+    const schemas = getSchemasForReportTypes(["Award"], profiles);
+    expect(schemas).toHaveLength(1);
+    expect(schemas[0].title).toEqual("Grant");
   });
 
-  it("should return null for unknown report types", () => {
-    const schema = getSchemaForReportType("Unknown", profiles);
-    expect(schema).toBeNull();
+  it("should return the correct schema for an abstract report type", () => {
+    const schemas = getSchemasForReportTypes(["Biosample"], profiles);
+    expect(schemas).toHaveLength(1);
+    expect(schemas[0].title).toEqual("Tissue");
+  });
+
+  it("should return the correct schemas for multiple concrete report types", () => {
+    const schemas = getSchemasForReportTypes(["Award", "Lab"], profiles);
+    expect(schemas).toHaveLength(2);
+    expect(schemas[0].title).toEqual("Grant");
+    expect(schemas[1].title).toEqual("Lab");
+  });
+
+  it("should return the correct schemas for abstract and concrete report types", () => {
+    const schemas = getSchemasForReportTypes(["Award", "Biosample"], profiles);
+    expect(schemas).toHaveLength(2);
+    expect(schemas[0].title).toEqual("Grant");
+    expect(schemas[1].title).toEqual("Tissue");
+  });
+
+  it("should return an empty array for unknown report types", () => {
+    const schemas = getSchemasForReportTypes(["Unknown"], profiles);
+    expect(schemas).toHaveLength(0);
+  });
+
+  it("should return null if profiles hasn't yet loaded", () => {
+    const schemas = getSchemasForReportTypes(["Award"], null);
+    expect(schemas).toBeNull();
   });
 });
 
-describe("Test `getReportType()`", () => {
+describe("Test `getSelectedTypes()`", () => {
   it("should return the correct report type for a report including a type filter", () => {
     const searchResults = {
       "@context": "/terms/",
+      "@id": "/multireport/?type=PrimaryCell",
       "@graph": [
         {
           "@id": "/primary-cells/IGVFSM0000EEEE/",
@@ -78,13 +124,77 @@ describe("Test `getReportType()`", () => {
         {
           field: "type",
           term: "PrimaryCell",
-          remove: "/report",
+          remove: "/multireport",
         },
       ],
     };
 
-    const reportType = getReportType(searchResults);
-    expect(reportType).toEqual("PrimaryCell");
+    const types = getSelectedTypes(searchResults);
+    expect(types).toHaveLength(1);
+    expect(types[0]).toEqual("PrimaryCell");
+  });
+
+  it("should return the correct report types for a report including multiple type filters", () => {
+    const searchResults = {
+      "@context": "/terms/",
+      "@id": "/multireport/?type=PrimaryCell&type=Tissue",
+      "@graph": [
+        {
+          "@id": "/primary-cells/IGVFSM0000EEEE/",
+          "@type": ["PrimaryCell", "Biosample", "Sample", "Item"],
+          accession: "IGVFSM0000EEEE",
+          uuid: "578c72a2-4f84-2c8f-96b0-ec8715e18185",
+        },
+      ],
+      filters: [
+        {
+          field: "type",
+          term: "PrimaryCell",
+          remove: "/multireport/?type=Tissue",
+        },
+        {
+          field: "type",
+          term: "Tissue",
+          remove: "/multireport/?type=PrimaryCell",
+        },
+      ],
+    };
+
+    const reportTypes = getSelectedTypes(searchResults);
+    expect(reportTypes).toHaveLength(2);
+    expect(reportTypes[0]).toEqual("PrimaryCell");
+    expect(reportTypes[1]).toEqual("Tissue");
+  });
+
+  it("should return the correct report types with a config filter", () => {
+    const searchResults = {
+      "@context": "/terms/",
+      "@id": "/multireport/?type=PrimaryCell&type=Tissue&config=InVitroSystem",
+      "@graph": [
+        {
+          "@id": "/primary-cells/IGVFSM0000EEEE/",
+          "@type": ["PrimaryCell", "Biosample", "Sample", "Item"],
+          accession: "IGVFSM0000EEEE",
+          uuid: "578c72a2-4f84-2c8f-96b0-ec8715e18185",
+        },
+      ],
+      filters: [
+        {
+          field: "type",
+          term: "PrimaryCell",
+          remove: "/multireport/?type=Tissue&config=InVitroSystem",
+        },
+        {
+          field: "type",
+          term: "Tissue",
+          remove: "/multireport/?type=PrimaryCell&config=InVitroSystem",
+        },
+      ],
+    };
+
+    const reportTypes = getSelectedTypes(searchResults);
+    expect(reportTypes).toHaveLength(1);
+    expect(reportTypes[0]).toEqual("InVitroSystem");
   });
 
   it("should return an empty report-type string for a report not including a type filter", () => {
@@ -102,19 +212,19 @@ describe("Test `getReportType()`", () => {
         {
           field: "query",
           term: "ChIP-seq",
-          remove: "/report",
+          remove: "/multireport",
         },
       ],
     };
 
-    const reportType = getReportType(searchResults);
-    expect(reportType).toEqual("");
+    const reportTypes = getSelectedTypes(searchResults);
+    expect(reportTypes).toHaveLength(0);
   });
 });
 
 describe("Test `getReportTypeColumnSpecs()`", () => {
   it("should return column specs for a known report type", () => {
-    const columnSpecs = getReportTypeColumnSpecs("Biosample", profiles);
+    const columnSpecs = getReportTypeColumnSpecs(["Biosample"], profiles);
     expect(columnSpecs).toEqual([
       {
         id: "@id",
@@ -132,292 +242,89 @@ describe("Test `getReportTypeColumnSpecs()`", () => {
   });
 
   it("should return an empty array for an unknown report type", () => {
-    const columnSpecs = getReportTypeColumnSpecs("Unknown", profiles);
+    const columnSpecs = getReportTypeColumnSpecs(["Unknown"], profiles);
     expect(columnSpecs).toEqual([]);
   });
 });
 
-describe("Test `getVisibleReportColumnSpecs()`", () => {
-  it("should return column specs for a known report type with no field= in the query string", () => {
-    const searchResults = {
-      "@context": "/terms/",
-      "@graph": [
-        {
-          "@id": "/tissues/IGVFSM003DDD/",
-          "@type": ["Tissue", "Biosample", "Sample", "Item"],
-          accession: "IGVFSM003DDD",
-          award: "/awards/HG012012/",
-          sample_terms: ["/sample-terms/UBERON_0002048/"],
-          donors: ["/rodent-donors/IGVFDO820DHC/"],
-          lab: "/labs/j-michael-cherry/",
-          status: "released",
-          taxa: "Homo sapiens",
-          uuid: "fd5524f2-0303-11ed-b939-0242ac120002",
-        },
-      ],
-      "@id": "/search?type=Biosample",
-      "@type": ["Search"],
-      clear_filters: "/search?type=Biosample",
-      columns: {
+describe("Test `getMergedSchemaProperties()`", () => {
+  it("correctly merges properties from multiple schemas", () => {
+    const tissueSchema = {
+      $id: "/profiles/tissue.json",
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      "@type": ["JSONSchema"],
+      properties: {
         "@id": {
           title: "ID",
+          type: "string",
         },
-        uuid: {
-          title: "UUID",
+        "@type": {
+          items: {
+            type: "string",
+          },
+          title: "Type",
+          type: "array",
         },
         accession: {
           title: "Accession",
+          type: "string",
+        },
+        moi: {
+          title: "Multiplicity Of Infection",
+          type: "number",
         },
       },
-      filters: [
-        {
-          field: "type",
-          term: "Biosample",
-          remove: "/search",
-        },
-      ],
-      title: "Search",
-      total: 1,
     };
 
-    const columnSpecs = getVisibleReportColumnSpecs(searchResults, profiles);
-
-    expect(columnSpecs).toEqual([
-      {
-        id: "@id",
-        title: "ID",
-      },
-      {
-        id: "accession",
-        title: "Accession",
-      },
-      {
-        id: "uuid",
-        title: "UUID",
-      },
-    ]);
-  });
-
-  it("should return column specs for a known report type with no field= in the query string", () => {
-    const searchResults = {
-      "@context": "/terms/",
-      "@graph": [
-        {
-          "@id": "/tissues/IGVFSM003DDD/",
-          "@type": ["Tissue", "Biosample", "Sample", "Item"],
-          accession: "IGVFSM003DDD",
-          award: "/awards/HG012012/",
-          sample_terms: ["/sample-terms/UBERON_0002048/"],
-          donors: ["/rodent-donors/IGVFDO820DHC/"],
-          lab: "/labs/j-michael-cherry/",
-          status: "released",
-          taxa: "Homo sapiens",
-          uuid: "fd5524f2-0303-11ed-b939-0242ac120002",
-        },
-      ],
-      "@id": "/search?type=Biosample",
-      "@type": ["Search"],
-      clear_filters: "/search?type=Biosample",
-      columns: {
+    const primaryCellSchema = {
+      $id: "/profiles/primary_cell.json",
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      "@type": ["JSONSchema"],
+      properties: {
         "@id": {
           title: "ID",
+          type: "string",
         },
-        uuid: {
-          title: "UUID",
+        "@type": {
+          items: {
+            type: "string",
+          },
+          title: "Type",
+          type: "array",
         },
         accession: {
           title: "Accession",
+          type: "string",
+        },
+        age: {
+          title: "Age",
+          type: "string",
+        },
+        age_units: {
+          title: "Age Units",
+          type: "string",
         },
       },
-      filters: [
-        {
-          field: "type",
-          term: "Biosample",
-          remove: "/search",
-        },
-      ],
-      title: "Search",
-      total: 1,
     };
 
-    const columnSpecs = getVisibleReportColumnSpecs(searchResults, profiles);
-
-    expect(columnSpecs).toEqual([
-      {
-        id: "@id",
-        title: "ID",
-      },
-      {
-        id: "accession",
-        title: "Accession",
-      },
-      {
-        id: "uuid",
-        title: "UUID",
-      },
+    const mergedProperties = getMergedSchemaProperties([
+      tissueSchema,
+      primaryCellSchema,
     ]);
+
+    const mergedKeys = Object.keys(mergedProperties);
+    expect(mergedKeys).toHaveLength(6);
+    expect(mergedKeys).toContain("@id");
+    expect(mergedKeys).toContain("@type");
+    expect(mergedKeys).toContain("accession");
+    expect(mergedKeys).toContain("moi");
+    expect(mergedKeys).toContain("age");
+    expect(mergedKeys).toContain("age_units");
   });
 
-  it("should return column specs for a known report type with field= in the query string", () => {
-    const searchResults = {
-      "@context": "/terms/",
-      "@graph": [
-        {
-          "@id": "/tissues/IGVFSM003DDD/",
-          "@type": ["Tissue", "Biosample", "Sample", "Item"],
-          accession: "IGVFSM003DDD",
-          award: "/awards/HG012012/",
-          sample_terms: ["/sample-terms/UBERON_0002048/"],
-          donors: ["/rodent-donors/IGVFDO820DHC/"],
-          lab: "/labs/j-michael-cherry/",
-          status: "released",
-          taxa: "Homo sapiens",
-          uuid: "fd5524f2-0303-11ed-b939-0242ac120002",
-        },
-      ],
-      "@id": "/search?type=Biosample&field=@id&field=uuid&field=notreal",
-      "@type": ["Search"],
-      clear_filters: "/search?type=Biosample",
-      columns: {
-        "@id": {
-          title: "ID",
-        },
-        uuid: {
-          title: "UUID",
-        },
-        accession: {
-          title: "Accession",
-        },
-      },
-      filters: [
-        {
-          field: "type",
-          term: "Biosample",
-          remove: "/search",
-        },
-      ],
-      title: "Search",
-      total: 1,
-    };
-
-    const columnSpecs = getVisibleReportColumnSpecs(searchResults, profiles);
-
-    expect(columnSpecs).toEqual([
-      {
-        id: "@id",
-        title: "ID",
-      },
-      {
-        id: "notreal",
-        title: "notreal",
-      },
-      {
-        id: "uuid",
-        title: "UUID",
-      },
-    ]);
-  });
-
-  it("should return no column specs for an unknown report type", () => {
-    const searchResults = {
-      "@context": "/terms/",
-      "@graph": [
-        {
-          "@id": "/whole-organisms/IGVFSM003KAS/",
-          "@type": ["WholeOrganism", "Biosample", "Sample", "Item"],
-          accession: "IGVFSM003KAS",
-          award: "/awards/HG012012/",
-          sample_terms: ["/sample-terms/UBERON_0000468/"],
-          lab: "/labs/j-michael-cherry/",
-          status: "released",
-          taxa: "Mus musculus",
-          uuid: "d4c46526-0307-11ed-b939-0242ac120002",
-        },
-      ],
-      "@id": "/search?type=WholeOrganism&field=@id&field=uuid",
-      "@type": ["Search"],
-      clear_filters: "/search?type=WholeOrganism",
-      columns: {
-        "@id": {
-          title: "ID",
-        },
-        uuid: {
-          title: "UUID",
-        },
-        accession: {
-          title: "Accession",
-        },
-      },
-      filters: [
-        {
-          field: "type",
-          term: "WholeOrganism",
-          remove: "/search",
-        },
-      ],
-      title: "Search",
-      total: 1,
-    };
-
-    const columnSpecs = getVisibleReportColumnSpecs(searchResults, profiles);
-
-    expect(columnSpecs).toEqual([]);
-  });
-
-  it("should filter out search config columns that don't exist in the schema", () => {
-    const searchResults = {
-      "@context": "/terms/",
-      "@graph": [
-        {
-          "@id": "/tissues/IGVFSM003DDD/",
-          "@type": ["Tissue", "Biosample", "Sample", "Item"],
-          accession: "IGVFSM003DDD",
-          award: "/awards/HG012012/",
-          biosample_term: "/sample-terms/UBERON_0002048/",
-          donors: ["/rodent-donors/IGVFDO820DHC/"],
-          lab: "/labs/j-michael-cherry/",
-          status: "released",
-          taxa: "Homo sapiens",
-          uuid: "fd5524f2-0303-11ed-b939-0242ac120002",
-        },
-      ],
-      "@id": "/search?type=Biosample",
-      "@type": ["Search"],
-      clear_filters: "/search?type=Biosample",
-      columns: {
-        "@id": {
-          title: "ID",
-        },
-        uuid: {
-          title: "UUID",
-        },
-        accessions: {
-          title: "Accession",
-        },
-      },
-      filters: [
-        {
-          field: "type",
-          term: "Biosample",
-          remove: "/search",
-        },
-      ],
-      title: "Search",
-      total: 1,
-    };
-
-    const columnSpecs = getVisibleReportColumnSpecs(searchResults, profiles);
-
-    expect(columnSpecs).toEqual([
-      {
-        id: "@id",
-        title: "ID",
-      },
-      {
-        id: "uuid",
-        title: "UUID",
-      },
-    ]);
+  it("returns null when passed null", () => {
+    const mergedProperties = getMergedSchemaProperties(null);
+    expect(mergedProperties).toBeNull();
   });
 });
 
@@ -501,9 +408,9 @@ describe("Test `getSortColumn()`", () => {
   });
 });
 
-describe("Test `schemaColumnsToColumnSpecs()`", () => {
+describe("Test `columnsToColumnSpecs()`", () => {
   it("should return sorted columnSpecs for schema", () => {
-    const columnSpecs = schemaColumnsToColumnSpecs(profiles.Award.columns);
+    const columnSpecs = columnsToColumnSpecs(profiles.Award.columns);
     expect(columnSpecs).toEqual([
       {
         id: "@id",
@@ -513,43 +420,5 @@ describe("Test `schemaColumnsToColumnSpecs()`", () => {
         id: "uuid",
       },
     ]);
-  });
-});
-
-describe("Test `getVisibleReportColumnSpecs()`", () => {
-  it("should return column IDs when the visible column IDs have values outside the column specs", () => {
-    const visibleColumnIds = ["@id", "uuid", "submitted_by.title"];
-    const columnSpecs = [
-      { id: "@id", title: "ID" },
-      { id: "uuid", title: "UUID" },
-    ];
-
-    const manuallyEnteredColumnIds = getManuallyEnteredColumnIds(
-      visibleColumnIds,
-      columnSpecs
-    );
-    expect(manuallyEnteredColumnIds).toEqual(["submitted_by.title"]);
-  });
-
-  it("should return empty array when the visible column IDs have values inside the column specs", () => {
-    const visibleColumnIds = ["@id", "uuid"];
-    const columnSpecs = [
-      { id: "@id", title: "ID" },
-      { id: "uuid", title: "UUID" },
-    ];
-    expect(getManuallyEnteredColumnIds(visibleColumnIds, columnSpecs)).toEqual(
-      []
-    );
-  });
-
-  it("should return empty array when the visible column IDs are empty", () => {
-    const visibleColumnIds = [];
-    const columnSpecs = [
-      { id: "@id", title: "ID" },
-      { id: "uuid", title: "UUID" },
-    ];
-    expect(getManuallyEnteredColumnIds(visibleColumnIds, columnSpecs)).toEqual(
-      []
-    );
   });
 });

--- a/lib/query-utils.ts
+++ b/lib/query-utils.ts
@@ -2,6 +2,12 @@
 import { NextJsServerQuery } from "../globals";
 
 /**
+ * Keys that should not be included in the query string. These keys can appear spuriously from
+ * internal routing and should not get included in our igvfd queries.
+ */
+const excludedKeys = ["path"];
+
+/**
  * Build a query string from the NextJS `serverQuery` object passed in server-side requests.
  * Repeated key=value pairs in `serverQuery` get deduplicated in the generated query string.
  *
@@ -17,7 +23,10 @@ import { NextJsServerQuery } from "../globals";
 export function getQueryStringFromServerQuery(
   serverQuery: NextJsServerQuery
 ): string {
-  return Object.keys(serverQuery)
+  const queryKeys = Object.keys(serverQuery).filter(
+    (key) => !excludedKeys.includes(key)
+  );
+  return queryKeys
     .map((queryKey) => {
       const value = serverQuery[queryKey];
       if (Array.isArray(value)) {

--- a/lib/report.js
+++ b/lib/report.js
@@ -13,50 +13,113 @@ import { splitPathAndQueryString } from "./query-utils";
  */
 
 /**
- * Get the schema for the given `reportType`. If no schema exists for the report type or `profiles`
- * isn't available, null gets returned.
- * @param {string} reportType `@type` of the report
+ * Get the schemas for the given types in `reportTypes`. Abstract types within `reportTypes` don't
+ * have their own schemas, but all their subtypes' schemas get included in the result. If a type in
+ * `reportType` doesn't have a schema nor subtypes, it gets ignored. If `profiles` isn't available,
+ * null gets returned.
+ * @param {Array<string>} reportTypes All `type` in the query string of the report
  * @param {object} profiles All schemas for all types keyed by their `@type`
- * @returns {object} Schema for the given `reportType`; null if not found
+ * @returns {Array<object>} Schema for the given `reportType`; null if not found
  */
-export function getSchemaForReportType(reportType, profiles) {
-  let schemaName;
+export function getSchemasForReportTypes(reportTypes, profiles) {
   if (profiles) {
-    schemaName = Object.keys(profiles).find(
-      (profileName) => profileName === reportType
+    return reportTypes.reduce((schemaAcc, reportType) => {
+      const schema = profiles[reportType];
+      if (schema) {
+        // Matching schema found for the report type. Add it to the schema accumulator.
+        return [...schemaAcc, schema];
+      }
+
+      // No matching schema for the report type. See if the report type is an abstract type with
+      // subtypes.
+      const subTypes = profiles._subtypes[reportType];
+      if (subTypes) {
+        // The report type is an abstract type with subtypes. Add all the subtypes' schemas to the
+        // schema accumulator.
+        return [...schemaAcc, ...subTypes.map((subType) => profiles[subType])];
+      }
+
+      // No matching schema for the report type, and the report type isn't an abstract type with
+      // subtypes. Ignore it.
+      return schemaAcc;
+    }, []);
+  }
+  return null;
+}
+
+/**
+ * Given report search results, determine all the `type=@type` types in the query string.
+ * @param {objects} searchResults Search results for a report
+ * @returns {Array<string>} Types in the query string
+ */
+function getTypes(searchResults) {
+  return searchResults.filters
+    .filter((filter) => filter.field === "type")
+    .map((filter) => filter.term);
+}
+
+/**
+ * Get the selected config type for the report from the "config=" query-string parameter. An empty
+ * string gets returned if no "config=" exists in the query string. If multiple "config=" exist in
+ * the query string, only the first one gets returned -- multiple "config=" isn't valid.
+ * @param {object} searchResults Search results for a report
+ * @returns {string} Selected config type for the report; empty string if none
+ */
+function getConfigType(searchResults) {
+  const query = new QueryString(searchResults["@id"]);
+  const configTypes = query.getKeyValues("config");
+  return configTypes.length > 0 ? configTypes[0] : "";
+}
+
+/**
+ * Get the selected object types based on the search query string and the "config=" query-string
+ * parameter. The "config=" parameter, if used, takes precedence over the "type=" parameters.
+ * @param {object} searchResults Search results for a report
+ * @returns {Array<string>} All selected types for the report
+ */
+export function getSelectedTypes(searchResults) {
+  const reportTypes = getTypes(searchResults);
+  const configType = getConfigType(searchResults);
+  return configType ? [configType] : reportTypes;
+}
+
+/**
+ * Merge the properties of all the given schemas into one object, forming one object that's the
+ * union of all the given schema properties. Only the contents of the `properties` property of each
+ * schema appears in the results. Other properties of schemas (e.g. `mixinProperties`) don't appear
+ * in the results. If `schemas` is null, null gets returned.
+ * @param {Array<object>} schemas Array of relevant schemas
+ * @returns {object} All properties of the given `schemas` merged into a single object
+ */
+export function getMergedSchemaProperties(schemas) {
+  if (schemas) {
+    return schemas.reduce(
+      (mergedSchemaProperties, schema) => ({
+        ...mergedSchemaProperties,
+        ...schema.properties,
+      }),
+      {}
     );
   }
-  return profiles?.[schemaName] || null;
+  return null;
 }
 
 /**
- * Given report search results, determine the `@type` of the objects within it. It returns the
- * empty string if the type can't be determined. That should never happen because /report/ requires
- * a single "type=" in the query string.
- * @param {objects} searchResults Search results for a report
- * @returns {string} Type of objects in the report
- */
-export function getReportType(searchResults) {
-  const typeFilter = searchResults.filters.find(
-    (filter) => filter.field === "type"
-  );
-  return typeFilter ? typeFilter.term : "";
-}
-
-/**
- * Get the columnSpecs for all possible columns for the given `reportType`. These get sorted by
+ * Get the columnSpecs for all possible columns for the given report types. These get sorted by
  * title, except for the `@id` column that always sorts first. An empty array gets returned if we
- * could find no schema for the report type, or profiles wasn't available.
- * @param {string} reportType `@type` of the report
+ * could find no schema for the report type, or profiles wasn't available. You can also pass a
+ * config= type to get the columnSpecs for that config type. Unknown config types return an empty
+ * array.
+ * @param {Array<string>} reportTypes All the `@type` of the report
  * @param {object} profiles All schemas for all types keyed by their `@type`
  * @returns {array} Array of columnSpec objects
  */
-export function getReportTypeColumnSpecs(reportType, profiles) {
+export function getReportTypeColumnSpecs(reportTypes, profiles) {
   let columnSpecs = [];
-  const schema = getSchemaForReportType(reportType, profiles);
-  if (schema) {
+  const schemas = getSchemasForReportTypes(reportTypes, profiles);
+  if (schemas) {
     // Collect all properties from the schema. This represents all possible columns for the report.
-    const schemaProperties = schema.properties;
+    const schemaProperties = getMergedSchemaProperties(schemas);
     columnSpecs = Object.keys(schemaProperties).map((propertyName) => ({
       id: propertyName,
       title: schemaProperties[propertyName].title,
@@ -64,50 +127,6 @@ export function getReportTypeColumnSpecs(reportType, profiles) {
     columnSpecs = sortColumnSpecs(columnSpecs);
   }
   return columnSpecs;
-}
-
-/**
- * Get an array of columnSpecs for columns that are visible in the report. These come from either
- * the "field=" query-string parameters, or from the `columns` property of the search results if no
- * "field=" exists in the query string. The resulting columnSpecs get sorted by title, except for
- * the `@id` column that always sorts first. An empty array gets returned if we could find no
- * schema for the report type, or `profiles` wasn't available.
- * @param {object} searchResults Search results for a report
- * @returns {array} Array of columnSpecs that are visible in the report
- */
-export function getVisibleReportColumnSpecs(searchResults, profiles) {
-  let columnIds = [];
-  const reportType = getReportType(searchResults);
-  const schema = getSchemaForReportType(reportType, profiles);
-  if (schema) {
-    // Get all the "field=" values from the query string, if any.
-    const { queryString } = splitPathAndQueryString(searchResults["@id"]);
-    const query = new QueryString(queryString);
-    columnIds = query.getKeyValues("field");
-    if (columnIds.length === 0) {
-      // No "field=" parameters exist in the query string, so all visible columns come from the search
-      // result `columns` property.
-      columnIds = Object.keys(searchResults.columns);
-
-      // Filter the columnIDs to only those that exist in the schema, in case the search config columns
-      // don't match the schema columns.
-      columnIds = columnIds.filter((columnId) =>
-        Object.keys(schema.properties).includes(columnId)
-      );
-    }
-
-    // Collect all properties from the schema. This represents all possible columns for the report.
-    const columnSpecs = columnIds
-      .map((propertyName) => {
-        return {
-          id: propertyName,
-          title: schema.properties[propertyName]?.title || propertyName,
-        };
-      })
-      .filter((columnSpec) => columnSpec !== null);
-    return sortColumnSpecs(columnSpecs);
-  }
-  return [];
 }
 
 /**
@@ -144,30 +163,16 @@ function sortColumnSpecs(columnSpecs) {
 }
 
 /**
- * Converts the `columns` property of a schema or from search results into an array of columnSpec
- * objects. The array gets sorted by title, except for the column for the `@id` property that
- * always sorts first.
- * @param {object} schemaColumns `columns` property of a schema or search results
+ * Converts the columns of a schema or from search results into an array of columnSpec objects.
+ * The array gets sorted by title, except for the column for the `@id` property that always sorts
+ * first.
+ * @param {object} schemaColumns columns from a schema or search results
  * @returns {array} Sorted array of columnSpec objects
  */
-export function schemaColumnsToColumnSpecs(schemaColumns) {
+export function columnsToColumnSpecs(schemaColumns) {
   const columnSpecs = Object.keys(schemaColumns).map((columnId) => ({
     id: columnId,
     title: schemaColumns[columnId].title,
   }));
   return sortColumnSpecs(columnSpecs);
-}
-
-/**
- * Get the manually entered column IDs the user entered in the query string. These are the ones
- * that don't exist in the schema for the report type. An empty array gets returned if no manually
- * entered columns exist.
- * @param {array} visibleColumnIds Array of column IDs that are visible in the report
- * @param {array} columnSpecs Array of columnSpec objects for the report type
- * @returns {array} Array of manually entered column IDs
- */
-export function getManuallyEnteredColumnIds(visibleColumnIds, columnSpecs) {
-  return visibleColumnIds.filter(
-    (columnId) => !columnSpecs.find((columnSpec) => columnSpec.id === columnId)
-  );
 }

--- a/lib/search-results.js
+++ b/lib/search-results.js
@@ -28,16 +28,18 @@ function getSearchResultItemTypes(searchResults) {
  * @returns {string} Page title for search results page
  */
 export function composeSearchResultsPageTitle(searchResults, profiles) {
-  const types = getSearchResultItemTypes(searchResults);
-  const schema = profiles[types[0]];
-  if (schema) {
-    const title = schema.title;
-    const remainingTypeCount = types.length - 1;
-    return types.length > 1
-      ? `${title} and ${remainingTypeCount} other type${
-          remainingTypeCount > 1 ? "s" : ""
-        }`
-      : title;
+  if (profiles) {
+    const types = getSearchResultItemTypes(searchResults);
+    const schema = profiles[types[0]];
+    if (schema) {
+      const title = schema.title;
+      const remainingTypeCount = types.length - 1;
+      return types.length > 1
+        ? `${title} and ${remainingTypeCount} other type${
+            remainingTypeCount > 1 ? "s" : ""
+          }`
+        : title;
+    }
   }
   return "";
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "isomorphic-dompurify": "^1.0.0",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
-        "marked": "^7.0.2",
+        "marked": "^9.0.0",
         "next": "13.4.12",
         "pretty-format": "^29.5.0",
         "prop-types": "^15.8.1",
@@ -206,22 +206,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.20.tgz",
-      "integrity": "sha512-Y6jd1ahLubuYweD/zJH+vvOY141v4f9igNQAQ+MBgq9JlHS2iTsZKn1aMsb3vGccZsXI16VzTBw52Xx0DWmtnA==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.0.tgz",
+      "integrity": "sha512-97z/ju/Jy1rZmDxybphrBuI+jtJjFVoz7Mr9yUQVVVi+DNZE333uFQeMOqcCIy1x3WYBIbWftUSLmbNXNT7qFQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.22.15",
+        "@babel/generator": "^7.23.0",
         "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.22.20",
-        "@babel/helpers": "^7.22.15",
-        "@babel/parser": "^7.22.16",
+        "@babel/helper-module-transforms": "^7.23.0",
+        "@babel/helpers": "^7.23.0",
+        "@babel/parser": "^7.23.0",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.20",
-        "@babel/types": "^7.22.19",
-        "convert-source-map": "^1.7.0",
+        "@babel/traverse": "^7.23.0",
+        "@babel/types": "^7.23.0",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.3",
@@ -235,12 +235,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
-    },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -251,12 +245,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
-      "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.15",
+        "@babel/types": "^7.23.0",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -300,13 +294,13 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -337,9 +331,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.20.tgz",
-      "integrity": "sha512-dLT7JVWIUUxKOs1UnJUBR3S70YK+pKX6AbJgB2vMIvEkZkrfJDbYDJesnPshtKV4LhDOR3Oc5YULeDizRek+5A==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
+      "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -416,14 +410,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.15.tgz",
-      "integrity": "sha512-7pAjK0aSdxOwR+CcYAqgWOGy5dcfvzsTIfFTb2odQqW47MDfv14UaJDY6eng8ylM2EaeKXdxaSWESbkmaQHTmw==",
+      "version": "7.23.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.1.tgz",
+      "integrity": "sha512-chNpneuK18yW5Oxsr+t553UZzzAs3aZnFm4bxhebsNTeshrC95yA7l5yl7GBAG+JG1rF0F7zzD2EixK9mWSDoA==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/traverse": "^7.23.0",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -515,9 +509,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
-      "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -704,9 +698,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
-      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
+      "version": "7.23.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.1.tgz",
+      "integrity": "sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==",
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -730,19 +724,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.20.tgz",
-      "integrity": "sha512-eU260mPZbU7mZ0N+X10pxXhQFMGTeLb9eFS0mxehS8HZp9o1uSnFeWQuG1UPrlxgA7QoUzFhOnilHDp0AXCyHw==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.0.tgz",
+      "integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.22.15",
+        "@babel/generator": "^7.23.0",
         "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.22.5",
+        "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.16",
-        "@babel/types": "^7.22.19",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -760,13 +754,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.19",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.19.tgz",
-      "integrity": "sha512-P7LAw/LbojPzkgp5oznjE6tQEIWbp4PkkfrZDINTro9zgBRtI324/EYsiSI7lhPbpIQ+DCeR2NNmMWANGGfZsg==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.19",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -882,9 +876,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.1.tgz",
-      "integrity": "sha512-PWiOzLIUAjN/w5K17PoF4n6sKBw0gqLHPhywmYHP4t1VFQQVYeb1yWsJwnMVEMl3tUHME7X/SJPZLmtG7XBDxQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.2.tgz",
+      "integrity": "sha512-0MGxAVt1m/ZK+LTJp/j0qF7Hz97D9O/FH9Ms3ltnyIdDD57cbb1ACIQTkbHvNXtWDv5TPq7w5Kq56+cNukbo7g==",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -928,9 +922,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.49.0.tgz",
-      "integrity": "sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.50.0.tgz",
+      "integrity": "sha512-NCC3zz2+nvYd+Ckfh87rA47zfu2QsQpvc6k1yzTk+b9KzRj0wkGa8LSoGOXN6Zv4lRf/EIoZ80biDh9HOI+RNQ==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -1481,9 +1475,9 @@
       "integrity": "sha512-RmHanbV21saP/6OEPBJ7yJMuys68cIf8OBBWd7+uj40LdpmswVAwe1uzeuFyUsd6SfeITWT3XnQfn6wULeKwDQ=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.19.tgz",
-      "integrity": "sha512-N/O+zGb6wZQdwu6atMZHbR7T9Np5SUFUjZqCbj0sXm+MwQO35M8TazVB4otm87GkXYs2l6OPwARd3/PUWhZBVQ==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.5.3.tgz",
+      "integrity": "sha512-lbZOoEjzSuTtpk9UgV9rOmxYw+PsSfNR+00mZcInqooiDMZ1u+RqT1YQYLsEZPW1kumZoQe5+exkCBtZ2xn0uw==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
@@ -1668,9 +1662,9 @@
       }
     },
     "node_modules/@rushstack/eslint-patch": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.4.0.tgz",
-      "integrity": "sha512-cEjvTPU32OM9lUFegJagO0mRnIn+rbqrG89vV8/xLnLFX0DoR0r1oy5IlTga71Q7uT3Qus7qm7wgeiMT/+Irlg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.5.0.tgz",
+      "integrity": "sha512-EF3948ckf3f5uPgYbQ6GhyA56Dmv8yg0+ir+BroRjwdxyZJsekhZzawOecC2rOTPCz173t7ZcR1HHZu0dZgOCw==",
       "dev": true
     },
     "node_modules/@sinclair/typebox": {
@@ -1872,9 +1866,9 @@
       }
     },
     "node_modules/@types/aria-query": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
-      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.2.tgz",
+      "integrity": "sha512-PHKZuMN+K5qgKIWhBodXzQslTo5P+K/6LqeKXS6O/4liIDdZqaX5RXrCK++LAw+y/nptN48YmUMFiQHRSWYwtQ==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -1919,17 +1913,17 @@
       }
     },
     "node_modules/@types/dompurify": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.2.tgz",
-      "integrity": "sha512-YBL4ziFebbbfQfH5mlC+QTJsvh0oJUrWbmxKMyEdL7emlHJqGR2Qb34TEFKj+VCayBvjKy3xczMFNhugThUsfQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.3.tgz",
+      "integrity": "sha512-odiGr/9/qMqjcBOe5UhcNLOFHSYmKFOyr+bJ/Xu3Qp4k1pNPAlNLUVNNLcLfjQI7+W7ObX58EdD3H+3p3voOvA==",
       "dependencies": {
         "@types/trusted-types": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
-      "integrity": "sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.7.tgz",
+      "integrity": "sha512-MhzcwU8aUygZroVwL2jeYk6JisJrPl/oov/gsgGCue9mkgl9wjGbzReYQClxiUgFDnib9FuHqTndccKeZKxTRw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -1942,18 +1936,18 @@
       "dev": true
     },
     "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-gPQuzaPR5h/djlAv2apEG1HVOyj1IUs7GpfMZixU0/0KXT3pm64ylHuMUI1/Akh+sq/iikxg6Z2j+fcMDXaaTQ==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
     },
     "node_modules/@types/istanbul-reports": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha512-kv43F9eb3Lhj+lr/Hn6OcLCs/sSM8bt+fIaP11rCYngfV6NVjzWXJ17owQtDQTL9tQ8WSLUrGsSJ6rJz0F1w1A==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
@@ -1992,25 +1986,25 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.198",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-      "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==",
+      "version": "4.14.199",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
+      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.2.tgz",
-      "integrity": "sha512-Y+/1vGBHV/cYk6OI1Na/LHzwnlNCAfU3ZNGrc1LdRe/LAIbdDPTTv/HU3M7yXN448aTVDq3eKRm2cg7iKLb8gw=="
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.0.tgz",
+      "integrity": "sha512-zI22/pJW2wUZOVyguFaUL1HABdmSVxpXrzIqkjsHmyUjNhPoWM1CKfvVuXfetHhIok4RY573cqS0mZ1SJEnoTg=="
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.6",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.6.tgz",
-      "integrity": "sha512-RK/kBbYOQQHLYj9Z95eh7S6t7gq4Ojt/NT8HTk8bWVhA5DaF+5SMnxHKkP4gPNN3wAZkKP+VjAf0ebtYzf+fxg=="
+      "version": "15.7.7",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.7.tgz",
+      "integrity": "sha512-FbtmBWCcSa2J4zL781Zf1p5YUBXQomPEcep9QZCfRfQgTxz3pJWiDFLebohZ9fFntX5ibzOkSsrJ0TEew8cAog=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.22",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.22.tgz",
-      "integrity": "sha512-60fLTOLqzarLED2O3UQImc/lsNRgG0jE/a1mPW9KjMemY0LMITWEsbS4VvZ4p6rorEHd5YKxxmMKSDK505GHpA==",
+      "version": "18.2.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.23.tgz",
+      "integrity": "sha512-qHLW6n1q2+7KyBEYnrZpcsAmU/iiCh9WGCKgXvMxx89+TYdJWRjZohVIo9XTcoLhfX3+/hP0Pbulu3bCZQ9PSA==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2026,14 +2020,14 @@
       }
     },
     "node_modules/@types/scheduler": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
+      "version": "0.16.4",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.4.tgz",
+      "integrity": "sha512-2L9ifAGl7wmXwP4v3pN4p2FLhD0O1qsJpvKmNin5VA8+UvNVb447UDaAEV6UdrkA+m/Xs58U1RFps44x6TFsVQ=="
     },
     "node_modules/@types/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw=="
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw=="
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -2042,9 +2036,9 @@
       "dev": true
     },
     "node_modules/@types/sizzle": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.4.tgz",
+      "integrity": "sha512-jA2llq2zNkg8HrALI7DtWzhALcVH0l7i89yhY3iBdOz6cBPeACoFq+fkQrjHA39t1hnSFOboZ7A/AY5MMZSlag==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -2065,24 +2059,24 @@
       "integrity": "sha512-IDaobHimLQhjwsQ/NMwRVfa/yL7L/wriQPMhw1ZJall0KX6E1oxk29XMDeilW5qTIg5aoiqf5Udy8U/51aNoQQ=="
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.24",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
-      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
+      "version": "17.0.25",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.25.tgz",
+      "integrity": "sha512-gy7iPgwnzNvxgAEi2bXOHWCVOG6f7xsprVJH4MjlAWeBmJ7vh/Y1kwMtUrs64ztf24zVIRCpr3n/z6gm9QIkgg==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "node_modules/@types/yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
       "dev": true
     },
     "node_modules/@types/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.1.tgz",
+      "integrity": "sha512-CHzgNU3qYBnp/O4S3yv2tXPlvMTq0YWSTVg2/JYLqWZGHwwgJGAwd00poay/11asPq8wLFwHzubyInqHIFmmiw==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -2090,15 +2084,15 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.2.tgz",
-      "integrity": "sha512-ooaHxlmSgZTM6CHYAFRlifqh1OAr3PAQEwi7lhYhaegbnXrnh7CDcHmc3+ihhbQC7H0i4JF0psI5ehzkF6Yl6Q==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.3.tgz",
+      "integrity": "sha512-vntq452UHNltxsaaN+L9WyuMch8bMd9CqJ3zhzTPXXidwbf5mqqKCVXEuvRZUqLJSTLeWE65lQwyXsRGnXkCTA==",
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.7.2",
-        "@typescript-eslint/type-utils": "6.7.2",
-        "@typescript-eslint/utils": "6.7.2",
-        "@typescript-eslint/visitor-keys": "6.7.2",
+        "@typescript-eslint/scope-manager": "6.7.3",
+        "@typescript-eslint/type-utils": "6.7.3",
+        "@typescript-eslint/utils": "6.7.3",
+        "@typescript-eslint/visitor-keys": "6.7.3",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -2124,14 +2118,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.2.tgz",
-      "integrity": "sha512-KA3E4ox0ws+SPyxQf9iSI25R6b4Ne78ORhNHeVKrPQnoYsb9UhieoiRoJgrzgEeKGOXhcY1i8YtOeCHHTDa6Fw==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.3.tgz",
+      "integrity": "sha512-TlutE+iep2o7R8Lf+yoer3zU6/0EAUc8QIBB3GYBc1KGz4c4TRm83xwXUZVPlZ6YCLss4r77jbu6j3sendJoiQ==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.7.2",
-        "@typescript-eslint/types": "6.7.2",
-        "@typescript-eslint/typescript-estree": "6.7.2",
-        "@typescript-eslint/visitor-keys": "6.7.2",
+        "@typescript-eslint/scope-manager": "6.7.3",
+        "@typescript-eslint/types": "6.7.3",
+        "@typescript-eslint/typescript-estree": "6.7.3",
+        "@typescript-eslint/visitor-keys": "6.7.3",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2151,12 +2145,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.2.tgz",
-      "integrity": "sha512-bgi6plgyZjEqapr7u2mhxGR6E8WCzKNUFWNh6fkpVe9+yzRZeYtDTbsIBzKbcxI+r1qVWt6VIoMSNZ4r2A+6Yw==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.3.tgz",
+      "integrity": "sha512-wOlo0QnEou9cHO2TdkJmzF7DFGvAKEnB82PuPNHpT8ZKKaZu6Bm63ugOTn9fXNJtvuDPanBc78lGUGGytJoVzQ==",
       "dependencies": {
-        "@typescript-eslint/types": "6.7.2",
-        "@typescript-eslint/visitor-keys": "6.7.2"
+        "@typescript-eslint/types": "6.7.3",
+        "@typescript-eslint/visitor-keys": "6.7.3"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2167,12 +2161,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.2.tgz",
-      "integrity": "sha512-36F4fOYIROYRl0qj95dYKx6kybddLtsbmPIYNK0OBeXv2j9L5nZ17j9jmfy+bIDHKQgn2EZX+cofsqi8NPATBQ==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.3.tgz",
+      "integrity": "sha512-Fc68K0aTDrKIBvLnKTZ5Pf3MXK495YErrbHb1R6aTpfK5OdSFj0rVN7ib6Tx6ePrZ2gsjLqr0s98NG7l96KSQw==",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.7.2",
-        "@typescript-eslint/utils": "6.7.2",
+        "@typescript-eslint/typescript-estree": "6.7.3",
+        "@typescript-eslint/utils": "6.7.3",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -2193,9 +2187,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.2.tgz",
-      "integrity": "sha512-flJYwMYgnUNDAN9/GAI3l8+wTmvTYdv64fcH8aoJK76Y+1FCZ08RtI5zDerM/FYT5DMkAc+19E4aLmd5KqdFyg==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.3.tgz",
+      "integrity": "sha512-4g+de6roB2NFcfkZb439tigpAMnvEIg3rIjWQ+EM7IBaYt/CdJt6em9BJ4h4UpdgaBWdmx2iWsafHTrqmgIPNw==",
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
       },
@@ -2205,12 +2199,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.2.tgz",
-      "integrity": "sha512-kiJKVMLkoSciGyFU0TOY0fRxnp9qq1AzVOHNeN1+B9erKFCJ4Z8WdjAkKQPP+b1pWStGFqezMLltxO+308dJTQ==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.3.tgz",
+      "integrity": "sha512-YLQ3tJoS4VxLFYHTw21oe1/vIZPRqAO91z6Uv0Ss2BKm/Ag7/RVQBcXTGcXhgJMdA4U+HrKuY5gWlJlvoaKZ5g==",
       "dependencies": {
-        "@typescript-eslint/types": "6.7.2",
-        "@typescript-eslint/visitor-keys": "6.7.2",
+        "@typescript-eslint/types": "6.7.3",
+        "@typescript-eslint/visitor-keys": "6.7.3",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2231,16 +2225,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.2.tgz",
-      "integrity": "sha512-ZCcBJug/TS6fXRTsoTkgnsvyWSiXwMNiPzBUani7hDidBdj1779qwM1FIAmpH4lvlOZNF3EScsxxuGifjpLSWQ==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.3.tgz",
+      "integrity": "sha512-vzLkVder21GpWRrmSR9JxGZ5+ibIUSudXlW52qeKpzUEQhRSmyZiVDDj3crAth7+5tmN1ulvgKaCU2f/bPRCzg==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.7.2",
-        "@typescript-eslint/types": "6.7.2",
-        "@typescript-eslint/typescript-estree": "6.7.2",
+        "@typescript-eslint/scope-manager": "6.7.3",
+        "@typescript-eslint/types": "6.7.3",
+        "@typescript-eslint/typescript-estree": "6.7.3",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -2255,11 +2249,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.2.tgz",
-      "integrity": "sha512-uVw9VIMFBUTz8rIeaUT3fFe8xIUx8r4ywAdlQv1ifH+6acn/XF8Y6rwJ7XNmkNMDrTW+7+vxFFPIF40nJCVsMQ==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.3.tgz",
+      "integrity": "sha512-HEVXkU9IB+nk9o63CeICMHxFWbHWr3E1mpilIQBe9+7L/lH97rleFLVtYsfnWB+JVMaiFnEaxvknvmIzX+CqVg==",
       "dependencies": {
-        "@typescript-eslint/types": "6.7.2",
+        "@typescript-eslint/types": "6.7.3",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -2276,9 +2270,9 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
     },
     "node_modules/ace-builds": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.27.0.tgz",
-      "integrity": "sha512-jOJPpZ6Ekw4c0447+POCM3KzeRHajLfX1ib5Kxm8MCLC5jHlJRQEdCK2BVUBHPBC53YcQ88nTTu9PvewehMLig=="
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.28.0.tgz",
+      "integrity": "sha512-wkJp+Wz8MRHtCVdt65L/jPFLAQ0iqJZ2EeD2XWOvKGbIi4mZNwHlpHRLRB8ZnQ07VoiB0TLFWwIjjm2FL9gUcQ=="
     },
     "node_modules/acorn": {
       "version": "8.10.0",
@@ -2697,9 +2691,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.15",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.15.tgz",
-      "integrity": "sha512-KCuPB8ZCIqFdA4HwKXsvz7j6gvSDNhDP7WnUjBleRkKjPdvCmHFuQ77ocavI8FT6NdvlBnE2UFr2H4Mycn8Vew==",
+      "version": "10.4.16",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
+      "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
       "dev": true,
       "funding": [
         {
@@ -2717,8 +2711,8 @@
       ],
       "dependencies": {
         "browserslist": "^4.21.10",
-        "caniuse-lite": "^1.0.30001520",
-        "fraction.js": "^4.2.0",
+        "caniuse-lite": "^1.0.30001538",
+        "fraction.js": "^4.3.6",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
@@ -2761,9 +2755,9 @@
       "dev": true
     },
     "node_modules/axe-core": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.1.tgz",
-      "integrity": "sha512-9l850jDDPnKq48nbad8SiEelCv4OrUWrKab/cPj0GScVg6cb6NbCCt/Ulk26QEq5jP9NnGr04Bit1BHyV6r5CQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.2.tgz",
+      "integrity": "sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -2985,9 +2979,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.10",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+      "version": "4.21.11",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.11.tgz",
+      "integrity": "sha512-xn1UXOKUz7DjdGlg9RrUr0GGiWzI97UQJnugHtH0OLDfJB7jMgoIkYvRIEO1l9EeEERVqeqLYOcFBW9ldjypbQ==",
       "dev": true,
       "funding": [
         {
@@ -3004,10 +2998,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001517",
-        "electron-to-chromium": "^1.4.477",
+        "caniuse-lite": "^1.0.30001538",
+        "electron-to-chromium": "^1.4.526",
         "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.11"
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3123,9 +3117,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001538",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz",
-      "integrity": "sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==",
+      "version": "1.0.30001539",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001539.tgz",
+      "integrity": "sha512-hfS5tE8bnNiNvEOEkm8HElUHroYwlqMMENEzELymy77+tJ6m+gA2krtHl5hxJaj71OlpC2cHZbdSMX1/YEqEkA==",
       "funding": [
         {
           "type": "opencollective",
@@ -3684,9 +3678,9 @@
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
-      "version": "16.18.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.52.tgz",
-      "integrity": "sha512-sm2aph6cRSsTMFYFgI+RpPLunXO9ClJkpizUVdT7KmGeyfQ14xnjTMT/f3MHcfKqevXqGT6BgVFzW8wcEoDUtA==",
+      "version": "16.18.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.54.tgz",
+      "integrity": "sha512-oTmGy68gxZZ21FhTJVVvZBYpQHEBZxHKTsGshobMqm9qWpbqdZsA5jvsuPZcHu0KwpmLrOHWPdEfg7XDpNT9UA==",
       "dev": true
     },
     "node_modules/cypress/node_modules/chalk": {
@@ -4006,9 +4000,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.523",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.523.tgz",
-      "integrity": "sha512-9AreocSUWnzNtvLcbpng6N+GkXnCcBR80IQkxRC9Dfdyg4gaWNUPBujAHUpKkiUkoSoR9UlhA4zD/IgBklmhzg==",
+      "version": "1.4.530",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.530.tgz",
+      "integrity": "sha512-rsJ9O8SCI4etS8TBsXuRfHa2eZReJhnGf5MHZd3Vo05PukWHKXhk3VQGbHHnDLa8nZz9woPCpLCMQpLGgkGNRA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4275,14 +4269,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.49.0.tgz",
-      "integrity": "sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.50.0.tgz",
+      "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.49.0",
+        "@eslint/js": "8.50.0",
         "@humanwhocodes/config-array": "^0.11.11",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -4328,19 +4322,19 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.4.19.tgz",
-      "integrity": "sha512-WE8367sqMnjhWHvR5OivmfwENRQ1ixfNE9hZwQqNCsd+iM3KnuMc1V8Pt6ytgjxjf23D+xbesADv9x3xaKfT3g==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.5.3.tgz",
+      "integrity": "sha512-VN2qbCpq2DMWgs7SVF8KTmc8bVaWz3s4nmcFqRLs7PNBt5AXejOhJuZ4zg2sCEHOvz5RvqdwLeI++NSCV6qHVg==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "13.4.19",
-        "@rushstack/eslint-patch": "^1.1.3",
+        "@next/eslint-plugin-next": "13.5.3",
+        "@rushstack/eslint-patch": "^1.3.3",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
-        "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-react": "^7.31.7",
+        "eslint-plugin-import": "^2.28.1",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
       },
       "peerDependencies": {
@@ -4386,9 +4380,9 @@
       }
     },
     "node_modules/eslint-import-resolver-typescript": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.0.tgz",
-      "integrity": "sha512-QTHR9ddNnn35RTxlaEnx2gCxqFlF2SEN0SE2d17SqwyM7YOSI2GHWRYp5BiRkObTUNYPupC/3Fq2a0PpT+EKpg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz",
+      "integrity": "sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
@@ -4629,9 +4623,9 @@
       }
     },
     "node_modules/eslint-plugin-testing-library": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.0.1.tgz",
-      "integrity": "sha512-CEYtjpcF3hAaQtYsTZqciR7s5z+T0LCMTwJeW+pz6kBnGtc866wAKmhaiK2Gsjc2jWNP7Gt6zhNr2DE1ZW4e+g==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.0.2.tgz",
+      "integrity": "sha512-3BV6FWtLbpKFb4Y1obSdt8PC9xSqz6T+7EHB/6pSCXqVjKPoS67ck903feKMKQphd5VhrX+N51yHuVaPa7elsw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.58.0"
@@ -5404,9 +5398,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.0.tgz",
-      "integrity": "sha512-pmjiZ7xtB8URYm74PlGJozDNyhvsVLUcpBa8DZBG3bWHwaHa9bPiRpiSfovw+fjhwONSCWKRyk+JQHEGZmMrzw==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
+      "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
       "dev": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -5484,9 +5478,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.21.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
-      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+      "version": "13.22.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.22.0.tgz",
+      "integrity": "sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -7873,9 +7867,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-7.0.5.tgz",
-      "integrity": "sha512-lwNAFTfXgqpt/XvK17a/8wY9/q6fcSPZT1aP6QW0u74VwaJF/Z9KbRcX23sWE4tODM+AolJNcUtErTkgOeFP/Q==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.0.3.tgz",
+      "integrity": "sha512-pI/k4nzBG1PEq1J3XFEHxVvjicfjl8rgaMaqclouGSMPhk7Q3Ejb2ZRxx/ZQOcQ1909HzVoWCFYq6oLgtL4BpQ==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -10433,9 +10427,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "isomorphic-dompurify": "^1.0.0",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
-    "marked": "^7.0.2",
+    "marked": "^9.0.0",
     "next": "13.4.12",
     "pretty-format": "^29.5.0",
     "prop-types": "^15.8.1",

--- a/pages/profiles/index.js
+++ b/pages/profiles/index.js
@@ -63,7 +63,7 @@ function SearchAndReportType({ type, title }) {
         <Bars4Icon />
       </ButtonLink>
       <ButtonLink
-        href={`/report?type=${type}`}
+        href={`/multireport?type=${type}`}
         label={`Report view of all ${title} objects`}
         type="secondary"
         size="sm"
@@ -114,7 +114,10 @@ function SubTree({ tree, objectType, schemas, collectionTitles = null }) {
             <AddLink schema={schema} label={`Add ${schema.title}`} />
           </>
         ) : (
-          <div className="font-bold">{title}</div>
+          <>
+            {title}
+            <SearchAndReportType type={objectType} title={title} />
+          </>
         )}
       </div>
       {childObjectTypes.length > 0 && (

--- a/pages/search.js
+++ b/pages/search.js
@@ -12,6 +12,7 @@ import {
   getSearchListItemRenderer,
   SearchListItem,
 } from "../components/search";
+import { SearchPager, useSearchLimits } from "../components/search-results";
 import {
   SearchResultsCount,
   SearchResultsHeader,
@@ -34,6 +35,7 @@ import {
  */
 export default function Search({ searchResults, accessoryData = null }) {
   const { profiles } = useContext(SessionContext);
+  const { totalPages } = useSearchLimits(searchResults);
   const pageTitle = profiles
     ? composeSearchResultsPageTitle(searchResults, profiles)
     : "";
@@ -49,6 +51,7 @@ export default function Search({ searchResults, accessoryData = null }) {
             <FacetTags searchResults={searchResults} />
             <SearchResultsHeader searchResults={searchResults} />
             <SearchResultsCount count={searchResults.total} />
+            {totalPages > 1 && <SearchPager searchResults={searchResults} />}
             <ul data-testid="search-list">
               {searchResults["@graph"].map((item) => {
                 // For each item, get the appropriate search-list item renderer for it, or the

--- a/pages/site-search.js
+++ b/pages/site-search.js
@@ -85,7 +85,7 @@ function TypeSectionHeader({
           <Bars4Icon className="h-4 w-4" />
         </ButtonLink>
         <ButtonLink
-          href={`/report?${query.format()}`}
+          href={`/multireport?${query.format()}`}
           type="primary"
           label={`View search report for ${typeTitle} with ${term}`}
           hasIconOnly


### PR DESCRIPTION
* While I changed the page filename from report.js to multireport.js to work with the NextJS router, I decided to keep all the supporting files named “report,” and keep “multireport” limited to anything path related.
* I moved the list and report pager to appear in a new slot between the results count and the results. People were sometimes confused about the space between the other controls and the results before noticing the pager on the right side. I also only show one page on each side of the selected page instead of two on each side, so it works on mobile better. The page numbers also appear narrower, also to work on mobile better.
* I removed the manually entered columns from the column-selection modal. It was an awkward UI.