### PR TITLE
IGVF-1424 Inject tooltips into portal root

### DIFF
--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,6 +53,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
+            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,7 +53,6 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/components/__tests__/tooltip.test.js
+++ b/components/__tests__/tooltip.test.js
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
-import { Tooltip, TooltipRef, useTooltip } from "../tooltip";
+import { Tooltip, TooltipPortalRoot, TooltipRef, useTooltip } from "../tooltip";
 
 describe("Test tooltips", () => {
   it("should render a tooltip", async () => {
@@ -14,6 +14,7 @@ describe("Test tooltips", () => {
             <button>Tooltip Reference</button>
           </TooltipRef>
           <Tooltip tooltipAttr={tooltipAttr}>Tooltip content</Tooltip>
+          <TooltipPortalRoot />
         </>
       );
     }

--- a/components/indexer-state.js
+++ b/components/indexer-state.js
@@ -5,7 +5,7 @@ import { useContext, useEffect, useState } from "react";
 // components
 import GlobalContext from "./global-context";
 import SessionContext from "./session-context";
-import { TooltipRef } from "./tooltip";
+import { Tooltip, TooltipRef, useTooltip } from "./tooltip";
 // lib
 import FetchRequest from "../lib/fetch-request";
 
@@ -85,45 +85,54 @@ function IndexerStateExpanded({
   indexingCount,
   isAdmin,
   onClick,
-  indexerStateTooltip,
 }) {
+  // Tooltip attributes for the indexer state badge; here so nav div doesn't clip tooltip
+  const tooltipAttr = useTooltip("indexer-state");
+
   const indexerStyle = isIndexing
     ? INDEXER_STYLE_INDEXING
     : INDEXER_STYLE_INDEXED;
 
   return (
-    <div
-      data-testid="indexer-state-expanded"
-      className={`mt-2 flex items-center justify-center border-t border-gray-200 p-4 dark:border-gray-700 ${indexerStyles[indexerStyle]}`}
-    >
-      <TooltipRef tooltipAttr={indexerStateTooltip}>
-        <button
-          id="indexer-outline"
-          className={`h-5 w-2/3 rounded-full border p-px ${
-            isAdmin ? "cursor-pointer" : "cursor-default"
-          }`}
-          onClick={isAdmin ? onClick : null}
-          data-testid="indexer-state-button"
-        >
-          <div
-            id="indexer-background"
-            className="flex h-full w-full items-center justify-center rounded-full text-[0.6rem] font-bold"
+    <>
+      <div
+        data-testid="indexer-state-expanded"
+        className={`mt-2 flex items-center justify-center border-t border-gray-200 p-4 dark:border-gray-700 ${indexerStyles[indexerStyle]}`}
+      >
+        <TooltipRef tooltipAttr={tooltipAttr}>
+          <button
+            id="indexer-outline"
+            className={`h-5 w-2/3 rounded-full border p-px ${
+              isAdmin ? "cursor-pointer" : "cursor-default"
+            }`}
+            onClick={isAdmin ? onClick : null}
+            data-testid="indexer-state-button"
           >
-            {isRequesting ? (
-              <RequestingIcon />
-            ) : (
-              <>
-                {isIndexing ? (
-                  <>INDEXING {abbreviateNumber(indexingCount)}</>
-                ) : (
-                  "INDEXED"
-                )}
-              </>
-            )}
-          </div>
-        </button>
-      </TooltipRef>
-    </div>
+            <div
+              id="indexer-background"
+              className="flex h-full w-full items-center justify-center rounded-full text-[0.6rem] font-bold"
+            >
+              {isRequesting ? (
+                <RequestingIcon />
+              ) : (
+                <>
+                  {isIndexing ? (
+                    <>INDEXING {abbreviateNumber(indexingCount)}</>
+                  ) : (
+                    "INDEXED"
+                  )}
+                </>
+              )}
+            </div>
+          </button>
+        </TooltipRef>
+      </div>
+      <Tooltip tooltipAttr={tooltipAttr}>
+        Database indexer state. Green indicates indexing has completed. Orange
+        indicates indexing in progress, as well as the number of items left to
+        index.
+      </Tooltip>
+    </>
   );
 }
 
@@ -138,8 +147,6 @@ IndexerStateExpanded.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
   // Function to call when the user clicks the indexer-state badge
   onClick: PropTypes.func.isRequired,
-  // Tooltip attributes for the indexer-state badge
-  indexerStateTooltip: PropTypes.object.isRequired,
 };
 
 /**
@@ -151,48 +158,57 @@ function IndexerStateCollapsed({
   indexingCount,
   isAdmin,
   onClick,
-  indexerStateTooltip,
 }) {
+  // Tooltip attributes for the indexer state badge; here so nav div doesn't clip tooltip
+  const tooltipAttr = useTooltip("indexer-state");
+
   const indexerStyle = isIndexing
     ? INDEXER_STYLE_INDEXING
     : INDEXER_STYLE_INDEXED;
 
   return (
-    <div
-      data-testid="indexer-state-collapsed"
-      className={`my-2 ${indexerStyles[indexerStyle]}`}
-    >
-      <TooltipRef tooltipAttr={indexerStateTooltip}>
-        <button
-          id="indexer-outline"
-          className={`mx-auto h-8 w-8 rounded-full border p-px ${
-            isAdmin ? "cursor-pointer" : "cursor-default"
-          }`}
-          onClick={isAdmin ? onClick : null}
-          data-testid="indexer-state-button"
-        >
-          <div
-            id="indexer-background"
-            className="flex h-full w-full items-center justify-center rounded-full p-2 text-[0.45rem] font-bold"
+    <>
+      <div
+        data-testid="indexer-state-collapsed"
+        className={`my-2 ${indexerStyles[indexerStyle]}`}
+      >
+        <TooltipRef tooltipAttr={tooltipAttr}>
+          <button
+            id="indexer-outline"
+            className={`mx-auto h-8 w-8 rounded-full border p-px ${
+              isAdmin ? "cursor-pointer" : "cursor-default"
+            }`}
+            onClick={isAdmin ? onClick : null}
+            data-testid="indexer-state-button"
           >
-            {isRequesting ? (
-              <RequestingIcon />
-            ) : (
-              <>
-                {isIndexing ? (
-                  <>{abbreviateNumber(indexingCount)}</>
-                ) : (
-                  <CheckIcon
-                    data-testid="indexer-state-indexed-icon"
-                    className="h-full w-full fill-white"
-                  />
-                )}
-              </>
-            )}
-          </div>
-        </button>
-      </TooltipRef>
-    </div>
+            <div
+              id="indexer-background"
+              className="flex h-full w-full items-center justify-center rounded-full p-2 text-[0.45rem] font-bold"
+            >
+              {isRequesting ? (
+                <RequestingIcon />
+              ) : (
+                <>
+                  {isIndexing ? (
+                    <>{abbreviateNumber(indexingCount)}</>
+                  ) : (
+                    <CheckIcon
+                      data-testid="indexer-state-indexed-icon"
+                      className="h-full w-full fill-white"
+                    />
+                  )}
+                </>
+              )}
+            </div>
+          </button>
+        </TooltipRef>
+      </div>
+      <Tooltip tooltipAttr={tooltipAttr}>
+        Database indexer state. Green indicates indexing has completed. Orange
+        indicates indexing in progress, as well as the number of items left to
+        index.
+      </Tooltip>
+    </>
   );
 }
 
@@ -207,8 +223,6 @@ IndexerStateCollapsed.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
   // Function to call when the user clicks the indexer-state badge
   onClick: PropTypes.func.isRequired,
-  // Tooltip attributes for the indexer-state badge
-  indexerStateTooltip: PropTypes.object.isRequired,
 };
 
 /**

--- a/components/tooltip.js
+++ b/components/tooltip.js
@@ -17,8 +17,15 @@ import {
 } from "@floating-ui/react";
 import PropTypes from "prop-types";
 import { Children, cloneElement, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 // lib
 import { toShishkebabCase } from "../lib/general";
+
+/**
+ * ID of the tooltip portal DOM root-level element that tooltips render into to avoid z-index and
+ * parent-width issues.
+ */
+const TOOLTIP_PORTAL_ROOT_ID = "tooltip-portal-root";
 
 /**
  * Height of the tooltip arrow (the small pointer from the tooltip to the tooltip ref) in pixels.
@@ -123,30 +130,33 @@ TooltipRef.propTypes = {
  * browser widths.
  */
 export function Tooltip({ tooltipAttr, children }) {
-  if (tooltipAttr.isVisible) {
-    return (
-      <div
-        className="max-w-[90%] rounded-md border border-gray-500 bg-gray-800 px-2 py-1 text-xs text-white drop-shadow-md md:max-w-[40%] 2xl:max-w-[20%] dark:border-white dark:bg-gray-300 dark:text-black"
-        ref={tooltipAttr.tooltipEl}
-        style={tooltipAttr.styles}
-        role="tooltip"
-        {...tooltipAttr.tooltipProps()}
-        id={tooltipAttr.id}
-        data-testid={tooltipAttr.id}
-      >
-        {children}
-        <FloatingArrow
-          className="fill-gray-800 dark:fill-gray-300 [&>path:first-of-type]:stroke-gray-500 dark:[&>path:first-of-type]:stroke-white [&>path:last-of-type]:stroke-gray-800 dark:[&>path:last-of-type]:stroke-gray-300"
-          ref={tooltipAttr.arrowRef}
-          context={tooltipAttr.context}
-          height={ARROW_HEIGHT}
-          width={ARROW_WIDTH}
-          strokeWidth={1}
-        />
-      </div>
-    );
-  }
-  return null;
+  return (
+    <>
+      {tooltipAttr.isVisible &&
+        createPortal(
+          <div
+            className="max-w-[90%] rounded-md border border-gray-500 bg-gray-800 px-2 py-1 text-xs text-white drop-shadow-md dark:border-white dark:bg-gray-300 dark:text-black md:max-w-[40%] 2xl:max-w-[20%]"
+            ref={tooltipAttr.tooltipEl}
+            style={tooltipAttr.styles}
+            role="tooltip"
+            {...tooltipAttr.tooltipProps()}
+            id={tooltipAttr.id}
+            data-testid={tooltipAttr.id}
+          >
+            {children}
+            <FloatingArrow
+              className="fill-gray-800 dark:fill-gray-300 [&>path:first-of-type]:stroke-gray-500 dark:[&>path:first-of-type]:stroke-white [&>path:last-of-type]:stroke-gray-800 dark:[&>path:last-of-type]:stroke-gray-300"
+              ref={tooltipAttr.arrowRef}
+              context={tooltipAttr.context}
+              height={ARROW_HEIGHT}
+              width={ARROW_WIDTH}
+              strokeWidth={1}
+            />
+          </div>,
+          document.getElementById(TOOLTIP_PORTAL_ROOT_ID)
+        )}
+    </>
+  );
 }
 
 Tooltip.propTypes = {
@@ -161,3 +171,13 @@ Tooltip.propTypes = {
     isVisible: PropTypes.bool,
   }),
 };
+
+/**
+ * Drop this component into the `<body>` of your HTML document. It creates the DOM root-level
+ * portal that the tooltips render into.
+ */
+export function TooltipPortalRoot() {
+  return (
+    <div id={TOOLTIP_PORTAL_ROOT_ID} data-testid={TOOLTIP_PORTAL_ROOT_ID} />
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -20,7 +20,6 @@ import GlobalContext from "../components/global-context";
 import NavigationSection from "../components/navigation";
 import ScrollToTop from "../components/scroll-to-top";
 import { Session } from "../components/session-context";
-import { Tooltip, useTooltip } from "../components/tooltip";
 import ViewportOverlay from "../components/viewport-overlay";
 // CSS
 import "../styles/globals.css";
@@ -31,8 +30,6 @@ function Site({ Component, pageProps, authentication }) {
   const { isLoading } = useAuth0();
   // Keep track of current dark mode settings
   const [isDarkMode, setIsDarkMode] = useState(false);
-  // Tooltip attributes for the indexer state badge; here so nav div doesn't clip tooltip
-  const tooltipAttr = useTooltip("indexer-state");
 
   useEffect(() => {
     // Install the dark-mode event listener to react to dark-mode changes.
@@ -62,7 +59,6 @@ function Site({ Component, pageProps, authentication }) {
       darkMode: {
         enabled: isDarkMode,
       },
-      indexerStateTooltip: tooltipAttr,
     };
   }, [
     pageProps.breadcrumbs,
@@ -131,11 +127,6 @@ function Site({ Component, pageProps, authentication }) {
                 )}
               </div>
             </div>
-            <Tooltip tooltipAttr={tooltipAttr}>
-              Database indexer state. Green indicates indexing has completed.
-              Orange indicates indexing in progress, as well as the number of
-              items left to index.
-            </Tooltip>
           </Session>
         </GlobalContext.Provider>
       </div>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,6 +1,7 @@
 // node_modules
 import { Html, Head, Main, NextScript } from "next/document";
 import { DropdownPortalRoot } from "../components/dropdown";
+import { TooltipPortalRoot } from "../components/tooltip";
 
 export default function Document() {
   return (
@@ -10,6 +11,7 @@ export default function Document() {
         <Main />
         <NextScript />
         <DropdownPortalRoot />
+        <TooltipPortalRoot />
       </body>
     </Html>
   );


### PR DESCRIPTION
This follows my discovery with the dropdown ticket that ephemeral components like this that should appear in front of all other elements on the page and not be bound by parent divs should get injected into a portal-root div. Similarly to dropdowns, I added a static root portal for tooltips in the _document.js file, then use createPortal to inject the tooltip into this portal.

I then moved the indexer-state tooltip out of the `<Site>` component and instead put it adjacent to the tooltip ref that controls it — far easier to handle.