### PR TITLE
IGVF-1127-construct-library-sets

### DIFF
--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,6 +53,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
+            'backend_url': 'https://igvfd-igvf-1200-samples-construct-library-sets.demo.igvf.org'
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,7 +53,6 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-igvf-1200-samples-construct-library-sets.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,7 +53,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-igvf-1200-samples-construct-library-sets.demo.igvf.org'
+            'backend_url': 'https://igvfd-igvf-1200-samples-construct-library-sets.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/components/sample-table.js
+++ b/components/sample-table.js
@@ -50,29 +50,32 @@ const sampleColumns = [
     id: "construct_library_sets",
     title: "Construct Library Set",
     display: ({ source }, { constructLibrarySetAccessions }) => {
-      return (
-        <SeparatedList>
-          {source.construct_library_sets
-            ? source.construct_library_sets.map((id) => {
-                if (constructLibrarySetAccessions) {
-                  const accession = constructLibrarySetAccessions.find(
-                    (lib) => lib["@id"] === id
-                  )?.accession;
+      if (source.construct_library_sets.length > 0) {
+        return (
+          <SeparatedList>
+            {source.construct_library_sets.map((id) => {
+                  if (constructLibrarySetAccessions) {
+                    const accession = constructLibrarySetAccessions.find(
+                      (lib) => lib["@id"] === id
+                    )?.accession;
+
+                    return accession ? (
+                      <Link href={id} key={id}>
+                        {accession}
+                      </Link>
+                    ) : null;
+                  }
                   return (
                     <Link href={id} key={id}>
-                      {accession}
+                      {id}
                     </Link>
                   );
-                }
-                return (
-                  <Link href={id} key={id}>
-                    {id}
-                  </Link>
-                );
-              })
-            : []}
-        </SeparatedList>
-      );
+                })
+              }
+          </SeparatedList>
+        );
+      }
+      return null;
     },
   },
   {

--- a/components/sample-table.js
+++ b/components/sample-table.js
@@ -47,6 +47,35 @@ const sampleColumns = [
     },
   },
   {
+    id: "construct_library_sets",
+    title: "Construct Library Set",
+    display: ({ source }, { constructLibrarySetAccessions }) => {
+      return (
+        <SeparatedList>
+          {source.construct_library_sets
+            ? source.construct_library_sets.map((id) => {
+                if (constructLibrarySetAccessions) {
+                  const accession = constructLibrarySetAccessions.find(
+                    (lib) => lib["@id"] === id
+                  )?.accession;
+                  return (
+                    <Link href={id} key={id}>
+                      {accession}
+                    </Link>
+                  );
+                }
+                return (
+                  <Link href={id} key={id}>
+                    {id}
+                  </Link>
+                );
+              })
+            : []}
+        </SeparatedList>
+      );
+    },
+  },
+  {
     id: "donors",
     title: "Donors",
     display: ({ source }) => {
@@ -72,10 +101,18 @@ const sampleColumns = [
 /**
  * Display a sortable table of the given multiplexed_samples.
  */
-export default function SampleTable({ samples }) {
+export default function SampleTable({
+  samples,
+  constructLibrarySetAccessions = null,
+}) {
   return (
     <DataGridContainer>
-      <SortableGrid data={samples} columns={sampleColumns} keyProp="@id" />
+      <SortableGrid
+        data={samples}
+        meta={{ constructLibrarySetAccessions }}
+        columns={sampleColumns}
+        keyProp="@id"
+      />
     </DataGridContainer>
   );
 }
@@ -83,4 +120,5 @@ export default function SampleTable({ samples }) {
 SampleTable.propTypes = {
   // Samples to display
   samples: PropTypes.arrayOf(PropTypes.object).isRequired,
+  constructLibrarySetAccessions: PropTypes.arrayOf(PropTypes.object),
 };

--- a/components/sample-table.js
+++ b/components/sample-table.js
@@ -50,7 +50,7 @@ const sampleColumns = [
     id: "construct_library_sets",
     title: "Construct Library Set",
     display: ({ source }, { constructLibrarySetAccessions }) => {
-      if (source.construct_library_sets.length > 0) {
+      if (source.construct_library_sets && source.construct_library_sets.length > 0) {
         return (
           <SeparatedList>
             {source.construct_library_sets.map((id) => {

--- a/components/sample-table.js
+++ b/components/sample-table.js
@@ -54,24 +54,23 @@ const sampleColumns = [
         return (
           <SeparatedList>
             {source.construct_library_sets.map((id) => {
-                  if (constructLibrarySetAccessions) {
-                    const accession = constructLibrarySetAccessions.find(
-                      (lib) => lib["@id"] === id
-                    )?.accession;
+              if (constructLibrarySetAccessions) {
+                const accession = constructLibrarySetAccessions.find(
+                  (lib) => lib["@id"] === id
+                )?.accession;
 
-                    return accession ? (
-                      <Link href={id} key={id}>
-                        {accession}
-                      </Link>
-                    ) : null;
-                  }
-                  return (
-                    <Link href={id} key={id}>
-                      {id}
-                    </Link>
-                  );
-                })
+                return accession ? (
+                  <Link href={id} key={id}>
+                    {accession}
+                  </Link>
+                ) : null;
               }
+              return (
+                <Link href={id} key={id}>
+                  {id}
+                </Link>
+              );
+            })}
           </SeparatedList>
         );
       }

--- a/components/sample-table.js
+++ b/components/sample-table.js
@@ -50,7 +50,10 @@ const sampleColumns = [
     id: "construct_library_sets",
     title: "Construct Library Set",
     display: ({ source }, { constructLibrarySetAccessions }) => {
-      if (source.construct_library_sets && source.construct_library_sets.length > 0) {
+      if (
+        source.construct_library_sets &&
+        source.construct_library_sets.length > 0
+      ) {
         return (
           <SeparatedList>
             {source.construct_library_sets.map((id) => {

--- a/pages/multiplexed-samples/[uuid].js
+++ b/pages/multiplexed-samples/[uuid].js
@@ -33,7 +33,6 @@ import {
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
-import { Link } from 'next/link';
 
 export default function MultiplexedSample({
   multiplexedSample,
@@ -65,20 +64,20 @@ export default function MultiplexedSample({
                     </DataItemValue>
                   </>
                 )}
-                {/* Property will exist since it's a calculated property */}
-                {multiplexedSample.construct_library_sets.length > 0 && (
-                  <>
-                    <DataItemLabel>Construct Library Sets</DataItemLabel>
-                    <DataItemValue>{multiplexedSample.construct_library_sets.map((lib) => <Link key={lib.accesstion} href={`${lib["@id"]}`}>{lib.accession}</Link>).join(", ")}</DataItemValue>
-                  </>
-                )}
               </SampleDataItems>
             </DataArea>
           </DataPanel>
           {multiplexedSample.multiplexed_samples.length > 0 && (
             <>
               <DataAreaTitle>Multiplexed Samples</DataAreaTitle>
-              <SampleTable samples={multiplexedSample.multiplexed_samples} />
+              <SampleTable
+                samples={multiplexedSample.multiplexed_samples}
+                constructLibrarySetAccessions={
+                  multiplexedSample.construct_library_sets
+                    ? multiplexedSample.construct_library_sets
+                    : null
+                }
+              />
             </>
           )}
           {multiplexedSample.file_sets.length > 0 && (

--- a/pages/multiplexed-samples/[uuid].js
+++ b/pages/multiplexed-samples/[uuid].js
@@ -33,6 +33,7 @@ import {
 import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
+import { Link } from 'next/link';
 
 export default function MultiplexedSample({
   multiplexedSample,
@@ -62,6 +63,13 @@ export default function MultiplexedSample({
                     <DataItemValue>
                       {multiplexedSample.cellular_sub_pool}
                     </DataItemValue>
+                  </>
+                )}
+                {/* Property will exist since it's a calculated property */}
+                {multiplexedSample.construct_library_sets.length > 0 && (
+                  <>
+                    <DataItemLabel>Construct Library Sets</DataItemLabel>
+                    <DataItemValue>{multiplexedSample.construct_library_sets.map((lib) => <Link key={lib.accesstion} href={`${lib["@id"]}`}>{lib.accession}</Link>).join(", ")}</DataItemValue>
                   </>
                 )}
               </SampleDataItems>


### PR DESCRIPTION
MultiplexedSamples now pass along its construct library sets accessions list to the samples table which then looks up the library set ID to find the accession, which is then placed in the table and links to the construct library page.
