### PR TITLE
IGVF-1253 Login help on 403 and no-result pages

### DIFF
--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,6 +53,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
+            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,7 +53,6 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/components/__tests__/error.test.js
+++ b/components/__tests__/error.test.js
@@ -1,8 +1,18 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
+import { useAuth0 } from "@auth0/auth0-react";
 import Error from "../error";
 
-describe("Test the Error component", () => {
+jest.mock("@auth0/auth0-react", () => ({
+  useAuth0: jest.fn(),
+}));
+
+describe("Test the Error component while logged out", () => {
   it("should render the error page with a status code and title", () => {
+    useAuth0.mockReturnValueOnce({
+      isAuthenticated: false,
+      loginWithRedirect: jest.fn(),
+    });
+
     render(
       <Error
         statusCode="AUTHENTICATION"
@@ -16,26 +26,87 @@ describe("Test the Error component", () => {
         "Unable to sign in. You can still explore the site without viewing unreleased data."
       )
     ).toBeInTheDocument();
+    expect(screen.queryByTestId("error-login")).not.toBeInTheDocument();
   });
 
   it("should render the error page with a status code and no title", () => {
+    useAuth0.mockReturnValueOnce({
+      isAuthenticated: false,
+      loginWithRedirect: jest.fn(),
+    });
+
     render(<Error statusCode={401} />);
 
     expect(screen.getByText("401")).toBeInTheDocument();
     expect(screen.queryByTestId("error-title")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("error-login")).not.toBeInTheDocument();
+  });
+
+  it("should render the error page with 403 status, title, and login help", () => {
+    const loginWithRedirect = jest.fn();
+    useAuth0.mockReturnValueOnce({
+      isAuthenticated: false,
+      loginWithRedirect,
+    });
+
+    render(
+      <Error statusCode={403} title="Access was denied to this resource" />
+    );
+
+    const title = screen.getByTestId("error-title");
+    const loginHelp = screen.getByTestId("error-login");
+    expect(screen.getByText("403")).toBeInTheDocument();
+    expect(title).toBeInTheDocument();
+    expect(loginHelp).toBeInTheDocument();
+    expect(within(loginHelp).getByText("sign in"));
+
+    screen.getByRole("button").click();
+    expect(loginWithRedirect).toHaveBeenCalled();
   });
 
   it("should render the error page with no status code and a title", () => {
+    useAuth0.mockReturnValueOnce({
+      isAuthenticated: false,
+      loginWithRedirect: jest.fn(),
+    });
+
     render(<Error title="Unable to sign in." />);
 
     expect(screen.getByText("ERROR")).toBeInTheDocument();
     expect(screen.getByText("Unable to sign in.")).toBeInTheDocument();
+    expect(screen.queryByTestId("error-login")).not.toBeInTheDocument();
   });
 
   it("should render the error page with no status code and no title", () => {
+    useAuth0.mockReturnValueOnce({
+      isAuthenticated: false,
+      loginWithRedirect: jest.fn(),
+    });
+
     render(<Error />);
 
     expect(screen.getByText("ERROR")).toBeInTheDocument();
     expect(screen.queryByTestId("error-title")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("error-login")).not.toBeInTheDocument();
+  });
+});
+
+describe("Test the Error component while logged in", () => {
+  it("should render the error page with 403 status, title, and no login help", () => {
+    const loginWithRedirect = jest.fn();
+    useAuth0.mockReturnValueOnce({
+      isAuthenticated: true,
+      loginWithRedirect,
+    });
+
+    render(
+      <Error statusCode={403} title="Access was denied to this resource" />
+    );
+
+    const title = screen.getByTestId("error-title");
+    const loginHelp = screen.queryByTestId("error-login");
+    expect(screen.getByText("403")).toBeInTheDocument();
+    expect(title).toBeInTheDocument();
+    expect(loginHelp).toBeNull();
   });
 });

--- a/components/error.js
+++ b/components/error.js
@@ -1,11 +1,13 @@
 // node_modules
 import { useAuth0 } from "@auth0/auth0-react";
+import Link from "next/link";
 import PropTypes from "prop-types";
 import { HTTP_STATUS_CODE } from "../lib/fetch-request";
 // components
 import { ButtonAsLink } from "./form-elements";
 // lib
 import { loginAuthProvider } from "../lib/authentication";
+import { LINK_INLINE_STYLE } from "../lib/constants";
 
 /**
  * Display the contents of a standard error page.
@@ -30,14 +32,22 @@ export default function Error({ statusCode = "ERROR", title = "" }) {
           <div className="mt-4 border-t border-gray-300 pt-2 text-sm font-normal dark:border-gray-500">
             {title && <h2 data-testid="error-title">{title}</h2>}
             {isLoginHelpVisible && (
-              <p className="mt-4" data-testid="error-login">
+              <p className="mt-4 text-left md:w-96" data-testid="error-login">
                 Please{" "}
                 <ButtonAsLink
                   onClick={() => loginAuthProvider(loginWithRedirect)}
                 >
                   sign in
                 </ButtonAsLink>{" "}
-                if you believe you should have access to this page
+                if you believe you should have access to this page. See the
+                instructions for{" "}
+                <Link
+                  href="/help/general-help/accessing-unreleased-data/"
+                  className={LINK_INLINE_STYLE}
+                >
+                  accessing unreleased data
+                </Link>{" "}
+                for more information.
               </p>
             )}
           </div>

--- a/components/error.js
+++ b/components/error.js
@@ -1,10 +1,22 @@
 // node_modules
+import { useAuth0 } from "@auth0/auth0-react";
 import PropTypes from "prop-types";
+import { HTTP_STATUS_CODE } from "../lib/fetch-request";
+// components
+import { ButtonAsLink } from "./form-elements";
+// lib
+import { loginAuthProvider } from "../lib/authentication";
 
 /**
  * Display the contents of a standard error page.
  */
 export default function Error({ statusCode = "ERROR", title = "" }) {
+  const { isAuthenticated, loginWithRedirect } = useAuth0();
+
+  // Login help should appear if the status code is 403 and the user has not logged in.
+  const isLoginHelpVisible =
+    !isAuthenticated && statusCode === HTTP_STATUS_CODE.FORBIDDEN;
+
   return (
     <div className="flex h-screen flex-col items-center justify-center">
       <div className="text-center">
@@ -14,13 +26,21 @@ export default function Error({ statusCode = "ERROR", title = "" }) {
         >
           {statusCode}
         </h1>
-        {title && (
-          <h2
-            data-testid="error-title"
-            className="mt-4 border-t border-gray-300 pt-2 text-sm font-normal dark:border-gray-500"
-          >
-            {title}
-          </h2>
+        {(title || isLoginHelpVisible) && (
+          <div className="mt-4 border-t border-gray-300 pt-2 text-sm font-normal dark:border-gray-500">
+            {title && <h2 data-testid="error-title">{title}</h2>}
+            {isLoginHelpVisible && (
+              <p className="mt-4" data-testid="error-login">
+                Please{" "}
+                <ButtonAsLink
+                  onClick={() => loginAuthProvider(loginWithRedirect)}
+                >
+                  sign in
+                </ButtonAsLink>{" "}
+                if you believe you should have access to this page
+              </p>
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/components/form-elements/button.js
+++ b/components/form-elements/button.js
@@ -22,6 +22,8 @@
 import Link from "next/link";
 import PropTypes from "prop-types";
 import React from "react";
+// lib
+import { LINK_INLINE_STYLE } from "../../lib/constants";
 
 /**
  * Tailwind CSS classes common to all buttons; both <Button> and <ButtonLink> types.
@@ -286,7 +288,7 @@ export function ButtonAsLink({ onClick, children }) {
     <button
       type="button"
       onClick={onClick}
-      className="inline font-medium underline"
+      className={`inline ${LINK_INLINE_STYLE}`}
     >
       {children}
     </button>

--- a/components/form-elements/button.js
+++ b/components/form-elements/button.js
@@ -277,3 +277,23 @@ AttachedButtons.propTypes = {
   // Additional Tailwind CSS classes to apply to the wrapper element
   className: PropTypes.string,
 };
+
+/**
+ * Renders a button that appears like a link. Best used for buttons that appear inline with text.
+ */
+export function ButtonAsLink({ onClick, children }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline font-medium underline"
+    >
+      {children}
+    </button>
+  );
+}
+
+ButtonAsLink.propTypes = {
+  // Called when the button is clicked
+  onClick: PropTypes.func.isRequired,
+};

--- a/components/form-elements/index.js
+++ b/components/form-elements/index.js
@@ -1,4 +1,4 @@
-import { AttachedButtons, Button, ButtonLink } from "./button";
+import { AttachedButtons, Button, ButtonAsLink, ButtonLink } from "./button";
 import FormLabel from "./form-label";
 import ListSelect from "./list-select";
 import RadioButton from "./radio-button";
@@ -8,6 +8,7 @@ import TextField from "./text-field";
 export {
   AttachedButtons,
   Button,
+  ButtonAsLink,
   ButtonLink,
   FormLabel,
   ListSelect,

--- a/components/no-collection-data.js
+++ b/components/no-collection-data.js
@@ -1,5 +1,6 @@
 // node_modules
 import { useAuth0 } from "@auth0/auth0-react";
+import Link from "next/link";
 import PropTypes from "prop-types";
 import { useContext } from "react";
 // components
@@ -8,6 +9,7 @@ import { ButtonAsLink } from "./form-elements";
 import GlobalContext from "./global-context";
 // lib
 import { loginAuthProvider } from "../lib/authentication";
+import { LINK_INLINE_STYLE } from "../lib/constants";
 
 /**
  * Display a message on a collection page indicating that no viewable collection data exists.
@@ -18,16 +20,22 @@ export default function NoCollectionData({ pageTitle = "" }) {
 
   return (
     <DataPanel className="my-0.5">
-      <div className="text-center italic">
-        No {pageTitle || page.title} to display
-      </div>
+      <div className="italic">No {pageTitle || page.title} to display.</div>
       {!isAuthenticated && (
-        <p className="mt-4 text-center text-sm">
+        <p className="mt-4 text-sm">
           Please{" "}
           <ButtonAsLink onClick={() => loginAuthProvider(loginWithRedirect)}>
             sign in
           </ButtonAsLink>{" "}
-          if you believe you should see {pageTitle || page.title}
+          if you believe you should see {pageTitle || page.title}. See the
+          instructions for{" "}
+          <Link
+            href="/help/general-help/accessing-unreleased-data/"
+            className={LINK_INLINE_STYLE}
+          >
+            accessing unreleased data
+          </Link>{" "}
+          for more information.
         </p>
       )}
     </DataPanel>
@@ -36,5 +44,5 @@ export default function NoCollectionData({ pageTitle = "" }) {
 
 NoCollectionData.propTypes = {
   // Page title to display in the message if not using pageTitle props from getServerSideProps()
-  pageTitle: PropTypes.string,
+  pageTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 };

--- a/components/no-collection-data.js
+++ b/components/no-collection-data.js
@@ -1,21 +1,35 @@
 // node_modules
+import { useAuth0 } from "@auth0/auth0-react";
 import PropTypes from "prop-types";
 import { useContext } from "react";
 // components
 import { DataPanel } from "./data-area";
+import { ButtonAsLink } from "./form-elements";
 import GlobalContext from "./global-context";
+// lib
+import { loginAuthProvider } from "../lib/authentication";
 
 /**
  * Display a message on a collection page indicating that no viewable collection data exists.
  */
 export default function NoCollectionData({ pageTitle = "" }) {
   const { page } = useContext(GlobalContext);
+  const { isAuthenticated, loginWithRedirect } = useAuth0();
 
   return (
     <DataPanel className="my-0.5">
       <div className="text-center italic">
         No {pageTitle || page.title} to display
       </div>
+      {!isAuthenticated && (
+        <p className="mt-4 text-center text-sm">
+          Please{" "}
+          <ButtonAsLink onClick={() => loginAuthProvider(loginWithRedirect)}>
+            sign in
+          </ButtonAsLink>{" "}
+          if you believe you should see {pageTitle || page.title}
+        </p>
+      )}
     </DataPanel>
   );
 }

--- a/cypress/e2e/login-help.cy.js
+++ b/cypress/e2e/login-help.cy.js
@@ -1,0 +1,68 @@
+/// <reference types="cypress" />
+
+describe("Make sure the login help appears in the correct situations", () => {
+  it("shows the login help text when viewing a protected page while signed out", () => {
+    cy.visit("/documents/c7870a38-4286-42fc-9551-22436306e22a/");
+    cy.contains("Access was denied to this resource");
+    cy.contains(
+      "Please sign in if you believe you should have access to this page"
+    );
+  });
+
+  it("shows the login help when viewing no search results while signed out", () => {
+    cy.visit("/search/?type=File&accession=INVALID");
+    cy.contains("No list items to display");
+    cy.contains("Please sign in if you believe you should see list items");
+  });
+
+  it("does not show the login help when viewing no search results while signed in", () => {
+    cy.loginAuth0(Cypress.env("AUTH_USERNAME"), Cypress.env("AUTH_PASSWORD"));
+    cy.contains("Cypress Testing");
+    cy.wait(1000);
+
+    cy.visit("/search/?type=File&accession=INVALID");
+    cy.contains("No list items to display");
+    cy.contains(
+      "Please sign in if you believe you should see list items"
+    ).should("not.exist");
+  });
+
+  it("shows the login help when viewing no site-search results while signed out", () => {
+    cy.visit("/site-search/?term=abcdefg");
+    cy.contains("No matching items to display");
+    cy.contains("Please sign in if you believe you should see matching items");
+  });
+
+  it("does not show the login help when viewing no site-search results while signed in", () => {
+    cy.loginAuth0(Cypress.env("AUTH_USERNAME"), Cypress.env("AUTH_PASSWORD"));
+    cy.contains("Cypress Testing");
+    cy.wait(1000);
+
+    cy.visit("/site-search/?term=abcdefg");
+    cy.contains("No matching items to display");
+    cy.contains(
+      "Please sign in if you believe you should see matching items"
+    ).should("not.exist");
+  });
+
+  it("shows the login help when viewing no id search results while signed out", () => {
+    cy.visit("/");
+    cy.get(`[data-testid="id-search-trigger"]`).click();
+    cy.get(`[data-testid="search-input"]`).type("abcdefg{enter}");
+    cy.contains("No items with the identifier “abcdefg” to display");
+    cy.contains(
+      "Please sign in if you believe you should see items with the identifier “abcdefg”"
+    );
+  });
+
+  it("does not show the login help when viewing no id search results while signed in", () => {
+    cy.loginAuth0(Cypress.env("AUTH_USERNAME"), Cypress.env("AUTH_PASSWORD"));
+    cy.contains("Cypress Testing");
+    cy.wait(1000);
+
+    cy.get(`[data-testid="id-search-trigger"]`).click();
+    cy.get(`[data-testid="search-input"]`).type("abcdefg{enter}");
+    cy.contains("No items with the identifier “abcdefg” to display");
+    cy.contains("Please sign in").should("not.exist");
+  });
+});

--- a/cypress/e2e/login-help.cy.js
+++ b/cypress/e2e/login-help.cy.js
@@ -49,9 +49,9 @@ describe("Make sure the login help appears in the correct situations", () => {
     cy.visit("/");
     cy.get(`[data-testid="id-search-trigger"]`).click();
     cy.get(`[data-testid="search-input"]`).type("abcdefg{enter}");
-    cy.contains("No items with the identifier “abcdefg” to display");
+    cy.contains("No items with the identifier abcdefg to display");
     cy.contains(
-      "Please sign in if you believe you should see items with the identifier “abcdefg”"
+      "Please sign in if you believe you should see items with the identifier abcdefg"
     );
   });
 
@@ -62,7 +62,7 @@ describe("Make sure the login help appears in the correct situations", () => {
 
     cy.get(`[data-testid="id-search-trigger"]`).click();
     cy.get(`[data-testid="search-input"]`).type("abcdefg{enter}");
-    cy.contains("No items with the identifier “abcdefg” to display");
+    cy.contains("No items with the identifier abcdefg to display");
     cy.contains("Please sign in").should("not.exist");
   });
 });

--- a/cypress/e2e/site-id-search.cy.js
+++ b/cypress/e2e/site-id-search.cy.js
@@ -109,7 +109,7 @@ describe("Test ID search", () => {
     cy.visit("/");
     cy.get(`[data-testid="id-search-trigger"]`).click();
     cy.get(`[data-testid="search-input"]`).type("abcdefg{enter}");
-    cy.contains("No item with the identifier “abcdefg” to display");
+    cy.contains("No items with the identifier “abcdefg” to display");
   });
 
   it("remembers past search terms and lets the user select them", () => {

--- a/cypress/e2e/site-id-search.cy.js
+++ b/cypress/e2e/site-id-search.cy.js
@@ -109,7 +109,7 @@ describe("Test ID search", () => {
     cy.visit("/");
     cy.get(`[data-testid="id-search-trigger"]`).click();
     cy.get(`[data-testid="search-input"]`).type("abcdefg{enter}");
-    cy.contains("No items with the identifier “abcdefg” to display");
+    cy.contains("No items with the identifier abcdefg to display");
   });
 
   it("remembers past search terms and lets the user select them", () => {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,32 +3,56 @@ import getConfig from "next/config";
 
 const { serverRuntimeConfig, publicRuntimeConfig } = getConfig();
 
-// igvf-ui NextJS server URL
+/**
+ * igvf-ui NextJS server URL
+ */
 export const SERVER_URL = publicRuntimeConfig.SERVER_URL;
-// igvfd server URL
+
+/**
+ * igvfd server URL
+ */
 export const API_URL = publicRuntimeConfig.PUBLIC_BACKEND_URL;
-// Docker internal network URL
+
+/**
+ * Docker internal network URL
+ */
 export const BACKEND_URL = serverRuntimeConfig.BACKEND_URL;
 
-// igvf-ui version number
+/**
+ * igvf-ui version number
+ */
 export const UI_VERSION = publicRuntimeConfig.UI_VERSION;
 
-// Auth0
+/**
+ * Auth0
+ */
 export const AUTH0_CLIENT_ID = "xaO8MMn04qlT3TUnhczmKWZgBzqRySDm";
 export const AUTH0_ISSUER_BASE_DOMAIN = "igvf-dacc.us.auth0.com";
 export const AUTH0_AUDIENCE = "https://igvf-dacc.us.auth0.com/api/v2/";
 
-// Site title
+/**
+ * Site title
+ */
 export const SITE_TITLE = "IGVF";
-// Brand color
+
+/**
+ * Brand color
+ */
 export const BRAND_COLOR = "#337788";
-// Path for authorization error page
+
+/**
+ * Path for authorization error page
+ */
 export const AUTH_ERROR_URI = "/auth-error";
 
-// List of `@type`s to ignore. This needs updating when deprecated schemas get removed from igvfd.
+/**
+ * List of `@type`s to ignore. This needs updating when deprecated schemas get removed from igvfd.
+ */
 export const deprecatedSchemas = [];
 
-// UNICODE entity codes, needed in JSX string templates. Each property named after the equivalent
+/**
+ * UNICODE entity codes, needed in JSX string templates. Each property named after the equivalent
+ */
 // HTML entity. Add new entries to this object as needed.
 export const UC = {
   newline: "\u000A", // newline
@@ -45,7 +69,9 @@ export const UC = {
   cmd: "\u2318", // Place of interest, command key
 };
 
-// Keyboard event key codes.
+/**
+ * Keyboard event key codes.
+ */
 export const KC = {
   TAB: 9,
   RETURN: 13,
@@ -53,5 +79,12 @@ export const KC = {
   SPACE: 32,
 };
 
-// Maximum number of characters in the URL, minus an arbitrary amount for the domain name.
+/**
+ * Maximum number of characters in the URL, minus an arbitrary amount for the domain name.
+ */
 export const MAX_URL_LENGTH = 4000;
+
+/**
+ * Default inline text styles for links.
+ */
+export const LINK_INLINE_STYLE = "font-medium underline";

--- a/package-lock.json
+++ b/package-lock.json
@@ -193,30 +193,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
-      "integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
+      "integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
-      "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
+      "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/generator": "^7.23.3",
         "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.23.0",
+        "@babel/helper-module-transforms": "^7.23.3",
         "@babel/helpers": "^7.23.2",
-        "@babel/parser": "^7.23.0",
+        "@babel/parser": "^7.23.3",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0",
+        "@babel/traverse": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -241,12 +241,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
+      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.0",
+        "@babel/types": "^7.23.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
-      "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -496,9 +496,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
+      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -568,9 +568,9 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-      "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
+      "integrity": "sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -670,9 +670,9 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.22.5.tgz",
-      "integrity": "sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
+      "integrity": "sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -710,19 +710,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
+      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/generator": "^7.23.3",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
+        "@babel/parser": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -740,9 +740,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
+      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
@@ -1730,9 +1730,9 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.0.0.tgz",
-      "integrity": "sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.1.0.tgz",
+      "integrity": "sha512-hcvfZEEyO0xQoZeHmUbuMs7APJCGELpilL7bY+BaJaMP57aWc6q1etFwScnoZDheYjk4ESdlzPdQ33IbsKAK/A==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -1998,15 +1998,15 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.10.0.tgz",
-      "integrity": "sha512-uoLj4g2OTL8rfUQVx2AFO1hp/zja1wABJq77P6IclQs6I/m9GLrm7jCdgzZkvWdDCQf1uEvoa8s8CupsgWQgVg==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.11.0.tgz",
+      "integrity": "sha512-uXnpZDc4VRjY4iuypDBKzW1rz9T5YBBK0snMn8MaTSNd2kMlj50LnLBABELjJiOL5YHk7ZD8hbSpI9ubzqYI0w==",
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.10.0",
-        "@typescript-eslint/type-utils": "6.10.0",
-        "@typescript-eslint/utils": "6.10.0",
-        "@typescript-eslint/visitor-keys": "6.10.0",
+        "@typescript-eslint/scope-manager": "6.11.0",
+        "@typescript-eslint/type-utils": "6.11.0",
+        "@typescript-eslint/utils": "6.11.0",
+        "@typescript-eslint/visitor-keys": "6.11.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -2032,14 +2032,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.10.0.tgz",
-      "integrity": "sha512-+sZwIj+s+io9ozSxIWbNB5873OSdfeBEH/FR0re14WLI6BaKuSOnnwCJ2foUiu8uXf4dRp1UqHP0vrZ1zXGrog==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.11.0.tgz",
+      "integrity": "sha512-+whEdjk+d5do5nxfxx73oanLL9ghKO3EwM9kBCkUtWMRwWuPaFv9ScuqlYfQ6pAD6ZiJhky7TZ2ZYhrMsfMxVQ==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.10.0",
-        "@typescript-eslint/types": "6.10.0",
-        "@typescript-eslint/typescript-estree": "6.10.0",
-        "@typescript-eslint/visitor-keys": "6.10.0",
+        "@typescript-eslint/scope-manager": "6.11.0",
+        "@typescript-eslint/types": "6.11.0",
+        "@typescript-eslint/typescript-estree": "6.11.0",
+        "@typescript-eslint/visitor-keys": "6.11.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2059,12 +2059,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.10.0.tgz",
-      "integrity": "sha512-TN/plV7dzqqC2iPNf1KrxozDgZs53Gfgg5ZHyw8erd6jd5Ta/JIEcdCheXFt9b1NYb93a1wmIIVW/2gLkombDg==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.11.0.tgz",
+      "integrity": "sha512-0A8KoVvIURG4uhxAdjSaxy8RdRE//HztaZdG8KiHLP8WOXSk0vlF7Pvogv+vlJA5Rnjj/wDcFENvDaHb+gKd1A==",
       "dependencies": {
-        "@typescript-eslint/types": "6.10.0",
-        "@typescript-eslint/visitor-keys": "6.10.0"
+        "@typescript-eslint/types": "6.11.0",
+        "@typescript-eslint/visitor-keys": "6.11.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2075,12 +2075,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.10.0.tgz",
-      "integrity": "sha512-wYpPs3hgTFblMYwbYWPT3eZtaDOjbLyIYuqpwuLBBqhLiuvJ+9sEp2gNRJEtR5N/c9G1uTtQQL5AhV0fEPJYcg==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.11.0.tgz",
+      "integrity": "sha512-nA4IOXwZtqBjIoYrJcYxLRO+F9ri+leVGoJcMW1uqr4r1Hq7vW5cyWrA43lFbpRvQ9XgNrnfLpIkO3i1emDBIA==",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.10.0",
-        "@typescript-eslint/utils": "6.10.0",
+        "@typescript-eslint/typescript-estree": "6.11.0",
+        "@typescript-eslint/utils": "6.11.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -2101,9 +2101,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.10.0.tgz",
-      "integrity": "sha512-36Fq1PWh9dusgo3vH7qmQAj5/AZqARky1Wi6WpINxB6SkQdY5vQoT2/7rW7uBIsPDcvvGCLi4r10p0OJ7ITAeg==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.11.0.tgz",
+      "integrity": "sha512-ZbEzuD4DwEJxwPqhv3QULlRj8KYTAnNsXxmfuUXFCxZmO6CF2gM/y+ugBSAQhrqaJL3M+oe4owdWunaHM6beqA==",
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
       },
@@ -2113,12 +2113,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.10.0.tgz",
-      "integrity": "sha512-ek0Eyuy6P15LJVeghbWhSrBCj/vJpPXXR+EpaRZqou7achUWL8IdYnMSC5WHAeTWswYQuP2hAZgij/bC9fanBg==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.11.0.tgz",
+      "integrity": "sha512-Aezzv1o2tWJwvZhedzvD5Yv7+Lpu1by/U1LZ5gLc4tCx8jUmuSCMioPFRjliN/6SJIvY6HpTtJIWubKuYYYesQ==",
       "dependencies": {
-        "@typescript-eslint/types": "6.10.0",
-        "@typescript-eslint/visitor-keys": "6.10.0",
+        "@typescript-eslint/types": "6.11.0",
+        "@typescript-eslint/visitor-keys": "6.11.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2139,16 +2139,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.10.0.tgz",
-      "integrity": "sha512-v+pJ1/RcVyRc0o4wAGux9x42RHmAjIGzPRo538Z8M1tVx6HOnoQBCX/NoadHQlZeC+QO2yr4nNSFWOoraZCAyg==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.11.0.tgz",
+      "integrity": "sha512-p23ibf68fxoZy605dc0dQAEoUsoiNoP3MD9WQGiHLDuTSOuqoTsa4oAy+h3KDkTcxbbfOtUjb9h3Ta0gT4ug2g==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.10.0",
-        "@typescript-eslint/types": "6.10.0",
-        "@typescript-eslint/typescript-estree": "6.10.0",
+        "@typescript-eslint/scope-manager": "6.11.0",
+        "@typescript-eslint/types": "6.11.0",
+        "@typescript-eslint/typescript-estree": "6.11.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -2163,11 +2163,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.10.0.tgz",
-      "integrity": "sha512-xMGluxQIEtOM7bqFCo+rCMh5fqI+ZxV5RUUOa29iVPz1OgCZrtc7rFnz5cLUazlkPKYqX+75iuDq7m0HQ48nCg==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.11.0.tgz",
+      "integrity": "sha512-+SUN/W7WjBr05uRxPggJPSzyB8zUpaYo2hByKasWbqr3PM8AXfZt8UHdNpBS1v9SA62qnSSMF3380SwDqqprgQ==",
       "dependencies": {
-        "@typescript-eslint/types": "6.10.0",
+        "@typescript-eslint/types": "6.11.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -2592,13 +2592,13 @@
       }
     },
     "node_modules/auth0-js": {
-      "version": "9.23.2",
-      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.23.2.tgz",
-      "integrity": "sha512-RiUBalXymeGjF0Ap/IyjKnsILO44eaFrSJDqchox6wUUWnJATGjEQLMTLzjWn8R1wZVKBGu1Fv7PPSViWhcYVQ==",
+      "version": "9.23.3",
+      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.23.3.tgz",
+      "integrity": "sha512-VVh3/1SiECWlwDU3XQ3Xhg40W9Buu18jYZYO93PEerApacm508v67SxBLKh5WeCGaqCUyPamU+NusguhWVn1Qw==",
       "dev": true,
       "dependencies": {
         "base64-js": "^1.5.1",
-        "idtoken-verifier": "^2.2.2",
+        "idtoken-verifier": "^2.2.4",
         "js-cookie": "^2.2.0",
         "minimist": "^1.2.5",
         "qs": "^6.10.1",
@@ -3017,9 +3017,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001561",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz",
-      "integrity": "sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==",
+      "version": "1.0.30001562",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz",
+      "integrity": "sha512-kfte3Hym//51EdX4239i+Rmp20EsLIYGdPkERegTgU19hQWCRhsRFGKHTliUlsry53tv17K7n077Kqa0WJU4ng==",
       "funding": [
         {
           "type": "opencollective",
@@ -3506,9 +3506,9 @@
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/cypress": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.4.0.tgz",
-      "integrity": "sha512-KeWNC9xSHG/ewZURVbaQsBQg2mOKw4XhjJZFKjWbEjgZCdxpPXLpJnfq5Jns1Gvnjp6AlnIfpZfWFlDgVKXdWQ==",
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.5.0.tgz",
+      "integrity": "sha512-oh6U7h9w8wwHfzNDJQ6wVcAeXu31DlIYlNOBvfd6U4CcB8oe4akawQmH+QJVOMZlM42eBoCne015+svVqdwdRQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3664,14 +3664,14 @@
       }
     },
     "node_modules/deep-equal": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
-      "integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.5",
         "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.1",
+        "get-intrinsic": "^1.2.2",
         "is-arguments": "^1.1.1",
         "is-array-buffer": "^3.0.2",
         "is-date-object": "^1.0.5",
@@ -3681,11 +3681,14 @@
         "object-is": "^1.1.5",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.0",
+        "regexp.prototype.flags": "^1.5.1",
         "side-channel": "^1.0.4",
         "which-boxed-primitive": "^1.0.2",
         "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.9"
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3862,9 +3865,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.578",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.578.tgz",
-      "integrity": "sha512-V0ZhSu1BQZKfG0yNEL6Dadzik8E1vAzfpVOapdSiT9F6yapEJ3Bk+4tZ4SMPdWiUchCgnM/ByYtBzp5ntzDMIA==",
+      "version": "1.4.582",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.582.tgz",
+      "integrity": "sha512-89o0MGoocwYbzqUUjc+VNpeOFSOK9nIdC5wY4N+PVUarUK0MtjyTjks75AZS2bW4Kl8MdewdFsWaH0jLy+JNoA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4485,9 +4488,9 @@
       }
     },
     "node_modules/eslint-plugin-testing-library": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.1.0.tgz",
-      "integrity": "sha512-r7kE+az3tbp8vyRwfyAGZ6V/xw+XvdWFPicIo6jbOPZoossOFDeHizARqPGV6gEkyF8hyCFhhH3mlQOGS3N5Sg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.1.2.tgz",
+      "integrity": "sha512-Ra16FeBlonfbScOIdZEta9o+OxtwDqiUt+4UCpIM42TuatyLdtfU/SbwnIzPcAszrbl58PGwyZ9YGU9dwIo/tA==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.58.0"
@@ -4991,16 +4994,16 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.1.tgz",
-      "integrity": "sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
     "node_modules/flatted": {
@@ -5068,9 +5071,9 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "10.16.4",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.4.tgz",
-      "integrity": "sha512-p9V9nGomS3m6/CALXqv6nFGMuFOxbWsmaOrdmhyQimMIlLl3LC7h7l86wge/Js/8cRu5ktutS/zlzgR7eBOtFA==",
+      "version": "10.16.5",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.5.tgz",
+      "integrity": "sha512-GEzVjOYP2MIpV9bT/GbhcsBNoImG3/2X3O/xVNWmktkv9MdJ7P/44zELm/7Fjb+O3v39SmKFnoDQB32giThzpg==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -6123,9 +6126,9 @@
       "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.1.tgz",
-      "integrity": "sha512-opCrKqbthmq3SKZ10mFMQG9dk3fTa3quaOLD35kJa5ejwZHd9xAr+kLuziiZz2cG32s4lMZxNdmdcEQnTDP4+g==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -7437,9 +7440,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "9.1.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.5.tgz",
-      "integrity": "sha512-14QG3shv8Kg/xc0Yh6TNkMj90wXH9mmldi5941I2OevfJ/FQAFLEwtwU2/FfgSAOMlWHrEukWSGQf8MiVYNG2A==",
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+      "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -8281,9 +8284,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -8296,9 +8299,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.6.tgz",
-      "integrity": "sha512-2Xgb+GQlkPAUCFi3sV+NOYcSI5XgduvDBL2Zt/hwJudeKXkyvRS65c38SB0yb9UB40+1rL83I6m0RtlOQ8eHdg==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.7.tgz",
+      "integrity": "sha512-4v6uESAgwCni6YF6DwJlRaDjg9Z+al5zM4JfngcazMy4WEf/XkPS5TEQjbD+DZ5iNuG6RrKQLa/HuX2SYzC3kQ==",
       "dev": true,
       "engines": {
         "node": ">=14.21.3"

--- a/pages/id-search.js
+++ b/pages/id-search.js
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 import NoCollectionData from "../components/no-collection-data";
 import PagePreamble from "../components/page-preamble";
 // lib
-import { UC } from "../lib/constants";
 import FetchRequest from "../lib/fetch-request";
 
 /**

--- a/pages/id-search.js
+++ b/pages/id-search.js
@@ -14,7 +14,7 @@ import FetchRequest from "../lib/fetch-request";
  */
 export default function IdSearch({ id }) {
   const errorText = id
-    ? `item with the identifier ${UC.ldquo}${id}${UC.rdquo}`
+    ? `items with the identifier ${UC.ldquo}${id}${UC.rdquo}`
     : "item";
   return (
     <>

--- a/pages/id-search.js
+++ b/pages/id-search.js
@@ -13,9 +13,13 @@ import FetchRequest from "../lib/fetch-request";
  * object with that ID, then this page renders with an error message.
  */
 export default function IdSearch({ id }) {
-  const errorText = id
-    ? `items with the identifier ${UC.ldquo}${id}${UC.rdquo}`
-    : "item";
+  const errorText = id ? (
+    <span>
+      items with the identifier <strong>{id}</strong>
+    </span>
+  ) : (
+    "item"
+  );
   return (
     <>
       <PagePreamble />


### PR DESCRIPTION
* Update npm packages.
* Add login text to the error page if the error is 403 and the user hasn’t logged in.
* Reword help tips so they make sense for search-id pages.
* Update npm packages after rebase with dev.
* Add Jest tests for testing the existence of the help tip message on a 403 page.
* Update text comparison of site-id-search Cypress test.
* Add Cypress tests for the login help.
* Temporarily point the UI demo at the igvfd dev demo.
* Make a standard component for buttons that look like links.