### PR TITLE
IGVF-1214 Reduce repeated strings in report cells

### DIFF
--- a/components/report/cell-renderers.js
+++ b/components/report/cell-renderers.js
@@ -15,6 +15,7 @@ import { FileDownload } from "../file-download";
 import SeparatedList from "../separated-list";
 import UnspecifiedProperty from "../unspecified-property";
 // lib
+import { stringsToStringsWithCounts } from "../../lib/arrays";
 import { attachmentToServerHref } from "../../lib/attachment";
 import { API_URL } from "../../lib/constants";
 
@@ -324,8 +325,14 @@ function UnknownObject({ id, source }) {
   for (let i = 0; i < components.length; i += 1) {
     if (Array.isArray(property)) {
       // Extract the specified property component from each element of the array.
-      const embeddedProperties = property.map((item) => item[components[i]]);
-      property = embeddedProperties.filter((item) => item).join(", ");
+      const embeddedProperties = property
+        .map((item) => item[components[i]])
+        .filter((item) => item);
+
+      // In case of repeated values, Display only unique values with their counts.
+      const propertiesWithCounts =
+        stringsToStringsWithCounts(embeddedProperties);
+      property = propertiesWithCounts.join(", ");
     } else {
       // Extract the specified property component from the embedded property.
       property = property[components[i]];

--- a/lib/__tests__/arrays.test.ts
+++ b/lib/__tests__/arrays.test.ts
@@ -1,0 +1,89 @@
+import {
+  CountedString,
+  countedStringsToStringsWithCounts,
+  stringsToCountedStrings,
+  stringsToStringsWithCounts,
+} from "../arrays";
+
+describe("Test countedStringsToStringsWithCounts utility", () => {
+  it("should convert counted strings to strings with counts", () => {
+    const countedStrings: CountedString[] = [
+      { a: 2 },
+      { A: 1 },
+      { b: 2 },
+      { c: 1 },
+    ];
+    const stringsWithCounts = countedStringsToStringsWithCounts(countedStrings);
+    expect(stringsWithCounts).toEqual(["a (2)", "A", "b (2)", "c"]);
+  });
+
+  it("should handle an empty array", () => {
+    const countedStrings: CountedString[] = [];
+    const stringsWithCounts = countedStringsToStringsWithCounts(countedStrings);
+    expect(stringsWithCounts).toEqual([]);
+  });
+
+  it("should handle an array with one element", () => {
+    const countedStrings: CountedString[] = [{ a: 1 }];
+    const stringsWithCounts = countedStringsToStringsWithCounts(countedStrings);
+    expect(stringsWithCounts).toEqual(["a"]);
+  });
+
+  it("should handle an array with one element repeated", () => {
+    const countedStrings: CountedString[] = [{ a: 6 }];
+    const stringsWithCounts = countedStringsToStringsWithCounts(countedStrings);
+    expect(stringsWithCounts).toEqual(["a (6)"]);
+  });
+});
+
+describe("Test stringsToCountedStrings utility", () => {
+  it("should group string arrays and sort them", () => {
+    const strings = ["b", "c", "a", "C", "a", "c", "A", "b", "b"];
+    const grouped = stringsToCountedStrings(strings);
+    expect(grouped).toEqual([{ a: 2 }, { A: 1 }, { b: 3 }, { c: 2 }, { C: 1 }]);
+  });
+
+  it("should handle an empty array", () => {
+    const strings: string[] = [];
+    const grouped = stringsToCountedStrings(strings);
+    expect(grouped).toEqual([]);
+  });
+
+  it("should handle an array with one element", () => {
+    const strings = ["a"];
+    const grouped = stringsToCountedStrings(strings);
+    expect(grouped).toEqual([{ a: 1 }]);
+  });
+
+  it("should handle an array with one element repeated", () => {
+    const strings = ["a", "a", "a", "a", "a", "a"];
+    const grouped = stringsToCountedStrings(strings);
+    expect(grouped).toEqual([{ a: 6 }]);
+  });
+});
+
+describe("Test stringsToStringsWithCounts utility", () => {
+  it("should convert strings to strings with counts", () => {
+    const strings = ["b", "c", "a", "C", "a", "c", "A", "b", "b"];
+    const stringsWithCounts = stringsToStringsWithCounts(strings);
+    expect(stringsWithCounts).toEqual(["a (2)", "A", "b (3)", "c (2)", "C"]);
+  });
+
+  it("should handle an empty array", () => {
+    const strings: string[] = [];
+    const stringsWithCounts = stringsToStringsWithCounts(strings);
+    expect(stringsWithCounts).toEqual([]);
+  });
+
+  it("should handle an array with one element", () => {
+    const strings = ["a"];
+    const stringsWithCounts = stringsToStringsWithCounts(strings);
+    expect(stringsWithCounts).toEqual(["a"]);
+  });
+
+  it("should handle an array with one element repeated", () => {
+    const strings = ["a", "a", "a", "a", "a", "a"];
+    const stringsWithCounts = stringsToStringsWithCounts(strings);
+    expect(stringsWithCounts).toEqual(["a (6)"]);
+  });
+});

--- a/lib/arrays.ts
+++ b/lib/arrays.ts
@@ -1,0 +1,71 @@
+// node_modules
+import _ from "lodash";
+
+/**
+ * Holds a single counted string, with the string as a key and the number of times it appears as
+ * the value.
+ */
+export interface CountedString {
+  [key: string]: number;
+}
+
+/**
+ * Convert a counted string array to an array of those strings followed by their counts in
+ * parentheses. Strings with a count of 1 appear without a count.
+ * Example: [{a: 2}, {A: 1}, {b: 2}, {c: 1}] -> ["a (2)", "A", "b (2)", "c"]
+ * @param {CountedString[]} countedStrings Strings and their corresponding counts
+ * @returns {string[]} Strings with counts in parentheses
+ */
+export function countedStringsToStringsWithCounts(
+  countedStrings: CountedString[]
+): string[] {
+  return countedStrings.map((item) => {
+    const key = Object.keys(item)[0];
+    const value = item[key];
+    if (value === 1) {
+      return key;
+    }
+    return `${key} (${value})`;
+  });
+}
+
+/**
+ * Given an array of strings with possible duplicates, return an array of objects with each
+ * unique string as the key and the number of times it appears in the array as the value. Sort
+ * the objects alphabetically by the string, case insensitive.
+ * Example: ["a", "b", "a", "c", "b", "A"] -> [{a: 2}, {A: 1}, {b: 2}, {c: 1}]
+ * @param {string[]} items Strings to count
+ * @returns {CountedString[]} Strings and their corresponding counts
+ */
+export function stringsToCountedStrings(items: string[]): CountedString[] {
+  const counts: CountedString = {};
+
+  // First build a single object with each string as a key and the number of times it appears as the
+  // value.
+  items.forEach((item) => {
+    if (counts[item]) {
+      counts[item] += 1;
+    } else {
+      counts[item] = 1;
+    }
+  });
+
+  // Sort the strings alphabetically, then map each string to an object with the string as the
+  // key and the number of times it appears as the value.
+  const uniqueSortedStrings = _.sortBy(Object.keys(counts), [
+    (str) => str.toLowerCase(),
+  ]);
+  return uniqueSortedStrings.map((item) => ({ [item]: counts[item] }));
+}
+
+/**
+ * Convert an array of strings with possible duplicates to an array of strings with duplicates
+ * removed, followed by their counts in parentheses. Strings with a count of 1 appear without a
+ * count.
+ * Example: ["a", "b", "a", "c", "b", "A"] -> ["a (2)", "A", "b (2)", "c"]
+ * @param {string[]} items Strings to count
+ * @returns {string[]} Strings with counts in parentheses
+ */
+export function stringsToStringsWithCounts(items: string[]): string[] {
+  return countedStringsToStringsWithCounts(stringsToCountedStrings(items));
+}


### PR DESCRIPTION
Other code can show arrays of strings, but all strings arrays in the schemas have `uniqueItems` set, so they don’t need this. The only cells that can have repeated strings use `UnknownObject`.