### PR TITLE
IGVF-418 Display live indexing state

### DIFF
--- a/components/__tests__/indexer-state.test.js
+++ b/components/__tests__/indexer-state.test.js
@@ -1,0 +1,343 @@
+import {
+  act,
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import GlobalContext from "../global-context";
+import IndexerState from "../indexer-state";
+import SessionContext from "../session-context";
+import { useTooltip } from "../tooltip";
+
+describe("Test the expanded IndexerState component", () => {
+  it("renders the expanded IndexerState component while indexed", async () => {
+    const indexerState = {
+      indexingCount: 0,
+      isIndexing: false,
+    };
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(indexerState),
+      })
+    );
+
+    function IndexerStateTester() {
+      const tooltipAttr = useTooltip("indexer-state");
+
+      const globalContext = {
+        indexerStateTooltip: tooltipAttr,
+      };
+
+      return (
+        <GlobalContext.Provider value={globalContext}>
+          <IndexerState />
+        </GlobalContext.Provider>
+      );
+    }
+
+    await act(async () => render(<IndexerStateTester />));
+
+    const indexerStateBadge = screen.getByTestId("indexer-state-expanded");
+    expect(indexerStateBadge).toBeInTheDocument();
+    expect(indexerStateBadge).toHaveTextContent("INDEXED");
+  });
+
+  it("renders the expanded IndexerState component while indexing", async () => {
+    const indexerState = {
+      indexingCount: 40_000,
+      isIndexing: true,
+    };
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(indexerState),
+      })
+    );
+
+    function IndexerStateTester() {
+      const tooltipAttr = useTooltip("indexer-state");
+
+      const globalContext = {
+        indexerStateTooltip: tooltipAttr,
+      };
+
+      return (
+        <GlobalContext.Provider value={globalContext}>
+          <IndexerState />
+        </GlobalContext.Provider>
+      );
+    }
+
+    await act(async () => render(<IndexerStateTester />));
+
+    const indexerStateBadge = screen.getByTestId("indexer-state-expanded");
+    expect(indexerStateBadge).toBeInTheDocument();
+    expect(indexerStateBadge).toHaveTextContent(/^INDEXING 40\.0K$/);
+  });
+
+  it("renders an indexed badge if the /indexer-state endpoint returns null", async () => {
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(null),
+      })
+    );
+
+    function IndexerStateTester() {
+      const tooltipAttr = useTooltip("indexer-state");
+
+      const globalContext = {
+        indexerStateTooltip: tooltipAttr,
+      };
+
+      return (
+        <GlobalContext.Provider value={globalContext}>
+          <IndexerState />
+        </GlobalContext.Provider>
+      );
+    }
+
+    await act(async () => render(<IndexerStateTester />));
+
+    const indexerStateBadge = screen.getByTestId("indexer-state-expanded");
+    expect(indexerStateBadge).toBeInTheDocument();
+    expect(indexerStateBadge).toHaveTextContent(/^INDEXED$/);
+  });
+});
+
+describe("Test the collapsed IndexerState component", () => {
+  it("renders the collapsed IndexerState component while indexed", async () => {
+    const indexerState = {
+      indexingCount: 0,
+      isIndexing: false,
+    };
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(indexerState),
+      })
+    );
+
+    function IndexerStateTester() {
+      const tooltipAttr = useTooltip("indexer-state");
+
+      const globalContext = {
+        indexerStateTooltip: tooltipAttr,
+      };
+
+      return (
+        <GlobalContext.Provider value={globalContext}>
+          <IndexerState isCollapsed />
+        </GlobalContext.Provider>
+      );
+    }
+
+    await act(async () => render(<IndexerStateTester />));
+
+    expect(screen.getByTestId("indexer-state-collapsed")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("indexer-state-indexed-icon")
+    ).toBeInTheDocument();
+  });
+
+  it("renders the collapsed IndexerState component while indexing", async () => {
+    const indexerState = {
+      indexingCount: 1_000_000_000,
+      isIndexing: true,
+    };
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(indexerState),
+      })
+    );
+
+    function IndexerStateTester() {
+      const tooltipAttr = useTooltip("indexer-state");
+
+      const globalContext = {
+        indexerStateTooltip: tooltipAttr,
+      };
+
+      return (
+        <GlobalContext.Provider value={globalContext}>
+          <IndexerState isCollapsed />
+        </GlobalContext.Provider>
+      );
+    }
+
+    await act(async () => render(<IndexerStateTester />));
+
+    const indexerStateBadge = screen.getByTestId("indexer-state-collapsed");
+    expect(indexerStateBadge).toBeInTheDocument();
+    expect(indexerStateBadge).toHaveTextContent(/^1.0B$/);
+  });
+});
+
+describe("Test requests to the /indexer-state endpoint subsequent to the initial one", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it("requests the indexer state after the interval timer expires", async () => {
+    const indexerState = {
+      indexingCount: 1,
+      isIndexing: true,
+    };
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(indexerState),
+      })
+    );
+
+    function IndexerStateTester() {
+      const tooltipAttr = useTooltip("indexer-state");
+
+      const globalContext = {
+        indexerStateTooltip: tooltipAttr,
+      };
+
+      return (
+        <GlobalContext.Provider value={globalContext}>
+          <IndexerState />
+        </GlobalContext.Provider>
+      );
+    }
+
+    await act(async () => render(<IndexerStateTester />));
+
+    // The initial request happened, and the request icon does not appear.
+    expect(window.fetch).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("indexer-requesting-icon")).toBeNull();
+
+    // Run the interval timer, then make sure fetch was called a second time, and the request icon
+    // appears.
+    await act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(window.fetch).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId("indexer-requesting-icon")).toBeInTheDocument();
+
+    // Wait for the timeout to expire, then make sure the request icon disappears.
+    await act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId("indexer-requesting-icon")
+    );
+  });
+
+  it("While in admin mode, it requests the indexer state when clicking the expanded badge button", async () => {
+    const indexerState = {
+      indexingCount: 2_000_000,
+      isIndexing: true,
+    };
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(indexerState),
+      })
+    );
+    const sessionProperties = {
+      admin: true,
+    };
+
+    function IndexerStateTester() {
+      const tooltipAttr = useTooltip("indexer-state");
+
+      const globalContext = {
+        indexerStateTooltip: tooltipAttr,
+      };
+
+      return (
+        <GlobalContext.Provider value={globalContext}>
+          <SessionContext.Provider value={{ sessionProperties }}>
+            <IndexerState />
+          </SessionContext.Provider>
+        </GlobalContext.Provider>
+      );
+    }
+
+    await act(async () => render(<IndexerStateTester />));
+
+    // The initial request happened, and the request icon does not appear.
+    expect(window.fetch).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("indexer-requesting-icon")).toBeNull();
+
+    // Click the badge button, then make sure fetch was called a second time, and the request icon
+    // appears.
+    await act(async () => {
+      const badgeButton = screen.getByTestId("indexer-state-button");
+      badgeButton.click();
+    });
+    expect(screen.getByTestId("indexer-requesting-icon")).toBeInTheDocument();
+
+    // Wait for the timeout to expire, then make sure the request icon disappears.
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId("indexer-requesting-icon")
+    );
+  });
+
+  it("While in admin mode, it requests the indexer state when clicking the collapsed badge button", async () => {
+    const indexerState = {
+      indexingCount: 999_999,
+      isIndexing: true,
+    };
+    window.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(indexerState),
+      })
+    );
+    const sessionProperties = {
+      admin: true,
+    };
+
+    function IndexerStateTester() {
+      const tooltipAttr = useTooltip("indexer-state");
+
+      const globalContext = {
+        indexerStateTooltip: tooltipAttr,
+      };
+
+      return (
+        <GlobalContext.Provider value={globalContext}>
+          <SessionContext.Provider value={{ sessionProperties }}>
+            <IndexerState isCollapsed />
+          </SessionContext.Provider>
+        </GlobalContext.Provider>
+      );
+    }
+
+    await act(async () => render(<IndexerStateTester />));
+
+    // The initial request happened, and the request icon does not appear.
+    expect(window.fetch).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("indexer-requesting-icon")).toBeNull();
+
+    // Click the badge button, then make sure fetch was called a second time, and the request icon
+    // appears.
+    await act(async () => {
+      const badgeButton = screen.getByTestId("indexer-state-button");
+      badgeButton.click();
+    });
+    expect(screen.getByTestId("indexer-requesting-icon")).toBeInTheDocument();
+
+    // Wait for the timeout to expire, then make sure the request icon disappears.
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId("indexer-requesting-icon")
+    );
+  });
+});

--- a/components/global-context.js
+++ b/components/global-context.js
@@ -10,6 +10,7 @@ const GlobalContext = React.createContext({
   page: {},
   breadcrumbs: [],
   darkMode: {},
+  indexerStateTooltip: null,
 });
 
 export default GlobalContext;

--- a/components/indexer-state.js
+++ b/components/indexer-state.js
@@ -1,0 +1,297 @@
+// node_modules
+import { ArrowPathIcon, CheckIcon } from "@heroicons/react/20/solid";
+import PropTypes from "prop-types";
+import { useContext, useEffect, useState } from "react";
+// components
+import GlobalContext from "./global-context";
+import SessionContext from "./session-context";
+import { TooltipRef } from "./tooltip";
+// lib
+import FetchRequest from "../lib/fetch-request";
+
+/**
+ * Interval in milliseconds to request the indexer state from the data provider.
+ */
+const INDEXER_STATE_REQUEST_INTERVAL = 300_000;
+
+/**
+ * Duration in milliseconds to display the indexer state request indicator.
+ */
+const INDEXER_STATE_REQUEST_INDICATOR_DURATION = 500;
+
+/**
+ * Use these constants to specify the styles of the indexer-state badge.
+ */
+const INDEXER_STYLE_INDEXED = "INDEXED";
+const INDEXER_STYLE_INDEXING = "INDEXING";
+
+/**
+ * Tailwind CSS styles for the indexer-state badge for both the indexing and indexed states.
+ */
+const indexerStyles = {
+  INDEXED:
+    "[&_#indexer-background]:bg-indexed-state [&_#indexer-outline]:border-indexed-state [&_#indexer-outline]:bg-none text-indexed-state [&_#indexer-icon]:fill-indexed-state",
+  INDEXING:
+    "[&_#indexer-background]:bg-indexing-state [&_#indexer-outline]:border-indexing-state [&_#indexer-outline]:bg-none text-indexing-state [&_#indexer-icon]:fill-indexing-state",
+};
+
+/**
+ * Abbreviate a number to a string with an order-of-magnitude suffix (e.g. 1000 => 1K). Works well
+ * for numbers less than 1 trillion.
+ * @param {number} number The number to abbreviate
+ * @returns {string} The abbreviated number
+ */
+function abbreviateNumber(number) {
+  // Round to the nearest tenth if two digits or less, otherwise round to the nearest whole.
+  function toTenthOrWhole(hundredsOf) {
+    return hundredsOf.toFixed(hundredsOf < 100 ? 1 : 0);
+  }
+
+  if (number >= 1_000_000_000) {
+    const hundredsOf = number / 1_000_000_000;
+    return `${toTenthOrWhole(hundredsOf)}B`;
+  }
+  if (number >= 1_000_000) {
+    const hundredsOf = number / 1_000_000;
+    return `${toTenthOrWhole(hundredsOf)}M`;
+  }
+  if (number >= 1000) {
+    const hundredsOf = number / 1000;
+    return `${toTenthOrWhole(hundredsOf)}K`;
+  }
+  return number;
+}
+
+/**
+ * Display the icon within the indexing-state badge that indicates that an indexer-state request
+ * has been triggered.
+ */
+function RequestingIcon() {
+  return (
+    <ArrowPathIcon
+      id="indexer-icon"
+      data-testid="indexer-requesting-icon"
+      className={`h-full fill-white [&>path]:origin-center [&>path]:animate-[spin_2s_infinite_linear]`}
+    />
+  );
+}
+
+/**
+ * Display the current indexer state badge for the navigation area when the user has expanded it.
+ */
+function IndexerStateExpanded({
+  isRequesting,
+  isIndexing,
+  indexingCount,
+  isAdmin,
+  onClick,
+  indexerStateTooltip,
+}) {
+  const indexerStyle = isIndexing
+    ? INDEXER_STYLE_INDEXING
+    : INDEXER_STYLE_INDEXED;
+
+  return (
+    <div
+      data-testid="indexer-state-expanded"
+      className={`mt-2 flex items-center justify-center border-t border-gray-200 p-4 dark:border-gray-700 ${indexerStyles[indexerStyle]}`}
+    >
+      <TooltipRef tooltipAttr={indexerStateTooltip}>
+        <button
+          id="indexer-outline"
+          className={`h-5 w-2/3 rounded-full border p-px ${
+            isAdmin ? "cursor-pointer" : "cursor-default"
+          }`}
+          onClick={isAdmin ? onClick : null}
+          data-testid="indexer-state-button"
+        >
+          <div
+            id="indexer-background"
+            className="flex h-full w-full items-center justify-center rounded-full text-[0.6rem] font-bold"
+          >
+            {isRequesting ? (
+              <RequestingIcon />
+            ) : (
+              <>
+                {isIndexing ? (
+                  <>INDEXING {abbreviateNumber(indexingCount)}</>
+                ) : (
+                  "INDEXED"
+                )}
+              </>
+            )}
+          </div>
+        </button>
+      </TooltipRef>
+    </div>
+  );
+}
+
+IndexerStateExpanded.propTypes = {
+  // True if an indexer-state request has been triggered
+  isRequesting: PropTypes.bool.isRequired,
+  // True if the indexer is currently indexing
+  isIndexing: PropTypes.bool.isRequired,
+  // Number of objects left to index if `isIndexing` is true
+  indexingCount: PropTypes.number.isRequired,
+  // True if user has logged in as an admin
+  isAdmin: PropTypes.bool.isRequired,
+  // Function to call when the user clicks the indexer-state badge
+  onClick: PropTypes.func.isRequired,
+  // Tooltip attributes for the indexer-state badge
+  indexerStateTooltip: PropTypes.object.isRequired,
+};
+
+/**
+ * Display the current indexer state badge for the navigation area when the user has collapsed it.
+ */
+function IndexerStateCollapsed({
+  isRequesting,
+  isIndexing,
+  indexingCount,
+  isAdmin,
+  onClick,
+  indexerStateTooltip,
+}) {
+  const indexerStyle = isIndexing
+    ? INDEXER_STYLE_INDEXING
+    : INDEXER_STYLE_INDEXED;
+
+  return (
+    <div
+      data-testid="indexer-state-collapsed"
+      className={`my-2 ${indexerStyles[indexerStyle]}`}
+    >
+      <TooltipRef tooltipAttr={indexerStateTooltip}>
+        <button
+          id="indexer-outline"
+          className={`mx-auto h-8 w-8 rounded-full border p-px ${
+            isAdmin ? "cursor-pointer" : "cursor-default"
+          }`}
+          onClick={isAdmin ? onClick : null}
+          data-testid="indexer-state-button"
+        >
+          <div
+            id="indexer-background"
+            className="flex h-full w-full items-center justify-center rounded-full p-2 text-[0.45rem] font-bold"
+          >
+            {isRequesting ? (
+              <RequestingIcon />
+            ) : (
+              <>
+                {isIndexing ? (
+                  <>{abbreviateNumber(indexingCount)}</>
+                ) : (
+                  <CheckIcon
+                    data-testid="indexer-state-indexed-icon"
+                    className="h-full w-full fill-white"
+                  />
+                )}
+              </>
+            )}
+          </div>
+        </button>
+      </TooltipRef>
+    </div>
+  );
+}
+
+IndexerStateCollapsed.propTypes = {
+  // True if an indexer-state request has been triggered
+  isRequesting: PropTypes.bool.isRequired,
+  // True if the indexer is currently indexing
+  isIndexing: PropTypes.bool.isRequired,
+  // Number of objects left to index if `isIndexing` is true
+  indexingCount: PropTypes.number.isRequired,
+  // True if user has logged in as an admin
+  isAdmin: PropTypes.bool.isRequired,
+  // Function to call when the user clicks the indexer-state badge
+  onClick: PropTypes.func.isRequired,
+  // Tooltip attributes for the indexer-state badge
+  indexerStateTooltip: PropTypes.object.isRequired,
+};
+
+/**
+ * Display the current indexer state badge. This handles the cases where the user has expanded or
+ * collapsed the navigation area. The indexer-state badge tooltip gets created in the `<Site>`
+ * component and placed into `GlobalContext` because creating the tooltip here causes the
+ * scrollable navigation parent component to limit the width of -- and even clip -- the tooltip.
+ */
+export default function IndexerState({ isCollapsed = false }) {
+  const { sessionProperties } = useContext(SessionContext);
+  const { indexerStateTooltip } = useContext(GlobalContext);
+  const isAdmin = !!sessionProperties?.admin;
+  const request = new FetchRequest({ backend: true });
+
+  // Current indexer state based on the /indexer-state endpoint data
+  const [isIndexing, setIsIndexing] = useState(false);
+  // Number of objects left to index
+  const [indexingCount, setIndexingCount] = useState(0);
+  // True if an indexer-state request has been triggered
+  const [isRequesting, setIsRequesting] = useState(false);
+
+  // Request the current indexer state from the data provider.
+  async function requestIndexerState() {
+    const indexerState = (
+      await request.getObject("/api/indexer-state/")
+    ).optional();
+    if (indexerState) {
+      setIsIndexing(indexerState.isIndexing);
+      setIndexingCount(indexerState.indexingCount);
+    }
+  }
+
+  // Trigger an indexer-state request and show the indexer-state request indicator.
+  function triggerIndexerStateRequest() {
+    // When requesting the indexer state, show an indicator for a short time.
+    setIsRequesting(true);
+    setTimeout(() => {
+      setIsRequesting(false);
+    }, INDEXER_STATE_REQUEST_INDICATOR_DURATION);
+
+    // Perform the periodic request to get the current indexer state.
+    requestIndexerState();
+  }
+
+  useEffect(() => {
+    // Poll the indexer state so that the indexer-state icon updates when the indexer starts or
+    // finishes, and shows a momentary display as each request initiates. Also make this request on
+    // page load so that the icon is up-to-date when the page loads.
+    requestIndexerState();
+    const interval = setInterval(() => {
+      triggerIndexerStateRequest();
+    }, INDEXER_STATE_REQUEST_INTERVAL);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  // Render an SVG circle with a radius of 26px and a blue fill
+  return (
+    <>
+      {isCollapsed ? (
+        <IndexerStateCollapsed
+          isRequesting={isRequesting}
+          isIndexing={isIndexing}
+          indexingCount={indexingCount}
+          isAdmin={isAdmin}
+          onClick={triggerIndexerStateRequest}
+          indexerStateTooltip={indexerStateTooltip}
+        />
+      ) : (
+        <IndexerStateExpanded
+          isRequesting={isRequesting}
+          isIndexing={isIndexing}
+          indexingCount={indexingCount}
+          isAdmin={isAdmin}
+          onClick={triggerIndexerStateRequest}
+          indexerStateTooltip={indexerStateTooltip}
+        />
+      )}
+    </>
+  );
+}
+
+IndexerState.propTypes = {
+  // True if the indexer-state is within the collapsed navigation area
+  isCollapsed: PropTypes.bool,
+};

--- a/components/navigation.js
+++ b/components/navigation.js
@@ -28,6 +28,7 @@ import { Button } from "./form-elements";
 import GlobalContext from "./global-context";
 import Icon from "./icon";
 import IdSearchTrigger from "./id-search-trigger";
+import IndexerState from "./indexer-state";
 import SiteLogo from "./logo";
 import Modal from "./modal";
 import SessionContext from "./session-context";
@@ -471,6 +472,16 @@ NavigationGroupItem.propTypes = {
   handleGroupClick: PropTypes.func.isRequired,
 };
 
+/**
+ * Wraps a generic navigation item in an <li> tag.
+ */
+function NavigationItem({ children }) {
+  return <li>{children}</li>;
+}
+
+/**
+ * Handles the button to expand or collapse the sidebar navigation.
+ */
 function NavigationCollapseButton({ toggleNavCollapsed, isNavCollapsed }) {
   return (
     <button
@@ -498,6 +509,9 @@ NavigationCollapseButton.propTypes = {
   isNavCollapsed: PropTypes.bool.isRequired,
 };
 
+/**
+ * Navigation-area item to handle the collapse/expand button.
+ */
 function NavigationCollapseItem({ toggleNavCollapsed, isNavCollapsed }) {
   return (
     <li>
@@ -732,6 +746,9 @@ function NavigationExpanded({ navigationClick, toggleNavCollapsed }) {
             Sign In
           </NavigationSignInItem>
         )}
+        <NavigationItem>
+          <IndexerState />
+        </NavigationItem>
       </NavigationList>
     </>
   );
@@ -787,6 +804,9 @@ function NavigationCollapsed({ navigationClick, toggleNavCollapsed }) {
           <QuestionMarkCircleIcon />
         </NavigationIcon>
       </NavigationHrefItem>
+      <NavigationItem>
+        <IndexerState isCollapsed />
+      </NavigationItem>
     </NavigationList>
   );
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -20,6 +20,7 @@ import GlobalContext from "../components/global-context";
 import NavigationSection from "../components/navigation";
 import ScrollToTop from "../components/scroll-to-top";
 import { Session } from "../components/session-context";
+import { Tooltip, useTooltip } from "../components/tooltip";
 import ViewportOverlay from "../components/viewport-overlay";
 // CSS
 import "../styles/globals.css";
@@ -30,6 +31,8 @@ function Site({ Component, pageProps, authentication }) {
   const { isLoading } = useAuth0();
   // Keep track of current dark mode settings
   const [isDarkMode, setIsDarkMode] = useState(false);
+  // Tooltip attributes for the indexer state badge; here so nav div doesn't clip tooltip
+  const tooltipAttr = useTooltip("indexer-state");
 
   useEffect(() => {
     // Install the dark-mode event listener to react to dark-mode changes.
@@ -59,6 +62,7 @@ function Site({ Component, pageProps, authentication }) {
       darkMode: {
         enabled: isDarkMode,
       },
+      indexerStateTooltip: tooltipAttr,
     };
   }, [
     pageProps.breadcrumbs,
@@ -127,6 +131,11 @@ function Site({ Component, pageProps, authentication }) {
                 )}
               </div>
             </div>
+            <Tooltip tooltipAttr={tooltipAttr}>
+              Database indexer state. Green indicates indexing has completed.
+              Orange indicates indexing in progress, as well as the number of
+              items left to index.
+            </Tooltip>
           </Session>
         </GlobalContext.Provider>
       </div>

--- a/pages/api/indexer-state.ts
+++ b/pages/api/indexer-state.ts
@@ -1,0 +1,60 @@
+// node_modules
+import type { NextApiRequest, NextApiResponse } from "next";
+// lib
+import FetchRequest from "../../lib/fetch-request";
+// types
+import type { ErrorObject } from "../../lib/fetch-request.d";
+
+/**
+ * Reflects the data returned by the data provider's /indexer-info endpoint.
+ */
+type IndexerInfo = {
+  invalidation_queue: {
+    ApproximateNumberOfMessages: number;
+    ApproximateNumberOfMessagesDelayed: number;
+    ApproximateNumberOfMessagesNotVisible: number;
+  };
+  is_indexing: boolean;
+  transaction_queue: {
+    ApproximateNumberOfMessages: number;
+    ApproximateNumberOfMessagesDelayed: number;
+    ApproximateNumberOfMessagesNotVisible: number;
+  };
+};
+
+/**
+ * The indexer state returned by this API endpoint.
+ */
+export type IndexerState = {
+  // True if the data provider is currently indexing.
+  isIndexing: boolean;
+  // The number of transactions remaining in the indexer's invalidation queue.
+  indexingCount: number;
+};
+
+/**
+ * This endpoint is used to determine if the indexer is currently indexing and how many
+ * transactions are remaining in the invalidation queue. Request the indexer state from the data
+ * provider. Convert this to the simplified `IndexerState` format.
+ * @param req {NextApiRequest} NextJS API request object.
+ * @param res {NextApiResponse} NextJS API response object.
+ */
+export default async function indexerState(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  const request = new FetchRequest({ cookie: req.headers.cookie });
+  const response = (await request.getObject(`/indexer-info`)).union();
+  if (response.isError) {
+    throw new Error((response as ErrorObject).description);
+  } else {
+    const stateFromDataProvider = response as IndexerInfo;
+    const state: IndexerState = {
+      isIndexing: stateFromDataProvider.is_indexing,
+      indexingCount:
+        stateFromDataProvider.invalidation_queue.ApproximateNumberOfMessages,
+    };
+
+    res.status(200).json(state);
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -150,6 +150,13 @@
   --color-schema-prop-type-text-null: #1f2937;
   --color-schema-prop-type-text-default: #1f2937;
 
+  --color-indexed-state-background: #4ade80;
+  --color-indexed-state-border: #22c55e;
+  --color-indexed-state-content: #f0fdf4;
+  --color-indexing-state-background: #fb923c;
+  --color-indexing-state-border: #f97316;
+  --color-indexing-state-content: #7c2d12;
+
   --color-site-search-header-background: #c9ebe2;
 
   --color-form-element-background: #ffffff;
@@ -296,6 +303,13 @@
   --color-schema-prop-type-text-link: #fdba74;
   --color-schema-prop-type-text-null: #d1d5db;
   --color-schema-prop-type-text-default: #e5e7eb;
+
+  --color-indexed-state-background: #14532d;
+  --color-indexed-state-border: #15803d;
+  --color-indexed-state-content: #22c55e;
+  --color-indexing-state-background: #9a3412;
+  --color-indexing-state-border: #c2410c;
+  --color-indexing-state-content: #fdba74;
 
   --color-site-search-header-background: #394240;
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -76,6 +76,9 @@ module.exports = {
         "schema-prop-type-link": "var(--color-schema-prop-type-bg-link)",
         "schema-prop-type-null": "var(--color-schema-prop-type-bg-null)",
         "schema-prop-type-default": "var(--color-schema-prop-type-bg-default)",
+
+        "indexed-state": "var(--color-indexed-state-background)",
+        "indexing-state": "var(--color-indexing-state-background)",
       },
       borderColor: {
         panel: "var(--color-panel-border)",
@@ -130,6 +133,9 @@ module.exports = {
         "schema-prop-type-null": "var(--color-schema-prop-type-border-null)",
         "schema-prop-type-default":
           "var(--color-schema-prop-type-border-default)",
+
+        "indexed-state": "var(--color-indexed-state-border)",
+        "indexing-state": "var(--color-indexing-state-border)",
       },
       fontSize: {
         xxs: "0.7rem",
@@ -177,6 +183,9 @@ module.exports = {
         "schema-prop-type-null": "var(--color-schema-prop-type-text-null)",
         "schema-prop-type-default":
           "var(--color-schema-prop-type-text-default)",
+
+        "indexed-state": "var(--color-indexed-state-content)",
+        "indexing-state": "var(--color-indexing-state-content)",
       },
       boxShadow: {
         // Status badges
@@ -209,6 +218,9 @@ module.exports = {
         "facet-clear-filter-icon": "var(--color-facet-clear-filter-icon-fill)",
         "facet-filter-icon-set": "var(--color-facet-filter-icon-set-fill)",
         "facet-filter-icon": "var(--color-facet-filter-icon-fill)",
+
+        "indexed-state": "var(--color-indexed-state-content)",
+        "indexing-state": "var(--color-indexing-state-content)",
       },
       gridTemplateColumns: {
         "min-2": "repeat(2, minmax(0, min-content))",


### PR DESCRIPTION
I have weirdly put the tooltip reference (indexer-state button) in indexer-state.js within the navigation area while the tooltip itself goes into the `<Site>` component in _app.js. This hopefully doesn’t become a common pattern for tooltips. The required CSS for the navigation area limits the width of — and can even cut off — the tooltip if I had placed it together with the tooltip reference. I instead had to put the tooltip above the level of navigation, which puts it within the `<Site>` component. To connect the tooltip and tooltip reference, I put the tooltip attributes in `GlobalContext` so that I wouldn’t have to pass the tooltip attributes with prop drilling.