### PR TITLE
IGVF-1439 Home-page chart updates

### DIFF
--- a/lib/__tests__/general.test.js
+++ b/lib/__tests__/general.test.js
@@ -10,6 +10,7 @@ import {
   sortedJson,
   toShishkebabCase,
   truncateJson,
+  truncateText,
   urlWithoutParams,
 } from "../general";
 
@@ -180,5 +181,15 @@ describe("Test the abbreviateNumber function", () => {
     expect(abbreviateNumber(500_000_000)).toBe("500M");
     expect(abbreviateNumber(1_500_000_000)).toBe("1.5B");
     expect(abbreviateNumber(500_000_000_000)).toBe("500B");
+  });
+});
+
+describe("Test the truncateText function", () => {
+  it("Should truncate a string correctly", () => {
+    expect(truncateText("Hello World", 8)).toBe("Hello…");
+    expect(truncateText("Hello World", 11)).toBe("Hello World");
+    expect(truncateText("Supercalifragilisticexpialidocious", 10)).toBe(
+      "Supercalif…"
+    );
   });
 });

--- a/lib/__tests__/home.test.ts
+++ b/lib/__tests__/home.test.ts
@@ -175,49 +175,61 @@ describe("Test convertFileSetsToStatusData function", () => {
         "@context": "/terms/",
         "@id": "/measurement-sets/IGVFDS3380CCRQ/",
         "@type": ["MeasurementSet", "FileSet", "Item"],
+        assay_term: {
+          term_name:
+            "muscular dystrophy-dystroglycanopathy (congenital with brain and eye anomalies), type A14",
+        },
         creation_timestamp: "2023-06-07T11:07:43.000000+00:00",
         lab: {
           title: "J. Michael Cherry, Stanford",
         },
+        preferred_assay_title: "10x multiome",
         status: "released",
-        summary: "MPRA (lentiMPRA) followed by bulk RNA-seq",
         uuid: "f3c038f8-3b58-4d1b-8468-f845340dd7e3",
       },
       {
         "@context": "/terms/",
         "@id": "/measurement-sets/IGVFDS9298GEKM/",
         "@type": ["MeasurementSet", "FileSet", "Item"],
+        assay_term: {
+          term_name: "imaging assay",
+        },
         creation_timestamp: "2023-09-19T05:22:02.000000+00:00",
         lab: {
           title: "J. Michael Cherry, Stanford",
         },
         status: "in progress",
-        summary: "single-cell RNA sequencing assay (Parse Split-seq)",
         uuid: "f1f04a03-009f-434f-a31b-3f12c6ead3aa",
       },
       {
         "@context": "/terms/",
         "@id": "/measurement-sets/IGVFDS3135GTPC/",
         "@type": ["MeasurementSet", "FileSet", "Item"],
+        assay_term: {
+          term_name: "MPRA",
+        },
         creation_timestamp: "2022-07-05T16:59:01.000000+00:00",
         lab: {
           title: "J. Michael Cherry, Stanford",
         },
         files: ["file1", "file2"],
+        preferred_assay_title: "yN2H",
         status: "in progress",
-        summary: "localizing STARR-seq (SUPERSTARR)",
         uuid: "fcff4286-f31e-4530-8f10-a5843f08c43c",
       },
       {
         "@context": "/terms/",
         "@id": "/measurement-sets/IGVFDS0077DACQ/",
         "@type": ["MeasurementSet", "FileSet", "Item"],
+        assay_term: {
+          term_name: "snM3C-seq",
+        },
         creation_timestamp: "2022-07-05T16:59:01.000000+00:00",
         lab: {
           title: "J. Michael Cherry, Stanford",
         },
+        preferred_assay_title: "snMCT-seq",
         status: "in progress",
-        summary: "localizing STARR-seq (SUPERSTARR)",
         uuid: "ccadf134-1e17-47db-84c1-72c67de06d84",
       },
     ];
@@ -226,28 +238,31 @@ describe("Test convertFileSetsToStatusData function", () => {
     expect(nivoData).toEqual({
       fileSetData: [
         {
-          summary:
-            "J. Michael Cherry, Stanford|single-cell RNA sequencing assay (Parse Split-seq)",
+          title: "J. Michael Cherry, Stanford|yN2H",
+          initiated: 0,
+          released: 0,
+          withFiles: 1,
+        },
+        {
+          title: "J. Michael Cherry, Stanford|snMCT-seq",
           released: 0,
           initiated: 1,
           withFiles: 0,
         },
         {
-          summary:
-            "J. Michael Cherry, Stanford|localizing STARR-seq (SUPERSTARR)",
+          title: "J. Michael Cherry, Stanford|imaging assay",
           released: 0,
           initiated: 1,
-          withFiles: 1,
+          withFiles: 0,
         },
         {
-          summary:
-            "J. Michael Cherry, Stanford|MPRA (lentiMPRA) followed by bulk RNA-seq",
+          title: "J. Michael Cherry, Stanford|10x multiome",
           released: 1,
           initiated: 0,
           withFiles: 0,
         },
       ],
-      maxCount: 2,
+      maxCount: 1,
     });
   });
 });

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -64,6 +64,7 @@ export const UC = {
   rsquo: "\u2019", // Right single quote
   ldquo: "\u201c", // Left double quote
   rdquo: "\u201d", // Right double quote
+  hellip: "\u2026", // Horizontal ellipsis
   shift: "\u21E7", // Shift key
   ctrl: "\u2303", // Control key
   cmd: "\u2318", // Place of interest, command key

--- a/lib/general.ts
+++ b/lib/general.ts
@@ -1,3 +1,6 @@
+// lib
+import { UC } from "./constants";
+
 /**
  * Convert an object path into the object type.
  * @param {string} path The @id of the object to get the type for.
@@ -222,4 +225,30 @@ export function abbreviateNumber(number: number): string {
     return `${toTenthOrWhole(hundredsOf)}K`;
   }
   return number.toString();
+}
+
+/**
+ * Truncates a string to the given maximum length, adding an ellipsis if the string is longer than
+ * the maximum length. Try not to truncate a string in the middle of a word, backing up to the
+ * previous space if possible. This isn't possible if the string consists a single word that's
+ * longer than the maximum length. In that case, just truncate the text to the maximum length.
+ * @param text Text to truncate
+ * @param maxLength Maximum length of the text
+ * @returns Truncated text
+ */
+export function truncateText(text: string, maxLength: number) {
+  let processedText = text;
+  if (processedText.length > maxLength) {
+    const trimmedText = processedText.replace(/(^\s)|(\s$)/gi, ""); // Trim leading/trailing white space
+    const truncatedText = trimmedText.substring(0, maxLength); // Truncate to maxLength
+    const isOneWord = truncatedText.match(/\s/gi) === null; // Detect single-word string
+
+    // Truncate to the previous word boundary in the truncated string unless the entire string has
+    // no spaces, in which case we just truncate in the middle of that word.
+    const finalTruncatedText = isOneWord
+      ? truncatedText
+      : truncatedText.substring(0, truncatedText.lastIndexOf(" "));
+    processedText = `${finalTruncatedText}${UC.hellip}`;
+  }
+  return processedText;
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -125,9 +125,14 @@ export default function Home({ fileSets, fileCount, sampleCount }) {
           />
         </FileSetChartSection>
       )}
-      <FileSetChartSection title={FILESET_STATUS_TITLE}>
-        <ChartFileSetStatus fileSets={fileSets} title={FILESET_STATUS_TITLE} />
-      </FileSetChartSection>
+      {fileSets.length > 0 && (
+        <FileSetChartSection title={FILESET_STATUS_TITLE}>
+          <ChartFileSetStatus
+            fileSets={fileSets}
+            title={FILESET_STATUS_TITLE}
+          />
+        </FileSetChartSection>
+      )}
     </div>
   );
 }
@@ -147,7 +152,7 @@ export async function getServerSideProps({ req }) {
   // We might need to paginate this request in the future, but for now just get all the results.
   const results = (
     await request.getObject(
-      "/report/?type=MeasurementSet&field=%40id&field=summary&field=files.@id&field=lab.title&field=status&field=creation_timestamp&field=release_timestamp&limit=all"
+      "/report/?type=MeasurementSet&field=%40id&field=preferred_assay_title&field=assay_term.term_name&field=files.@id&field=lab.title&field=status&field=creation_timestamp&field=release_timestamp&limit=all"
     )
   ).union();
 


### PR DESCRIPTION
Don’t display the home-page status chart if no MeasurementSet objects are accessible. Use the `preferred_assay_title` property if it exists, or the `assay_term.term_name` if it doesn’t as the title for each status-chart bar. Truncate those titles if they go beyond 64 characters.

I think we’re trying to get this into this release.