### PR TITLE
IGVF-1195 Move Model UI to new object type

### DIFF
--- a/components/search/__tests__/list-renderer.test.js
+++ b/components/search/__tests__/list-renderer.test.js
@@ -15,7 +15,7 @@ import HumanDonor from "../list-renderer/human-donor";
 import HumanGenomicVariant from "../list-renderer/human-genomic-variant";
 import Lab from "../list-renderer/lab";
 import MeasurementSet from "../list-renderer/measurement-set";
-import Model from "../list-renderer/model";
+import ModelSet from "../list-renderer/model-set";
 import MultiplexedSample from "../list-renderer/multiplexed-sample";
 import OntologyTerm from "../list-renderer/ontology-term";
 import Page from "../list-renderer/page";
@@ -2313,11 +2313,11 @@ describe("Test PhenotypicFeature component", () => {
   });
 });
 
-describe("Test the Model component", () => {
-  it("renders a model item without a summary", () => {
+describe("Test the ModelSet component", () => {
+  it("renders a model-set item without a summary", () => {
     const item = {
       "@id": "/models/IGVFDS1234MODL/",
-      "@type": ["Model", "FileSet", "Item"],
+      "@type": ["ModelSet", "FileSet", "Item"],
       accession: "IGVFDS1234MODL",
       alternate_accessions: ["IGVFDS1234MODM"],
       aliases: ["igvf:xpresso"],
@@ -2334,12 +2334,12 @@ describe("Test the Model component", () => {
 
     render(
       <SessionContext.Provider value={{ profiles }}>
-        <Model item={item} />
+        <ModelSet item={item} />
       </SessionContext.Provider>
     );
 
     const uniqueId = screen.getByTestId("search-list-item-unique-id");
-    expect(uniqueId).toHaveTextContent(/Model/);
+    expect(uniqueId).toHaveTextContent(/ModelSet/);
     expect(uniqueId).toHaveTextContent(/IGVFDS1234MODL$/);
 
     const title = screen.getByTestId("search-list-item-title");
@@ -2353,10 +2353,10 @@ describe("Test the Model component", () => {
     expect(status).toHaveTextContent("released");
   });
 
-  it("renders a model item with a summary", () => {
+  it("renders a model-set item with a summary", () => {
     const item = {
       "@id": "/models/IGVFDS1234MODL/",
-      "@type": ["Model", "FileSet", "Item"],
+      "@type": ["ModelSet", "FileSet", "Item"],
       accession: "IGVFDS1234MODL",
       alternate_accessions: ["IGVFDS1234MODM"],
       aliases: ["igvf:xpresso"],
@@ -2374,12 +2374,12 @@ describe("Test the Model component", () => {
 
     render(
       <SessionContext.Provider value={{ profiles }}>
-        <Model item={item} />
+        <ModelSet item={item} />
       </SessionContext.Provider>
     );
 
     const uniqueId = screen.getByTestId("search-list-item-unique-id");
-    expect(uniqueId).toHaveTextContent(/Model/);
+    expect(uniqueId).toHaveTextContent(/ModelSet/);
     expect(uniqueId).toHaveTextContent(/IGVFDS1234MODL$/);
 
     const title = screen.getByTestId("search-list-item-title");

--- a/components/search/list-renderer/index.js
+++ b/components/search/list-renderer/index.js
@@ -60,7 +60,7 @@ import HumanDonor from "./human-donor";
 import Lab from "./lab";
 import MeasurementSet from "./measurement-set";
 import MultiplexedSample from "./multiplexed-sample";
-import Model from "./model";
+import ModelSet from "./model-set";
 import OntologyTerm from "./ontology-term";
 import Page from "./page";
 import PhenotypicFeature from "./phenotypic-feature";
@@ -96,7 +96,7 @@ const renderers = {
   Lab,
   MatrixFile: File,
   MeasurementSet,
-  Model,
+  ModelSet,
   Modification,
   MultiplexedSample,
   Page,

--- a/components/search/list-renderer/model-set.js
+++ b/components/search/list-renderer/model-set.js
@@ -12,31 +12,31 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function Model({ item: model }) {
+export default function ModelSet({ item: modelSet }) {
   return (
     <SearchListItemContent>
       <SearchListItemMain>
         <SearchListItemUniqueId>
-          <SearchListItemType item={model} />
-          {model.accession}
+          <SearchListItemType item={modelSet} />
+          {modelSet.accession}
         </SearchListItemUniqueId>
-        <SearchListItemTitle>{model.model_name}</SearchListItemTitle>
+        <SearchListItemTitle>{modelSet.model_name}</SearchListItemTitle>
         <SearchListItemMeta>
-          <div key="lab">{model.lab.title}</div>
-          {model.summary && <div key="summary">{model.summary}</div>}
-          {model.alternate_accessions?.length > 0 && (
+          <div key="lab">{modelSet.lab.title}</div>
+          {modelSet.summary && <div key="summary">{modelSet.summary}</div>}
+          {modelSet.alternate_accessions?.length > 0 && (
             <AlternateAccessions
-              alternateAccessions={model.alternate_accessions}
+              alternateAccessions={modelSet.alternate_accessions}
             />
           )}
         </SearchListItemMeta>
       </SearchListItemMain>
-      <SearchListItemQuality item={model} />
+      <SearchListItemQuality item={modelSet} />
     </SearchListItemContent>
   );
 }
 
-Model.propTypes = {
-  // Single model search-result object to display on a search-result list page
+ModelSet.propTypes = {
+  // Single ModelSet search-result object to display on a search-result list page
   item: PropTypes.object.isRequired,
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -26,7 +26,7 @@ export const BRAND_COLOR = "#337788";
 export const AUTH_ERROR_URI = "/auth-error";
 
 // List of `@type`s to ignore. This needs updating when deprecated schemas get removed from igvfd.
-export const deprecatedSchemas = ["ConstructLibrary", "Model", "Prediction"];
+export const deprecatedSchemas = [];
 
 // UNICODE entity codes, needed in JSX string templates. Each property named after the equivalent
 // HTML entity. Add new entries to this object as needed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3842,9 +3842,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.555",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.555.tgz",
-      "integrity": "sha512-k1wGC7UXDTyCWcONkEMRG/w6Jvrxi+SVEU+IeqUKUKjv2lGJ1b+jf1mqrloyxVTG5WYYjNQ+F6+Cb1fGrLvNcA==",
+      "version": "1.4.557",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.557.tgz",
+      "integrity": "sha512-6x0zsxyMXpnMJnHrondrD3SuAeKcwij9S+83j2qHAQPXbGTDDfgImzzwgGlzrIcXbHQ42tkG4qA6U860cImNhw==",
       "dev": true
     },
     "node_modules/emittery": {

--- a/pages/model-sets/[id].js
+++ b/pages/model-sets/[id].js
@@ -29,8 +29,8 @@ import errorObjectToProps from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
 
-export default function Model({
-  model,
+export default function ModelSet({
+  modelSet,
   softwareVersion = null,
   documents,
   files,
@@ -40,44 +40,44 @@ export default function Model({
   return (
     <>
       <Breadcrumbs />
-      <EditableItem item={model}>
+      <EditableItem item={modelSet}>
         <PagePreamble>
           <AlternateAccessions
-            alternateAccessions={model.alternate_accessions}
+            alternateAccessions={modelSet.alternate_accessions}
           />
         </PagePreamble>
-        <ObjectPageHeader item={model} isJsonFormat={isJson} />
-        <JsonDisplay item={model} isJsonFormat={isJson}>
+        <ObjectPageHeader item={modelSet} isJsonFormat={isJson} />
+        <JsonDisplay item={modelSet} isJsonFormat={isJson}>
           <DataPanel>
             <DataArea>
               <DataItemLabel>Accession</DataItemLabel>
-              <DataItemValue>{model.accession}</DataItemValue>
+              <DataItemValue>{modelSet.accession}</DataItemValue>
               <DataItemLabel>Model Version</DataItemLabel>
-              <DataItemValue>{model.model_version}</DataItemValue>
+              <DataItemValue>{modelSet.model_version}</DataItemValue>
               <DataItemLabel>File Set Type</DataItemLabel>
-              <DataItemValue>{model.file_set_type}</DataItemValue>
-              {model.aliases?.length > 0 && (
+              <DataItemValue>{modelSet.file_set_type}</DataItemValue>
+              {modelSet.aliases?.length > 0 && (
                 <>
                   <DataItemLabel>Aliases</DataItemLabel>
                   <DataItemValue>
-                    <AliasList aliases={model.aliases} />
+                    <AliasList aliases={modelSet.aliases} />
                   </DataItemValue>
                 </>
               )}
-              {model.prediction_objects.length > 0 && (
+              {modelSet.prediction_objects.length > 0 && (
                 <>
                   <DataItemLabel>Prediction Objects</DataItemLabel>
                   <DataItemValue>
-                    {model.prediction_objects.join(", ")}
+                    {modelSet.prediction_objects.join(", ")}
                   </DataItemValue>
                 </>
               )}
-              {model.input_file_sets?.length > 0 && (
+              {modelSet.input_file_sets?.length > 0 && (
                 <>
                   <DataItemLabel>Input File Sets</DataItemLabel>
                   <DataItemValue>
                     <SeparatedList>
-                      {model.input_file_sets.map((fileSet) => (
+                      {modelSet.input_file_sets.map((fileSet) => (
                         <Link href={fileSet["@id"]} key={fileSet["@id"]}>
                           {fileSet.accession}
                         </Link>
@@ -86,16 +86,16 @@ export default function Model({
                   </DataItemValue>
                 </>
               )}
-              {model.model_zoo_location && (
+              {modelSet.model_zoo_location && (
                 <>
                   <DataItemLabel>Model Zoo Location</DataItemLabel>
                   <DataItemValue>
                     <a
-                      href={model.model_zoo_location}
+                      href={modelSet.model_zoo_location}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      {model.model_zoo_location}
+                      {modelSet.model_zoo_location}
                     </a>
                   </DataItemValue>
                 </>
@@ -110,11 +110,11 @@ export default function Model({
                   </DataItemValue>
                 </>
               )}
-              {model.publication_identifiers?.length > 0 && (
+              {modelSet.publication_identifiers?.length > 0 && (
                 <>
                   <DataItemLabel>Publication Identifiers</DataItemLabel>
                   <DataItemValue>
-                    <DbxrefList dbxrefs={model.publication_identifiers} />
+                    <DbxrefList dbxrefs={modelSet.publication_identifiers} />
                   </DataItemValue>
                 </>
               )}
@@ -139,9 +139,9 @@ export default function Model({
   );
 }
 
-Model.propTypes = {
-  // Model to display
-  model: PropTypes.object.isRequired,
+ModelSet.propTypes = {
+  // Model Set to display
+  modelSet: PropTypes.object.isRequired,
   // Software version associated with this model
   softwareVersion: PropTypes.object,
   // Files to display
@@ -157,37 +157,37 @@ Model.propTypes = {
 export async function getServerSideProps({ params, req, query }) {
   const isJson = isJsonFormat(query);
   const request = new FetchRequest({ cookie: req.headers.cookie });
-  const model = await request.getObject(`/models/${params.id}/`);
-  if (FetchRequest.isResponseSuccess(model)) {
-    const softwareVersion = model.software_version
-      ? await request.getObject(model.software_version, null)
+  const modelSet = await request.getObject(`/model-sets/${params.id}/`);
+  if (FetchRequest.isResponseSuccess(modelSet)) {
+    const softwareVersion = modelSet.software_version
+      ? await request.getObject(modelSet.software_version, null)
       : null;
-    const documents = model.documents
-      ? await requestDocuments(model.documents, request)
+    const documents = modelSet.documents
+      ? await requestDocuments(modelSet.documents, request)
       : [];
-    const filePaths = model.files.map((file) => file["@id"]);
+    const filePaths = modelSet.files.map((file) => file["@id"]);
     const files =
       filePaths.length > 0 ? await requestFiles(filePaths, request) : [];
 
     const breadcrumbs = await buildBreadcrumbs(
-      model,
-      model.accession,
+      modelSet,
+      modelSet.accession,
       req.headers.cookie
     );
-    const attribution = await buildAttribution(model, req.headers.cookie);
+    const attribution = await buildAttribution(modelSet, req.headers.cookie);
 
     return {
       props: {
-        model,
+        modelSet,
         softwareVersion,
         documents,
         files,
-        pageContext: { title: model.model_name },
+        pageContext: { title: modelSet.model_name },
         breadcrumbs,
         attribution,
         isJson,
       },
     };
   }
-  return errorObjectToProps(model);
+  return errorObjectToProps(modelSet);
 }


### PR DESCRIPTION
The `deprecatedSchemas` change happens because igvfd now no longer has any of these deprecated schemas, so we don’t have to hide them anymore.