### PR TITLE
IGVF-985 Collapsible array properties

### DIFF
--- a/components/__tests__/collapse-control.test.js
+++ b/components/__tests__/collapse-control.test.js
@@ -1,0 +1,206 @@
+import { render, screen } from "@testing-library/react";
+import {
+  CollapseControlInline,
+  CollapseControlVertical,
+  useCollapseControl,
+} from "../collapse-control";
+
+describe("Test the inline collapse control", () => {
+  it("displays the control and calls our callback when clicked", () => {
+    const setIsCollapsed = jest.fn();
+
+    function Component() {
+      const items = ["Test", "Test", "Test", "Test", "Test"];
+      const collapser = useCollapseControl(items, true, 2);
+
+      return (
+        <>
+          <div>
+            {collapser.items.map((item, index) => (
+              <p key={index}>{item}</p>
+            ))}
+          </div>
+          {collapser.isCollapseControlVisible && (
+            <CollapseControlInline
+              length={items.length}
+              isCollapsed={true}
+              setIsCollapsed={setIsCollapsed}
+            />
+          )}
+        </>
+      );
+    }
+
+    render(<Component />);
+
+    // Result shows the control and calls our callback when clicked.
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getAllByText("Test").length).toBe(2);
+    screen.getByRole("button").click();
+    expect(setIsCollapsed).toHaveBeenCalled();
+  });
+
+  it("displays all items if fewer items than the maximum", () => {
+    const setIsCollapsed = jest.fn();
+
+    function Component() {
+      const items = ["Test", "Test", "Test", "Test", "Test"];
+      const collapser = useCollapseControl(items, true, 6);
+
+      return (
+        <>
+          <div>
+            {collapser.items.map((item, index) => (
+              <p key={index}>{item}</p>
+            ))}
+          </div>
+          {collapser.isCollapseControlVisible && (
+            <CollapseControlInline
+              length={items.length}
+              isCollapsed={true}
+              setIsCollapsed={setIsCollapsed}
+            />
+          )}
+        </>
+      );
+    }
+
+    render(<Component />);
+
+    // Result shows the control and calls our callback when clicked.
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getAllByText("Test").length).toBe(5);
+  });
+
+  it("displays all items if isCollapsible is false", () => {
+    const setIsCollapsed = jest.fn();
+
+    function Component() {
+      const items = ["Test", "Test", "Test", "Test", "Test"];
+      const collapser = useCollapseControl(items, false, 2);
+
+      return (
+        <>
+          <div>
+            {collapser.items.map((item, index) => (
+              <p key={index}>{item}</p>
+            ))}
+          </div>
+          {collapser.isCollapseControlVisible && (
+            <CollapseControlInline
+              length={5}
+              isCollapsed={true}
+              setIsCollapsed={setIsCollapsed}
+            />
+          )}
+        </>
+      );
+    }
+
+    render(<Component />);
+
+    // Result shows the control and calls our callback when clicked.
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getAllByText("Test").length).toBe(5);
+  });
+});
+
+describe("Test the vertical collapse control", () => {
+  it("displays the control and calls our callback when clicked", () => {
+    const setIsCollapsed = jest.fn();
+
+    function Component() {
+      const items = ["Test", "Test", "Test", "Test", "Test"];
+      const collapser = useCollapseControl(items, true, 2);
+
+      return (
+        <>
+          <div>
+            {collapser.items.map((item, index) => (
+              <p key={index}>{item}</p>
+            ))}
+          </div>
+          {collapser.isCollapseControlVisible && (
+            <CollapseControlVertical
+              length={items.length}
+              isCollapsed={true}
+              setIsCollapsed={setIsCollapsed}
+            />
+          )}
+        </>
+      );
+    }
+
+    render(<Component />);
+
+    // Result shows the control and calls our callback when clicked.
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getAllByText("Test").length).toBe(2);
+    screen.getByRole("button").click();
+    expect(setIsCollapsed).toHaveBeenCalled();
+  });
+
+  it("displays all items if fewer items than the maximum", () => {
+    const setIsCollapsed = jest.fn();
+
+    function Component() {
+      const items = ["Test", "Test", "Test", "Test", "Test"];
+      const collapser = useCollapseControl(items, true, 6);
+
+      return (
+        <>
+          <div>
+            {collapser.items.map((item, index) => (
+              <p key={index}>{item}</p>
+            ))}
+          </div>
+          {collapser.isCollapseControlVisible && (
+            <CollapseControlVertical
+              length={items.length}
+              isCollapsed={true}
+              setIsCollapsed={setIsCollapsed}
+            />
+          )}
+        </>
+      );
+    }
+
+    render(<Component />);
+
+    // Result shows the control and calls our callback when clicked.
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getAllByText("Test").length).toBe(5);
+  });
+
+  it("displays all items if isCollapsible is false", () => {
+    const setIsCollapsed = jest.fn();
+
+    function Component() {
+      const items = ["Test", "Test", "Test", "Test", "Test"];
+      const collapser = useCollapseControl(items, false, 2);
+
+      return (
+        <>
+          <div>
+            {collapser.items.map((item, index) => (
+              <p key={index}>{item}</p>
+            ))}
+          </div>
+          {collapser.isCollapseControlVisible && (
+            <CollapseControlVertical
+              length={items.length}
+              isCollapsed={true}
+              setIsCollapsed={setIsCollapsed}
+            />
+          )}
+        </>
+      );
+    }
+
+    render(<Component />);
+
+    // Result shows the control and calls our callback when clicked.
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getAllByText("Test").length).toBe(5);
+  });
+});

--- a/components/__tests__/data-area.test.js
+++ b/components/__tests__/data-area.test.js
@@ -4,14 +4,11 @@ import {
   DataAreaTitle,
   DataAreaTitleLink,
   DataItemLabel,
+  DataItemList,
   DataItemValue,
   DataItemValueUrl,
-  DataItemValueCollapseControl,
-  DataItemValueControlLabel,
   DataPanel,
-  useDataAreaCollapser,
 } from "../data-area";
-import SeparatedList from "../separated-list";
 import Status from "../status";
 
 describe("Test the DataArea component", () => {
@@ -91,172 +88,82 @@ describe("Test the DataArea component", () => {
   });
 });
 
-describe("Test the useDataAreaCollapser hook", () => {
-  it("properly collapses and expands the data area", () => {
-    const data = [
-      "IGVFFS0001AAAA",
-      "IGVFFS0002AAAA",
-      "IGVFFS0003AAAA",
-      "IGVFFS0004AAAA",
-      "IGVFFS0005AAAA",
-      "IGVFFS0006AAAA",
-    ];
-
-    function TestComponent() {
-      const collapser = useDataAreaCollapser(data);
-      return (
-        <>
-          <DataPanel>
-            <DataArea>
-              <DataItemLabel>Status</DataItemLabel>
-              <DataItemValue>
-                <SeparatedList>
-                  {collapser.displayedData.map((item) => (
-                    <div key={item} data-testid={`displayed-item-${item}`}>
-                      {item}
-                    </div>
-                  ))}
-                </SeparatedList>
-                <DataItemValueCollapseControl collapser={collapser}>
-                  <DataItemValueControlLabel collapser={collapser} />
-                </DataItemValueCollapseControl>
-              </DataItemValue>
-            </DataArea>
-          </DataPanel>
-        </>
-      );
-    }
-
-    render(<TestComponent />);
-
-    // Get the SVG within the button and check its data-testid attribute
-    const button = screen.getByRole("button");
-    expect(button.firstChild).toHaveAttribute(
-      "data-testid",
-      "data-item-value-expand-icon"
+describe("Test DataItemList", () => {
+  it("renders a list of items that's not collapsible", () => {
+    render(
+      <DataItemList>
+        {"Item 1"}
+        {"Item 2"}
+        {"Item 3"}
+        {"Item 4"}
+        {"Item 5"}
+        {"Item 6"}
+        {"Item 7"}
+      </DataItemList>
     );
 
-    // Only the first 3 items should be displayed
-    expect(
-      screen.queryByTestId("displayed-item-IGVFFS0001AAAA")
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("displayed-item-IGVFFS0002AAAA")
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("displayed-item-IGVFFS0003AAAA")
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("displayed-item-IGVFFS0004AAAA")
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId("displayed-item-IGVFFS0005AAAA")
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId("displayed-item-IGVFFS0006AAAA")
-    ).not.toBeInTheDocument();
+    const items = screen.getAllByText(/Item [0-9]/);
+    expect(items.length).toBe(7);
+
+    const listItems = screen.getAllByRole("listitem");
+    listItems.forEach((item) => {
+      expect(item).toHaveClass("border-data-list-item");
+    });
+  });
+
+  it("renders a collapsible list that collapses when the control is clicked", () => {
+    render(
+      <DataItemList isCollapsible maxItemsBeforeCollapse={4}>
+        {"Item 1"}
+        {"Item 2"}
+        {"Item 3"}
+        {"Item 4"}
+        {"Item 5"}
+        {"Item 6"}
+        {"Item 7"}
+      </DataItemList>
+    );
+
+    let items = screen.getAllByText(/Item [0-9]/);
+    expect(items.length).toBe(4);
+
+    const button = screen.getByTestId("collapse-control-vertical");
+    fireEvent.click(button);
+    items = screen.getAllByText(/Item [0-9]/);
+    expect(items.length).toBe(7);
 
     fireEvent.click(button);
-    expect(button.firstChild).toHaveAttribute(
-      "data-testid",
-      "data-item-value-collapse-icon"
+    items = screen.getAllByText(/Item [0-9]/);
+    expect(items.length).toBe(4);
+  });
+
+  it("renders a single-item list and doesn't contain a border class", () => {
+    render(<DataItemList>{"Item 1"}</DataItemList>);
+
+    const listItems = screen.getAllByRole("listitem");
+    listItems.forEach((item) => {
+      expect(item).not.toHaveClass("border-data-list-item");
+    });
+  });
+
+  it("renders a list for URLs with the break-all class", () => {
+    render(
+      <DataItemList isUrlList>
+        <a href="https://igvf.org/" target="_blank" rel="noopener noreferrer">
+          https://igvf.org/
+        </a>
+        <a href="https://igvf.org/" target="_blank" rel="noopener noreferrer">
+          https://igvf.org/
+        </a>
+        <a href="https://igvf.org/" target="_blank" rel="noopener noreferrer">
+          https://igvf.org/
+        </a>
+      </DataItemList>
     );
 
-    // All items should be displayed
-    expect(
-      screen.queryByTestId("displayed-item-IGVFFS0001AAAA")
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("displayed-item-IGVFFS0002AAAA")
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("displayed-item-IGVFFS0003AAAA")
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("displayed-item-IGVFFS0004AAAA")
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("displayed-item-IGVFFS0005AAAA")
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("displayed-item-IGVFFS0006AAAA")
-    ).toBeInTheDocument();
-  });
-
-  it("does not render the collapse button if there are no items to collapse", () => {
-    const data = ["IGVFFS0001AAAA", "IGVFFS0002AAAA", "IGVFFS0003AAAA"];
-
-    function TestComponent() {
-      const collapser = useDataAreaCollapser(data);
-      return (
-        <>
-          <DataPanel>
-            <DataArea>
-              <DataItemLabel>Status</DataItemLabel>
-              <DataItemValue>
-                <SeparatedList>
-                  {collapser.displayedData.map((item) => (
-                    <div key={item} data-testid={`displayed-item-${item}`}>
-                      {item}
-                    </div>
-                  ))}
-                </SeparatedList>
-                <DataItemValueCollapseControl collapser={collapser}>
-                  <DataItemValueControlLabel collapser={collapser} />
-                </DataItemValueCollapseControl>
-              </DataItemValue>
-            </DataArea>
-          </DataPanel>
-        </>
-      );
-    }
-
-    render(<TestComponent />);
-
-    const button = screen.queryByRole("button");
-    expect(button).not.toBeInTheDocument();
-
-    // All items should be displayed
-    expect(
-      screen.queryByTestId("displayed-item-IGVFFS0001AAAA")
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("displayed-item-IGVFFS0002AAAA")
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("displayed-item-IGVFFS0003AAAA")
-    ).toBeInTheDocument();
-  });
-
-  it("renders nothing if you provide no data", () => {
-    function TestComponent() {
-      const collapser = useDataAreaCollapser();
-      return (
-        <>
-          <DataPanel>
-            <DataArea>
-              <DataItemLabel>Status</DataItemLabel>
-              <DataItemValue>
-                <SeparatedList>
-                  {collapser.displayedData.map((item) => (
-                    <div key={item} data-testid={`displayed-item-${item}`}>
-                      {item}
-                    </div>
-                  ))}
-                </SeparatedList>
-                <DataItemValueCollapseControl collapser={collapser}>
-                  <DataItemValueControlLabel collapser={collapser} />
-                </DataItemValueCollapseControl>
-              </DataItemValue>
-            </DataArea>
-          </DataPanel>
-        </>
-      );
-    }
-
-    render(<TestComponent />);
-
-    const button = screen.queryByRole("button");
-    expect(button).not.toBeInTheDocument();
+    const listItems = screen.getAllByRole("listitem");
+    listItems.forEach((item) => {
+      expect(item).toHaveClass("break-all");
+    });
   });
 });

--- a/components/__tests__/separated-list.test.js
+++ b/components/__tests__/separated-list.test.js
@@ -1,7 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import SeparatedList from "../separated-list";
 
-describe("SeparatedList", () => {
+describe("Test SeparatedList that's not collapsible", () => {
   it("displays a default comma-separated list", () => {
     render(
       <SeparatedList>
@@ -38,5 +38,56 @@ describe("SeparatedList", () => {
     // Result shows a single test item and no separator.
     expect(screen.getAllByText(/Item 1/)).toHaveLength(1);
     expect(screen.queryByTestId("comma")).toBeNull();
+  });
+
+  it("displays nothing with no items", () => {
+    render(<SeparatedList separator={<span data-testid="comma">, </span>} />);
+
+    // Result shows no items and no separator.
+    expect(screen.queryByTestId("comma")).toBeNull();
+  });
+});
+
+describe("Test SeparatedList that's collapsible", () => {
+  it("displays a list with a collapsible control", () => {
+    render(
+      <SeparatedList
+        separator={<span data-testid="separator"> sep </span>}
+        isCollapsible
+        maxItemsBeforeCollapse={3}
+      >
+        <div key="1" data-testid="item">
+          Item 1
+        </div>
+        <div key="2" data-testid="item">
+          Item 2
+        </div>
+        <div key="3" data-testid="item">
+          Item 3
+        </div>
+        <div key="4" data-testid="item">
+          Item 4
+        </div>
+      </SeparatedList>
+    );
+
+    // Result shows the two test items with a single comma and a collapsible control.
+    expect(screen.getAllByText(/Item [0-9]/)).toHaveLength(3);
+    expect(screen.getAllByTestId("separator")).toHaveLength(2);
+    expect(screen.getByTestId("collapse-control-inline")).toBeInTheDocument();
+
+    // Click the control to expand the list to all three items
+    act(() => {
+      screen.getByTestId("collapse-control-inline").click();
+    });
+    expect(screen.getAllByText(/Item [0-9]/)).toHaveLength(4);
+    expect(screen.getAllByTestId("separator")).toHaveLength(3);
+
+    // Click the control to collapse the list back to two items
+    act(() => {
+      screen.getByTestId("collapse-control-inline").click();
+    });
+    expect(screen.getAllByText(/Item [0-9]/)).toHaveLength(3);
+    expect(screen.getAllByTestId("separator")).toHaveLength(2);
   });
 });

--- a/components/attribution.js
+++ b/components/attribution.js
@@ -41,7 +41,7 @@ export default function Attribution({ attribution = null }) {
               <>
                 <DataItemLabel>Principal Investigator(s)</DataItemLabel>
                 <DataItemValue>
-                  <SeparatedList>
+                  <SeparatedList isCollapsible>
                     {attribution.pis.map((pi) => (
                       <Link href={pi["@id"]} key={pi["@id"]}>
                         {pi.title}

--- a/components/chromosome-locations.js
+++ b/components/chromosome-locations.js
@@ -1,5 +1,11 @@
 // node_modules
 import PropTypes from "prop-types";
+// components
+import {
+  CollapseControlVertical,
+  DEFAULT_MAX_COLLAPSE_ITEMS_VERTICAL,
+  useCollapseControl,
+} from "./collapse-control";
 
 /**
  * Display a single gene location and assembly.
@@ -32,23 +38,44 @@ ChromosomeLocation.propTypes = {
  */
 export default function ChromosomeLocations({
   locations,
+  isCollapsible = false,
+  maxItemsBeforeCollapse = DEFAULT_MAX_COLLAPSE_ITEMS_VERTICAL,
   className = null,
   testid = null,
 }) {
+  const collapser = useCollapseControl(
+    locations,
+    isCollapsible,
+    maxItemsBeforeCollapse
+  );
+
   return (
-    <ul className={className} data-testid={testid}>
-      {locations.map((location, index) => (
-        <li key={index} className="[&>div]:flex [&>div]:items-center">
-          <ChromosomeLocation location={location} />
-        </li>
-      ))}
-    </ul>
+    <div>
+      <ul className={className} data-testid={testid}>
+        {collapser.items.map((location, index) => (
+          <li key={index} className="[&>div]:flex [&>div]:items-center">
+            <ChromosomeLocation location={location} />
+          </li>
+        ))}
+      </ul>
+      {collapser.isCollapseControlVisible && (
+        <CollapseControlVertical
+          length={locations.length}
+          isCollapsed={collapser.isCollapsed}
+          setIsCollapsed={collapser.setIsCollapsed}
+        />
+      )}
+    </div>
   );
 }
 
 ChromosomeLocations.propTypes = {
   // Gene locations to display as defined in the schema
   locations: PropTypes.arrayOf(PropTypes.object).isRequired,
+  // True if the list should be collapsible
+  isCollapsible: PropTypes.bool,
+  // Maximum number of items before the list appears collapsed
+  maxItemsBeforeCollapse: PropTypes.number,
   // Tailwind CSS class name to apply to the wrapper around the gene location array display
   className: PropTypes.string,
   // Test ID for wrapper element

--- a/components/collapse-control.js
+++ b/components/collapse-control.js
@@ -145,7 +145,7 @@ export function CollapseControlVertical({
   return (
     <button
       onClick={() => setIsCollapsed(!isCollapsed)}
-      className="block items-center rounded-b-sm border-b border-l border-r border-collapse-ctrl bg-collapse-ctrl py-0.5 pl-2.5 pr-1.5 text-xs font-bold text-collapse-ctrl"
+      className="border-collapse-ctrl bg-collapse-ctrl text-collapse-ctrl block flex items-center rounded-b-sm border-b border-l border-r py-0.5 pl-2.5 pr-1.5 text-xs font-bold"
       data-testid="collapse-control-vertical"
       aria-label={label}
     >
@@ -153,12 +153,12 @@ export function CollapseControlVertical({
         <>
           {"ALL "}
           {length}
-          <ArrowDownIcon className="ml-0.5 inline-block h-3 w-3" />
+          <ArrowDownIcon className="ml-0.5 h-3 w-3" />
         </>
       ) : (
         <>
           {"FEWER "}
-          <ArrowUpIcon className="inline h-4 w-4" />
+          <ArrowUpIcon className="h-4 w-4" />
         </>
       )}
     </button>

--- a/components/collapse-control.js
+++ b/components/collapse-control.js
@@ -1,0 +1,175 @@
+/**
+ * Some lists of items might be so long that people don't want to see the whole thing by default.
+ * This module lets you display a truncated list of items with an expand/collapse control, but only
+ * if the list is long enough to need one. In this example, we show the list of items within a <ul>
+ * and have a collapse button appear if the list is long enough to need one.
+ *
+ * ```jsx
+ * const collapser = useCollapseControl(
+ *   items,
+ *   isCollapsible,
+ *   maxItemsBeforeCollapse
+ * );
+ *
+ * return (
+ *   <div>
+ *     <ul className={className} data-testid={testid}>
+ *       {collapser.items.map((location) => (
+ *         <li key={index}>
+ *           {location}
+ *         </li>
+ *       ))}
+ *     </ul>
+ *     {collapser.isCollapseControlVisible && (
+ *       <CollapseControlVertical
+ *         length={locations.length}
+ *         isCollapsed={collapser.isCollapsed}
+ *         setIsCollapsed={collapser.setIsCollapsed}
+ *       />
+ *     )}
+ *   </div>
+ * );
+ * ```
+ */
+
+// node_modules
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  ArrowDownIcon,
+  ArrowUpIcon,
+} from "@heroicons/react/20/solid";
+import PropTypes from "prop-types";
+import { useState } from "react";
+
+/**
+ * Hook to control the collapsed state of a list. It keeps the collapsed/expanded state and
+ * handles the truncation of the list of items while collapsed.
+ * @param {Array} items List of items to display
+ * @param {boolean} isCollapsible True if the list should be collapsible
+ * @param {number} maxItemsBeforeCollapse Max number of items before the list appears collapsed
+ * @returns {Object} Object containing the collapsed state, the collapsed/expanded state setter,
+ *   and the truncated list of items
+ */
+export function useCollapseControl(
+  items,
+  isCollapsible,
+  maxItemsBeforeCollapse
+) {
+  // True if the list appears collapsed
+  const [isCollapsed, setIsCollapsed] = useState(true);
+
+  const isCollapseControlVisible =
+    isCollapsible && items.length > maxItemsBeforeCollapse;
+  const truncatedItems =
+    isCollapseControlVisible && isCollapsed
+      ? items.slice(0, maxItemsBeforeCollapse)
+      : items;
+
+  return {
+    // True if the list appears collapsed; only applies if `isCollapsible` is true
+    isCollapsed,
+    // Function to set the collapsed state
+    setIsCollapsed,
+    // True if the list is collapsable and has enough items to need one
+    isCollapseControlVisible,
+    // Truncated list of items to display
+    items: truncatedItems,
+  };
+}
+
+/**
+ * Default maximum number of inline items before the list appears collapsed, and an expand/collapse
+ * control appears.
+ */
+export const DEFAULT_MAX_COLLAPSE_ITEMS_INLINE = 10;
+
+/**
+ * Default maximum number of vertical items before the list appears collapsed, and an
+ * expand/collapse control appears.
+ */
+export const DEFAULT_MAX_COLLAPSE_ITEMS_VERTICAL = 5;
+
+/**
+ * Displays the expand/collapse control for a collapsible list.
+ */
+export function CollapseControlInline({ length, isCollapsed, setIsCollapsed }) {
+  const label = isCollapsed
+    ? `Show all ${length} items in list`
+    : `Show fewer items in list`;
+
+  return (
+    <button
+      onClick={() => setIsCollapsed(!isCollapsed)}
+      className="ml-1 inline items-center rounded-sm border border-collapse-ctrl bg-collapse-ctrl pl-1.5 pr-1 text-xs font-bold text-collapse-ctrl"
+      data-testid="collapse-control-inline"
+      aria-label={label}
+    >
+      {isCollapsed ? (
+        <>
+          {"ALL "}
+          {length}
+          <ArrowRightIcon className="inline-block h-3 w-3" />
+        </>
+      ) : (
+        <>
+          {"FEWER "}
+          <ArrowLeftIcon className="inline h-4 w-4" />
+        </>
+      )}
+    </button>
+  );
+}
+
+CollapseControlInline.propTypes = {
+  // Total length of the list
+  length: PropTypes.number.isRequired,
+  // True if the list appears collapsed
+  isCollapsed: PropTypes.bool.isRequired,
+  // Function to set the collapsed state
+  setIsCollapsed: PropTypes.func.isRequired,
+};
+
+/**
+ * Displays the expand/collapse control for `<DataItemList>`.
+ */
+export function CollapseControlVertical({
+  length,
+  isCollapsed,
+  setIsCollapsed,
+}) {
+  const label = isCollapsed
+    ? `Show all ${length} items in list`
+    : `Show fewer items in list`;
+
+  return (
+    <button
+      onClick={() => setIsCollapsed(!isCollapsed)}
+      className="block items-center rounded-b-sm border-b border-l border-r border-collapse-ctrl bg-collapse-ctrl py-0.5 pl-2.5 pr-1.5 text-xs font-bold text-collapse-ctrl"
+      data-testid="collapse-control-vertical"
+      aria-label={label}
+    >
+      {isCollapsed ? (
+        <>
+          {"ALL "}
+          {length}
+          <ArrowDownIcon className="ml-0.5 inline-block h-3 w-3" />
+        </>
+      ) : (
+        <>
+          {"FEWER "}
+          <ArrowUpIcon className="inline h-4 w-4" />
+        </>
+      )}
+    </button>
+  );
+}
+
+CollapseControlVertical.propTypes = {
+  // Total length of the list
+  length: PropTypes.number.isRequired,
+  // True if the list appears collapsed
+  isCollapsed: PropTypes.bool.isRequired,
+  // Function to set the collapsed state
+  setIsCollapsed: PropTypes.func.isRequired,
+};

--- a/components/common-data-items.js
+++ b/components/common-data-items.js
@@ -13,15 +13,14 @@
 // node_modules
 import Link from "next/link";
 import PropTypes from "prop-types";
+import { Fragment } from "react";
 // components
 import AliasList from "./alias-list";
 import {
   DataItemLabel,
+  DataItemList,
   DataItemValue,
-  DataItemValueCollapseControl,
-  DataItemValueControlLabel,
   DataItemValueUrl,
-  useDataAreaCollapser,
 } from "./data-area";
 import DbxrefList from "./dbxref-list";
 import ProductInfo from "./product-info";
@@ -85,7 +84,7 @@ export function DonorDataItems({ item, children }) {
         <>
           <DataItemLabel>Publication Identifiers</DataItemLabel>
           <DataItemValue>
-            <DbxrefList dbxrefs={item.publication_identifiers} />
+            <DbxrefList dbxrefs={item.publication_identifiers} isCollapsible />
           </DataItemValue>
         </>
       )}
@@ -129,42 +128,25 @@ export function SampleDataItems({
   constructLibrarySets = [],
   children,
 }) {
-  const constructLibrarySetCollapser =
-    useDataAreaCollapser(constructLibrarySets);
-
   return (
     <>
       <DataItemLabel>Summary</DataItemLabel>
       <DataItemValue>{item.summary}</DataItemValue>
       {children}
-      {constructLibrarySetCollapser.displayedData.length > 0 && (
+      {constructLibrarySets.length > 0 && (
         <>
           <DataItemLabel>Construct Library Sets</DataItemLabel>
-          <DataItemValue>
-            {constructLibrarySetCollapser.displayedData.map((con, i) => {
-              return (
-                <div key={con["@id"]} className="my-1 first:mt-0 last:mb-0">
-                  <div>
-                    <Link href={con["@id"]}>{con.accession}</Link>
-                    <span className="text-gray-400 dark:text-gray-600">
-                      {" "}
-                      {con.summary}
-                    </span>
-                  </div>
-                  {i ===
-                    constructLibrarySetCollapser.displayedData.length - 1 && (
-                    <DataItemValueCollapseControl
-                      collapser={constructLibrarySetCollapser}
-                    >
-                      <DataItemValueControlLabel
-                        collapser={constructLibrarySetCollapser}
-                      />
-                    </DataItemValueCollapseControl>
-                  )}
-                </div>
-              );
-            })}
-          </DataItemValue>
+          <DataItemList isCollapsible>
+            {constructLibrarySets.map((fileSet) => (
+              <Fragment key={fileSet["@id"]}>
+                <Link href={fileSet["@id"]}>{fileSet.accession}</Link>
+                <span className="text-gray-600 dark:text-gray-400">
+                  {" "}
+                  {fileSet.summary}
+                </span>
+              </Fragment>
+            ))}
+          </DataItemList>
         </>
       )}
       {item.virtual && (
@@ -227,7 +209,7 @@ export function SampleDataItems({
             Sorted Fraction{sortedFractions.length === 1 ? "" : "s"} of Sample
           </DataItemLabel>
           <DataItemValue>
-            <SeparatedList>
+            <SeparatedList isCollapsible>
               {sortedFractions.map((sample) => (
                 <Link href={sample["@id"]} key={sample.accession}>
                   {sample.accession}
@@ -241,7 +223,7 @@ export function SampleDataItems({
         <>
           <DataItemLabel>Multiplexed In</DataItemLabel>
           <DataItemValue>
-            <SeparatedList>
+            <SeparatedList isCollapsible>
               {item.multiplexed_in.map((sample) => (
                 <Link href={sample["@id"]} key={sample.accession}>
                   {sample.accession}
@@ -271,7 +253,7 @@ export function SampleDataItems({
         <>
           <DataItemLabel>External Resources</DataItemLabel>
           <DataItemValue>
-            <DbxrefList dbxrefs={item.dbxrefs} />
+            <DbxrefList dbxrefs={item.dbxrefs} isCollapsible />
           </DataItemValue>
         </>
       )}
@@ -299,7 +281,7 @@ export function SampleDataItems({
         <>
           <DataItemLabel>Publication Identifiers</DataItemLabel>
           <DataItemValue>
-            <DbxrefList dbxrefs={item.publication_identifiers} />
+            <DbxrefList dbxrefs={item.publication_identifiers} isCollapsible />
           </DataItemValue>
         </>
       )}
@@ -427,7 +409,7 @@ export function BiosampleDataItems({
             Pooled From Sample{pooledFrom.length === 1 ? "" : "s"}
           </DataItemLabel>
           <DataItemValue>
-            <SeparatedList>
+            <SeparatedList isCollapsible>
               {pooledFrom.map((biosample) => (
                 <Link href={biosample["@id"]} key={biosample["@id"]}>
                   {biosample.accession}
@@ -443,7 +425,7 @@ export function BiosampleDataItems({
             Pooled In Sample{pooledIn.length === 1 ? "" : "s"}
           </DataItemLabel>
           <DataItemValue>
-            <SeparatedList>
+            <SeparatedList isCollapsible>
               {pooledIn.map((biosample) => (
                 <Link href={biosample["@id"]} key={biosample["@id"]}>
                   {biosample.accession}
@@ -459,7 +441,7 @@ export function BiosampleDataItems({
             Sample Part{parts.length === 1 ? "" : "s"}
           </DataItemLabel>
           <DataItemValue>
-            <SeparatedList>
+            <SeparatedList isCollapsible>
               {parts.map((biosample) => (
                 <Link href={biosample["@id"]} key={biosample["@id"]}>
                   {biosample.accession}
@@ -481,7 +463,7 @@ export function BiosampleDataItems({
         <>
           <DataItemLabel>Disease Terms</DataItemLabel>
           <DataItemValue>
-            <SeparatedList>
+            <SeparatedList isCollapsible>
               {diseaseTerms.map((diseaseTerm) => (
                 <Link href={diseaseTerm["@id"]} key={diseaseTerm["@id"]}>
                   {diseaseTerm.term_name}
@@ -501,7 +483,7 @@ export function BiosampleDataItems({
         <>
           <DataItemLabel>Donors</DataItemLabel>
           <DataItemValue>
-            <SeparatedList>
+            <SeparatedList isCollapsible>
               {donors.map((donor) => (
                 <Link href={donor["@id"]} key={donor.uuid}>
                   {donor.accession}
@@ -568,7 +550,7 @@ export function OntologyTermDataItems({ item, isA, children }) {
         <>
           <DataItemLabel>List of Term Names</DataItemLabel>
           <DataItemValue>
-            <SeparatedList>
+            <SeparatedList isCollapsible>
               {isA.map((term) => (
                 <Link href={term["@id"]} key={term.term_id}>
                   {term.term_name}
@@ -660,7 +642,7 @@ export function FileDataItems({ item, fileSet = null, children }) {
         <>
           <DataItemLabel>External Resources</DataItemLabel>
           <DataItemValue>
-            <DbxrefList dbxrefs={item.dbxrefs} />
+            <DbxrefList dbxrefs={item.dbxrefs} isCollapsible />
           </DataItemValue>
         </>
       )}
@@ -774,7 +756,7 @@ export function FileSetDataItems({ item, children }) {
         <>
           <DataItemLabel>External Resources</DataItemLabel>
           <DataItemValue>
-            <DbxrefList dbxrefs={item.dbxrefs} />
+            <DbxrefList dbxrefs={item.dbxrefs} isCollapsible />
           </DataItemValue>
         </>
       )}

--- a/components/data-area.js
+++ b/components/data-area.js
@@ -11,11 +11,15 @@
  */
 
 // node_modules
-import { BarsArrowDownIcon, BarsArrowUpIcon } from "@heroicons/react/20/solid";
 import PropTypes from "prop-types";
-import { useState } from "react";
+import { Children } from "react";
 // components
-import { Button, ButtonLink } from "./form-elements";
+import {
+  CollapseControlVertical,
+  DEFAULT_MAX_COLLAPSE_ITEMS_VERTICAL,
+  useCollapseControl,
+} from "./collapse-control";
+import { ButtonLink } from "./form-elements";
 
 /**
  * Displays a panel -- typically to display data items for an object, but you can use this for
@@ -152,146 +156,55 @@ DataItemValueUrl.propTypes = {
 };
 
 /**
- * Default number of items to display in a collapsible/expandable data area before considering it
- * collapsible. A data area with fewer than this number of items will not appear collapsible.
+ * Display a collapsable list of items in the value area of a data item.
  */
-const DEFAULT_COLLAPSE_LIMIT = 3;
-
-/**
- * Hook to manage the collapsed/expanded state of a data area value. We have chosen certain array
- * data items to appear with fewer than their full number of items, with a button to expand them to
- * their full number. This hook manages the state of the data area, including whether it appears
- * collapsed or expanded, and whether it has enough items to collapse at all. Here's an example
- * where we want to display a collapsible list of samples, and display a button to expand or
- * collapse the list. The last item of the list is the button to expand or collapse the list (which
- * just one way to handle this):
- *
- * const samplesCollapser = useDataAreaCollapser(samples || []);
- * {samplesCollapser.displayedData.length > 0 && (
- *   <>
- *     <DataItemLabel className="flex items-baseline">Samples</DataItemLabel>
- *     <DataItemValue>
- *       <SeparatedList>
- *         {samplesCollapser.displayedData.map((sample, index) => (
- *            <Fragment key={sample.accession}>{sample.accession}</Fragment>
- *         ))}
- *         {index === samplesCollapser.displayedData.length - 1 && (
- *           <DataItemValueCollapseControl key="collapse" collapser={samplesCollapser} />
- *         )}
- *       </SeparatedList>
- *     </DataItemValue>
- *   </>
- * )}
- *
- * For consistency, the object `useDataAreaCollapser` returns we often call a "collapser" preceded
- * by the name of the property it controls.
- *
- * @param {Array<any>} data Data to display as either a collapsed or full list
- * @param {number} collapseLimit Number of items to display when collapsed
- * @param {boolean} defaultIsCollapsed True if the data should appear collapsed by default
- * @returns {object} Contains the following properties:
- *   isCollapsed: True if the data is collapsed; invalid if `isCollapsible` is false
- *   setIsCollapsed: Function to set the collapsed/expanded states
- *   isCollapsible: True if the data has more than `collapseLimit` items
- *   isDataTruncated: True if `displayedData` has been truncated to `collapseLimit` items
- *   displayedData: The data to display -- either the full or truncated list
- *   hiddenDataCount: Number of items hidden when `isDataTruncated` is true
- */
-export function useDataAreaCollapser(
-  data = [],
-  collapseLimit = DEFAULT_COLLAPSE_LIMIT,
-  defaultIsCollapsed = true
-) {
-  const [isCollapsed, setIsCollapsed] = useState(defaultIsCollapsed);
-  const isCollapsible = data.length > collapseLimit;
-  const isDataTruncated = isCollapsible && isCollapsed;
-  const displayedData = isDataTruncated ? data.slice(0, collapseLimit) : data;
-  const hiddenDataCount = isDataTruncated ? data.length - collapseLimit : 0;
-
-  return {
-    isCollapsed,
-    setIsCollapsed,
-    isCollapsible,
-    isDataTruncated,
-    displayedData,
-    hiddenDataCount,
-  };
-}
-
-/**
- * Displays a button to expand or collapse a data item value. This button only appears if the
- * `isExpandable` property of the given collapser object holds true. Place this button within a
- * <DataItemValue> element. This takes an optional child element to display next to the button, and
- * typically you would use <DataItemValueControlLabel> for this.
- */
-export function DataItemValueCollapseControl({
-  collapser,
-  className = null,
+export function DataItemList({
+  isCollapsible = false,
+  maxItemsBeforeCollapse = DEFAULT_MAX_COLLAPSE_ITEMS_VERTICAL,
+  isUrlList = false,
   children,
 }) {
-  return (
-    <>
-      {collapser.isCollapsible && (
-        <div className={className}>
-          <Button
-            type="secondary"
-            size="sm"
-            hasIconOnly
-            onClick={() => collapser.setIsCollapsed(!collapser.isCollapsed)}
-          >
-            {collapser.isCollapsed ? (
-              <BarsArrowDownIcon
-                data-testid="data-item-value-expand-icon"
-                className="h-4 w-4"
-              />
-            ) : (
-              <BarsArrowUpIcon
-                data-testid="data-item-value-collapse-icon"
-                className="h-4 w-4"
-              />
-            )}
-            {children}
-          </Button>
-        </div>
-      )}
-    </>
+  const childArray = Children.toArray(children);
+  const collapser = useCollapseControl(
+    childArray,
+    isCollapsible,
+    maxItemsBeforeCollapse
   );
-}
 
-DataItemValueCollapseControl.propTypes = {
-  // Object returned by `useDataAreaCollapser`
-  collapser: PropTypes.shape({
-    isCollapsed: PropTypes.bool.isRequired,
-    setIsCollapsed: PropTypes.func.isRequired,
-    isCollapsible: PropTypes.bool.isRequired,
-  }).isRequired,
-  // Additional Tailwind CSS classes to apply to the wrapping div
-  className: PropTypes.string,
-};
+  const hasSingleChild = childArray.length === 1;
+  const urlListCss = isUrlList ? "break-all" : "";
 
-/**
- * You can place this component as a child of <DataItemValueCollapseControl> to display a label
- * indicating how many items are hidden while the data is collapsed, or just the word "fewer"
- * while the data is expanded.
- */
-export function DataItemValueControlLabel({ collapser }) {
   return (
-    <div className="ml-1 text-xs">
-      {collapser.hiddenDataCount > 0 ? (
-        <>{`${collapser.hiddenDataCount} more`}</>
-      ) : (
-        <>fewer</>
+    <div>
+      <ul className={hasSingleChild ? "" : "border border-data-list-item"}>
+        {Children.map(collapser.items, (child) => (
+          <li
+            className={`${
+              hasSingleChild
+                ? ""
+                : "border-b border-data-list-item px-2 py-0.5 last:border-none"
+            } ${urlListCss}`}
+          >
+            {child}
+          </li>
+        ))}
+      </ul>
+      {collapser.isCollapseControlVisible && (
+        <CollapseControlVertical
+          length={children.length}
+          isCollapsed={collapser.isCollapsed}
+          setIsCollapsed={collapser.setIsCollapsed}
+        />
       )}
     </div>
   );
 }
 
-DataItemValueControlLabel.propTypes = {
-  // Collapser object returned by `useDataAreaCollapser`
-  collapser: PropTypes.shape({
-    isCollapsed: PropTypes.bool.isRequired,
-    setIsCollapsed: PropTypes.func.isRequired,
-    isCollapsible: PropTypes.bool.isRequired,
-    hiddenDataCount: PropTypes.number.isRequired,
-  }).isRequired,
+DataItemList.propTypes = {
+  // True if the list should be collapsible
+  isCollapsible: PropTypes.bool,
+  // Maximum number of items before the list appears collapsed
+  maxItemsBeforeCollapse: PropTypes.number,
+  // True if the list contains URLs, and should break on any character
+  isUrlList: PropTypes.bool,
 };

--- a/components/dbxref-list.js
+++ b/components/dbxref-list.js
@@ -242,9 +242,13 @@ DbxrefItem.propTypes = {
 /**
  * Display a comma-separated list of linked dbxrefs.
  */
-export default function DbxrefList({ dbxrefs, meta = {} }) {
+export default function DbxrefList({
+  dbxrefs,
+  isCollapsible = false,
+  meta = {},
+}) {
   return (
-    <SeparatedList>
+    <SeparatedList isCollapsible={isCollapsible}>
       {_.uniq(dbxrefs).map((dbxref) => {
         return <DbxrefItem key={dbxref} dbxref={dbxref} meta={meta} />;
       })}
@@ -255,6 +259,8 @@ export default function DbxrefList({ dbxrefs, meta = {} }) {
 DbxrefList.propTypes = {
   // Dbxrefs to display
   dbxrefs: PropTypes.arrayOf(PropTypes.string).isRequired,
+  // True if the list of linked dbxrefs should be collapsible
+  isCollapsible: PropTypes.bool,
   // Metadata that affects certain dbxrefs
   meta: PropTypes.object,
 };

--- a/components/product-info.js
+++ b/components/product-info.js
@@ -13,7 +13,7 @@ export default function ProductInfo({
   productId = null,
   lotId = null,
 }) {
-  const prodLot = lotId ? `${productId} (${lotId})` : "";
+  const prodLot = lotId ? `${productId} (${lotId})` : productId;
   if (sources.length > 0) {
     const sourceType = pathToType(sources[0]["@id"]);
     if (sourceType === "sources") {

--- a/components/separated-list.js
+++ b/components/separated-list.js
@@ -1,6 +1,12 @@
 // node_modules
 import PropTypes from "prop-types";
-import React from "react";
+import { Children, Fragment } from "react";
+// components
+import {
+  CollapseControlInline,
+  DEFAULT_MAX_COLLAPSE_ITEMS_INLINE,
+  useCollapseControl,
+} from "./collapse-control";
 
 /**
  * Display a list of inline React components with a separator between the items -- sort of like
@@ -42,23 +48,42 @@ export default function SeparatedList({
   separator = ", ",
   className = "",
   testid = null,
+  isCollapsible = false,
+  maxItemsBeforeCollapse = DEFAULT_MAX_COLLAPSE_ITEMS_INLINE,
   children,
 }) {
-  if (children.length > 0) {
+  const collapser = useCollapseControl(
+    children,
+    isCollapsible,
+    maxItemsBeforeCollapse
+  );
+  const items = isCollapsible ? collapser.items : Children.toArray(children);
+
+  if (items.length > 0) {
     return (
       <div className={className || ""} data-testid={testid}>
-        {children
+        {items
           .filter(Boolean)
-          .map((item) => <React.Fragment key={item.key}>{item}</React.Fragment>)
+          .map((item) => <Fragment key={item.key}>{item}</Fragment>)
           .reduce((combined, curr, index) => [
             combined,
-            <React.Fragment key={`sep-${index}`}>{separator}</React.Fragment>,
-            curr,
+            <Fragment key={`sep-${index}`}>{separator}</Fragment>,
+            <Fragment key={`sep-${index + 1}`}>
+              {curr}
+              {collapser.isCollapseControlVisible &&
+              index === collapser.items.length - 1 ? (
+                <CollapseControlInline
+                  length={children.length}
+                  isCollapsed={collapser.isCollapsed}
+                  setIsCollapsed={collapser.setIsCollapsed}
+                />
+              ) : null}
+            </Fragment>,
           ])}
       </div>
     );
   }
-  return <div className={className || ""}>{children}</div>;
+  return null;
 }
 
 SeparatedList.propTypes = {
@@ -68,4 +93,8 @@ SeparatedList.propTypes = {
   className: PropTypes.string,
   // Test ID for wrapper element
   testid: PropTypes.string,
+  // True if the list should be collapsible
+  isCollapsible: PropTypes.bool,
+  // Maximum number of items before the list appears collapsed
+  maxItemsBeforeCollapse: PropTypes.number,
 };

--- a/lib/common-requests.ts
+++ b/lib/common-requests.ts
@@ -185,27 +185,6 @@ export async function requestOntologyTerms(
 }
 
 /**
- * Retrieve the phenotypic-feature objects for the given phenotypic-feature paths from the data
- * provider.
- * @param {Array<string>} paths Paths to the phenotypic-feature objects to request
- * @param {FetchRequest} request The request object to use to make the request
- * @returns {Array<object>} The phenotypic features objects requested
- */
-export async function requestPhenotypicFeatures(
-  paths: Array<string>,
-  request: FetchRequest
-): Promise<Array<DataProviderObject>> {
-  return (
-    await request.getMultipleObjectsBulk(paths, [
-      "feature",
-      "observation_date",
-      "quantity",
-      "quantity_units",
-    ])
-  ).unwrap_or([]);
-}
-
-/**
  * Retrieve the samples objects for the given sample paths from the data provider.
  * @param {Array<string>} paths Paths to the samples objects to request
  * @param {FetchRequest} request The request object to use to make the request

--- a/pages/alignment-files/[...id].js
+++ b/pages/alignment-files/[...id].js
@@ -73,7 +73,7 @@ export default function AlignmentFile({
                 <>
                   <DataItemLabel>Reference Files</DataItemLabel>
                   <DataItemValue>
-                    <SeparatedList>
+                    <SeparatedList isCollapsible>
                       {referenceFiles.map((file) => (
                         <Link href={file["@id"]} key={file["@id"]}>
                           {file.accession}

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -71,7 +71,10 @@ export default function AnalysisSet({
                 <>
                   <DataItemLabel>Publication Identifiers</DataItemLabel>
                   <DataItemValue>
-                    <DbxrefList dbxrefs={analysisSet.publication_identifiers} />
+                    <DbxrefList
+                      dbxrefs={analysisSet.publication_identifiers}
+                      isCollapsible
+                    />
                   </DataItemValue>
                 </>
               )}

--- a/pages/analysis-steps/[id].js
+++ b/pages/analysis-steps/[id].js
@@ -63,19 +63,23 @@ export default function AnalysisStep({
               </DataItemValue>
               <DataItemLabel>Input Content Types</DataItemLabel>
               <DataItemValue>
-                {analysisStep.input_content_types.join(", ")}
+                <SeparatedList isCollapsible>
+                  {analysisStep.input_content_types}
+                </SeparatedList>
               </DataItemValue>
               <DataItemLabel>Output Content Types</DataItemLabel>
               <DataItemValue>
-                {analysisStep.output_content_types.join(", ")}
+                <SeparatedList isCollapsible>
+                  {analysisStep.output_content_types}
+                </SeparatedList>
               </DataItemValue>
               {analysisStep.parents?.length > 0 && (
                 <>
                   <DataItemLabel>Parents</DataItemLabel>
                   <DataItemValue>
-                    <SeparatedList>
+                    <SeparatedList isCollapsible>
                       {analysisStep.parents.map((parent) => (
-                        <Link href={parent} key={parent}>
+                        <Link href={parent["@id"]} key={parent["@id"]}>
                           {parent.title}
                         </Link>
                       ))}

--- a/pages/auxiliary-sets/[id].js
+++ b/pages/auxiliary-sets/[id].js
@@ -33,7 +33,6 @@ import {
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import { truthyOrZero } from "../../lib/general";
 import { splitIlluminaSequenceFiles } from "../../lib/files";
 import { isJsonFormat } from "../../lib/query-utils";
 
@@ -42,7 +41,6 @@ export default function AuxiliarySet({
   documents,
   donors,
   libraryConstructionPlatform = null,
-  constructLibraries,
   files,
   relatedDatasets,
   seqspecFiles,
@@ -72,7 +70,7 @@ export default function AuxiliarySet({
                   <>
                     <DataItemLabel>Donors</DataItemLabel>
                     <DataItemValue>
-                      <SeparatedList>
+                      <SeparatedList isCollapsible>
                         {donors.map((donor) => (
                           <Link href={donor["@id"]} key={donor.uuid}>
                             {donor.accession}
@@ -86,7 +84,7 @@ export default function AuxiliarySet({
                   <>
                     <DataItemLabel>Samples</DataItemLabel>
                     <DataItemValue>
-                      <SeparatedList>
+                      <SeparatedList isCollapsible>
                         {auxiliarySet.samples.map((sample) => (
                           <Link href={sample["@id"]} key={sample["@id"]}>
                             {sample.accession}
@@ -104,29 +102,6 @@ export default function AuxiliarySet({
                         {libraryConstructionPlatform.term_name}
                       </Link>
                     </DataItemValue>
-                  </>
-                )}
-                {constructLibraries.length > 0 && (
-                  <>
-                    <DataItemLabel>Construct Libraries</DataItemLabel>
-                    <DataItemValue>
-                      <SeparatedList>
-                        {constructLibraries.map((constructLibrary) => (
-                          <Link
-                            href={constructLibrary["@id"]}
-                            key={constructLibrary["@id"]}
-                          >
-                            {constructLibrary.accession}
-                          </Link>
-                        ))}
-                      </SeparatedList>
-                    </DataItemValue>
-                  </>
-                )}
-                {truthyOrZero(auxiliarySet.moi) && (
-                  <>
-                    <DataItemLabel>MOI</DataItemLabel>
-                    <DataItemValue>{auxiliarySet.moi}</DataItemValue>
                   </>
                 )}
               </FileSetDataItems>
@@ -196,8 +171,6 @@ AuxiliarySet.propTypes = {
   donors: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Library construction platform object
   libraryConstructionPlatform: PropTypes.object,
-  // Construct library objects
-  constructLibraries: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Files to display
   files: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Related Datasets to display
@@ -239,10 +212,6 @@ export async function getServerSideProps({ params, req, query }) {
             await request.getObject(auxiliarySet.library_construction_platform)
           ).optional()
         : null;
-
-    const constructLibraries = auxiliarySet.construct_libraries
-      ? await requestFileSets(auxiliarySet.construct_libraries, request)
-      : [];
 
     let files = [];
     if (auxiliarySet.files.length > 0) {
@@ -302,7 +271,6 @@ export async function getServerSideProps({ params, req, query }) {
         documents,
         donors,
         libraryConstructionPlatform,
-        constructLibraries,
         files,
         relatedDatasets,
         seqspecFiles,

--- a/pages/awards/[name].js
+++ b/pages/awards/[name].js
@@ -45,7 +45,7 @@ export default function Award({ award, pis, contactPi, isJson }) {
                 <>
                   <DataItemLabel>Principal Investigator(s)</DataItemLabel>
                   <DataItemValue>
-                    <SeparatedList>
+                    <SeparatedList isCollapsible>
                       {pis.map((pi) => (
                         <Link href={pi["@id"]} key={pi["@id"]}>
                           {pi.title}

--- a/pages/biomarkers/[id].js
+++ b/pages/biomarkers/[id].js
@@ -15,6 +15,7 @@ import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
+import SeparatedList from "../../components/separated-list";
 // lib
 import buildAttribution from "../../lib/attribution";
 import { getBiomarkerTitle } from "../../lib/biomarker";
@@ -65,7 +66,11 @@ export default function Biomarker({
               {biomarker.synonyms?.length > 0 && (
                 <>
                   <DataItemLabel>Synonyms</DataItemLabel>
-                  <DataItemValue>{biomarker.synonyms.join(", ")}</DataItemValue>
+                  <DataItemValue>
+                    <SeparatedList isCollapsible>
+                      {biomarker.synonyms}
+                    </SeparatedList>
+                  </DataItemValue>
                 </>
               )}
               {biomarker.aliases?.length > 0 && (

--- a/pages/construct-library-sets/[id].js
+++ b/pages/construct-library-sets/[id].js
@@ -6,17 +6,13 @@ import { Fragment } from "react";
 import AlternateAccessions from "../../components/alternate-accessions";
 import Attribution from "../../components/attribution";
 import Breadcrumbs from "../../components/breadcrumbs";
-import ChromosomeLocations from "../../components/chromosome-locations";
 import { FileSetDataItems } from "../../components/common-data-items";
 import {
   DataArea,
   DataItemLabel,
   DataAreaTitle,
   DataItemValue,
-  DataItemValueCollapseControl,
-  DataItemValueControlLabel,
   DataPanel,
-  useDataAreaCollapser,
 } from "../../components/data-area";
 import DbxrefList from "../../components/dbxref-list";
 import DocumentTable from "../../components/document-table";
@@ -47,9 +43,6 @@ import { isJsonFormat } from "../../lib/query-utils";
  * case the data is malformed.
  */
 function LibraryDetails({ library }) {
-  const genesCollapser = useDataAreaCollapser(library.genes);
-  const lociCollapser = useDataAreaCollapser(library.loci);
-
   return (
     <>
       <DataAreaTitle className="capitalize">
@@ -65,7 +58,7 @@ function LibraryDetails({ library }) {
             <>
               <DataItemLabel>Associated Phenotypes</DataItemLabel>
               <DataItemValue>
-                <SeparatedList>
+                <SeparatedList isCollapsible>
                   {library.associated_phenotypes.map((phenotype) => (
                     <Link href={phenotype["@id"]} key={phenotype["@id"]}>
                       {phenotype.term_name}
@@ -123,44 +116,6 @@ function LibraryDetails({ library }) {
             <>
               <DataItemLabel>Exon</DataItemLabel>
               <DataItemValue>{library.exon}</DataItemValue>
-            </>
-          )}
-          {genesCollapser.displayedData.length > 0 && (
-            <>
-              <DataItemLabel>Genes</DataItemLabel>
-              <DataItemValue>
-                <SeparatedList>
-                  {genesCollapser.displayedData.map((gene, index) => (
-                    <Fragment key={gene["@id"]}>
-                      <Link href={gene["@id"]}>{gene.geneid}</Link>
-                      {index === genesCollapser.displayedData.length - 1 && (
-                        <DataItemValueCollapseControl
-                          key="more-control"
-                          collapser={genesCollapser}
-                          className="ml-1 inline-block"
-                        >
-                          <DataItemValueControlLabel
-                            key="more-control"
-                            collapser={genesCollapser}
-                            className="ml-1 inline-block"
-                          />
-                        </DataItemValueCollapseControl>
-                      )}
-                    </Fragment>
-                  ))}
-                </SeparatedList>
-              </DataItemValue>
-            </>
-          )}
-          {lociCollapser.displayedData.length > 0 && (
-            <>
-              <DataItemLabel>Loci</DataItemLabel>
-              <DataItemValue>
-                <ChromosomeLocations locations={lociCollapser.displayedData} />
-                <DataItemValueCollapseControl collapser={lociCollapser}>
-                  <DataItemValueControlLabel collapser={lociCollapser} />
-                </DataItemValueCollapseControl>
-              </DataItemValue>
             </>
           )}
         </DataArea>

--- a/pages/curated-sets/[id].js
+++ b/pages/curated-sets/[id].js
@@ -67,6 +67,7 @@ export default function CuratedSet({
                     <DataItemValue>
                       <DbxrefList
                         dbxrefs={curatedSet.publication_identifiers}
+                        isCollapsible
                       />
                     </DataItemValue>
                   </>
@@ -75,7 +76,7 @@ export default function CuratedSet({
                   <>
                     <DataItemLabel>Donors</DataItemLabel>
                     <DataItemValue>
-                      <SeparatedList>
+                      <SeparatedList isCollapsible>
                         {donors.map((donor) => (
                           <Link href={donor["@id"]} key={donor.uuid}>
                             {donor.accession}
@@ -89,7 +90,7 @@ export default function CuratedSet({
                   <>
                     <DataItemLabel>Samples</DataItemLabel>
                     <DataItemValue>
-                      <SeparatedList>
+                      <SeparatedList isCollapsible>
                         {curatedSet.samples.map((sample) => (
                           <Link href={sample["@id"]} key={sample["@id"]}>
                             {sample.accession}

--- a/pages/documents/[id].js
+++ b/pages/documents/[id].js
@@ -8,8 +8,8 @@ import Breadcrumbs from "../../components/breadcrumbs";
 import {
   DataArea,
   DataItemLabel,
+  DataItemList,
   DataItemValue,
-  DataItemValueUrl,
   DataPanel,
 } from "../../components/data-area";
 import DocumentAttachmentLink from "../../components/document-link";
@@ -63,7 +63,7 @@ export default function Document({ document, attribution = null, isJson }) {
               {document.urls?.length > 0 && (
                 <>
                   <DataItemLabel>Additional Information</DataItemLabel>
-                  <DataItemValueUrl>
+                  <DataItemList isCollapsible isUrlList>
                     {document.urls.map((url) => (
                       <div key={url}>
                         <a href={url} target="_blank" rel="noopener noreferrer">
@@ -71,7 +71,7 @@ export default function Document({ document, attribution = null, isJson }) {
                         </a>
                       </div>
                     ))}
-                  </DataItemValueUrl>
+                  </DataItemList>
                 </>
               )}
               <DataItemLabel>Download</DataItemLabel>

--- a/pages/genes/[id].js
+++ b/pages/genes/[id].js
@@ -20,6 +20,7 @@ import buildBreadcrumbs from "../../lib/breadcrumbs";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
+import SeparatedList from "../../components/separated-list";
 
 function EnsemblLink({ geneid, taxa }) {
   const organism = taxa.replace(/ /g, "_");
@@ -66,6 +67,7 @@ export default function Gene({ gene, isJson }) {
                     <DbxrefList
                       dbxrefs={gene.dbxrefs}
                       meta={{ taxa: gene.taxa }}
+                      isCollapsible
                     />
                   </DataItemValue>
                 </>
@@ -79,14 +81,23 @@ export default function Gene({ gene, isJson }) {
               {gene.synonyms?.length > 0 && (
                 <>
                   <DataItemLabel>Synonyms</DataItemLabel>
-                  <DataItemValue>{gene.synonyms.join(", ")}</DataItemValue>
+                  <DataItemValue>
+                    <SeparatedList isCollapsible>
+                      {gene.synonyms.map((synonym) => (
+                        <span key={synonym}>{synonym}</span>
+                      ))}
+                    </SeparatedList>
+                  </DataItemValue>
                 </>
               )}
               {gene.locations?.length > 0 && (
                 <>
                   <DataItemLabel>Gene Locations</DataItemLabel>
                   <DataItemValue>
-                    <ChromosomeLocations locations={gene.locations} />
+                    <ChromosomeLocations
+                      locations={gene.locations}
+                      isCollapsible
+                    />
                   </DataItemValue>
                 </>
               )}

--- a/pages/human-donors/[uuid].js
+++ b/pages/human-donors/[uuid].js
@@ -19,6 +19,7 @@ import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import RelatedDonorsTable from "../../components/related-donors-table";
+import SeparatedList from "../../components/separated-list";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
 import { requestDocuments } from "../../lib/common-requests";
@@ -52,7 +53,9 @@ export default function HumanDonor({
                 <>
                   <DataItemLabel>Identifiers</DataItemLabel>
                   <DataItemValue>
-                    {donor.human_donor_identifiers.join(", ")}
+                    <SeparatedList isCollapsible>
+                      {donor.human_donor_identifiers}
+                    </SeparatedList>
                   </DataItemValue>
                 </>
               )}

--- a/pages/in-vitro-systems/[id].js
+++ b/pages/in-vitro-systems/[id].js
@@ -103,7 +103,7 @@ export default function InVitroSystem({
                   <>
                     <DataItemLabel>Origin Sample Of</DataItemLabel>
                     <DataItemValue>
-                      <SeparatedList>
+                      <SeparatedList isCollapsible>
                         {originOf.map((sample) => (
                           <Link href={sample["@id"]} key={sample.accession}>
                             {sample.accession}

--- a/pages/labs/[name].js
+++ b/pages/labs/[name].js
@@ -53,7 +53,7 @@ export default function Lab({ lab, awards = null, pi = null, isJson }) {
               {awards?.length > 0 && (
                 <>
                   <DataItemLabel>Awards</DataItemLabel>
-                  <SeparatedList>
+                  <SeparatedList isCollapsible>
                     {awards.map((award) => (
                       <Link
                         href={award["@id"]}

--- a/pages/matrix-files/[...id].js
+++ b/pages/matrix-files/[...id].js
@@ -73,7 +73,7 @@ export default function MatrixFile({
                 <>
                   <DataItemLabel>Reference Files</DataItemLabel>
                   <DataItemValue>
-                    <SeparatedList>
+                    <SeparatedList isCollapsible>
                       {referenceFiles.map((file) => (
                         <Link href={file["@id"]} key={file["@id"]}>
                           {file.accession}

--- a/pages/model-sets/[id].js
+++ b/pages/model-sets/[id].js
@@ -96,7 +96,10 @@ export default function ModelSet({
                   <>
                     <DataItemLabel>Publication Identifiers</DataItemLabel>
                     <DataItemValue>
-                      <DbxrefList dbxrefs={modelSet.publication_identifiers} />
+                      <DbxrefList
+                        dbxrefs={modelSet.publication_identifiers}
+                        isCollapsible
+                      />
                     </DataItemValue>
                   </>
                 )}

--- a/pages/multiplexed-samples/[uuid].js
+++ b/pages/multiplexed-samples/[uuid].js
@@ -32,7 +32,6 @@ import {
   requestBiomarkers,
   requestBiosamples,
   requestDocuments,
-  requestDonors,
   requestFileSets,
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
@@ -42,7 +41,7 @@ import { Ok } from "../../lib/result";
 
 export default function MultiplexedSample({
   multiplexedSample,
-  constructLibrarySets = [],
+  constructLibrarySets,
   biomarkers,
   documents,
   attribution = null,
@@ -148,7 +147,7 @@ MultiplexedSample.propTypes = {
   // MultiplexedSample-cell sample to display
   multiplexedSample: PropTypes.object.isRequired,
   // Construct libraries that link to this MutliplexedSample
-  constructLibrarySets: PropTypes.arrayOf(PropTypes.object),
+  constructLibrarySets: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Documents associated with the sample
   documents: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Sorted fractions sample
@@ -188,15 +187,13 @@ export async function getServerSideProps({ params, req, query }) {
     const documents = multiplexedSample.documents
       ? await requestDocuments(multiplexedSample.documents, request)
       : [];
-    const donors = multiplexedSample.donors
-      ? await requestDonors(multiplexedSample.donors, request)
-      : [];
     const sortedFractions =
       multiplexedSample.sorted_fractions?.length > 0
         ? await requestBiosamples(multiplexedSample.sorted_fractions, request)
         : [];
-    // For sources, use getMultipleObjects for sources instead of getMultipleObjectBulk.
-    // Sources point at both lab and source objects, however, it currently only LinkTo sources.
+
+    // Use getMultipleObjects for sources instead of getMultipleObjectBulk. Sources point at both
+    // lab and source objects, however, it currently only LinkTo sources.
     let sources = [];
     if (multiplexedSample.sources?.length > 0) {
       const sourcePaths = multiplexedSample.sources.map(
@@ -223,7 +220,6 @@ export async function getServerSideProps({ params, req, query }) {
         constructLibrarySets,
         biomarkers,
         documents,
-        donors,
         sortedFractions,
         sources,
         pageContext: {

--- a/pages/prediction-sets/[id].js
+++ b/pages/prediction-sets/[id].js
@@ -7,16 +7,13 @@ import AlternateAccessions from "../../components/alternate-accessions";
 import Attribution from "../../components/attribution";
 import Breadcrumbs from "../../components/breadcrumbs";
 import { FileSetDataItems } from "../../components/common-data-items";
-import ChromosomeLocations from "../../components/chromosome-locations";
 import {
   DataArea,
   DataAreaTitle,
   DataItemLabel,
+  DataItemList,
   DataItemValue,
-  DataItemValueCollapseControl,
-  DataItemValueControlLabel,
   DataPanel,
-  useDataAreaCollapser,
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
@@ -45,19 +42,16 @@ export default function PredictionSet({
   attribution = null,
   isJson,
 }) {
-  const genesCollapser = useDataAreaCollapser(predictionSet.targeted_genes);
-  const lociCollapser = useDataAreaCollapser(predictionSet.targeted_loci);
   const constructLibrarySets =
     predictionSet.samples?.length > 0
-      ? predictionSet.samples.reduce((acc, sample) => {
-          if (sample.construct_library_sets) {
-            return acc.concat(sample.construct_library_sets);
-          }
-          return acc;
-        }, [])
+      ? predictionSet.samples.reduce(
+          (acc, sample) =>
+            sample.construct_library_sets
+              ? acc.concat(sample.construct_library_sets)
+              : acc,
+          []
+        )
       : [];
-  const constructLibrarySetCollapser =
-    useDataAreaCollapser(constructLibrarySets);
 
   return (
     <>
@@ -77,7 +71,7 @@ export default function PredictionSet({
                   <>
                     <DataItemLabel>Donors</DataItemLabel>
                     <DataItemValue>
-                      <SeparatedList>
+                      <SeparatedList isCollapsible>
                         {donors.map((donor) => (
                           <Link href={donor["@id"]} key={donor.uuid}>
                             {donor.accession}
@@ -91,7 +85,7 @@ export default function PredictionSet({
                   <>
                     <DataItemLabel>Samples</DataItemLabel>
                     <DataItemValue>
-                      <SeparatedList>
+                      <SeparatedList isCollapsible>
                         {predictionSet.samples.map((sample) => (
                           <Link href={sample["@id"]} key={sample["@id"]}>
                             {sample.accession}
@@ -101,88 +95,30 @@ export default function PredictionSet({
                     </DataItemValue>
                   </>
                 )}
-                {constructLibrarySetCollapser.displayedData.length > 0 && (
+                {constructLibrarySets.length > 0 && (
                   <>
                     <DataItemLabel>Construct Library Sets</DataItemLabel>
-                    <DataItemValue>
-                      {constructLibrarySetCollapser.displayedData.map(
-                        (con, i) => {
-                          return (
-                            <div
-                              key={con["@id"]}
-                              className="my-1 first:mt-0 last:mb-0"
-                            >
-                              <div>
-                                <Link href={con["@id"]}>{con.accession}</Link>
-                                <span className="text-gray-400 dark:text-gray-600">
-                                  {" "}
-                                  {con.summary}
-                                </span>
-                              </div>
-                              {i ===
-                                constructLibrarySetCollapser.displayedData
-                                  .length -
-                                  1 && (
-                                <DataItemValueCollapseControl
-                                  collapser={constructLibrarySetCollapser}
-                                >
-                                  <DataItemValueControlLabel
-                                    collapser={constructLibrarySetCollapser}
-                                  />
-                                </DataItemValueCollapseControl>
-                              )}
-                            </div>
-                          );
-                        }
-                      )}
-                    </DataItemValue>
+                    <DataItemList isCollapsible>
+                      {constructLibrarySets.map((fileSet) => {
+                        return (
+                          <div key={fileSet["@id"]}>
+                            <Link href={fileSet["@id"]}>
+                              {fileSet.accession}
+                            </Link>
+                            <span className="text-gray-600 dark:text-gray-400">
+                              {" "}
+                              {fileSet.summary}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </DataItemList>
                   </>
                 )}
                 {predictionSet.scope && (
                   <>
                     <DataItemLabel>Scope</DataItemLabel>
                     <DataItemValue>{predictionSet.scope}</DataItemValue>
-                  </>
-                )}
-                {genesCollapser.displayedData.length > 0 && (
-                  <>
-                    <DataItemLabel>Targeted Genes</DataItemLabel>
-                    <DataItemValue>
-                      <SeparatedList>
-                        {genesCollapser.displayedData.map((gene, index) => (
-                          <Fragment key={gene}>
-                            <Link href={gene}>{gene}</Link>
-                            {index ===
-                              genesCollapser.displayedData.length - 1 && (
-                              <DataItemValueCollapseControl
-                                key="more-control"
-                                collapser={genesCollapser}
-                                className="ml-1 inline-block"
-                              >
-                                <DataItemValueControlLabel
-                                  key="more-control"
-                                  collapser={genesCollapser}
-                                  className="ml-1 inline-block"
-                                />
-                              </DataItemValueCollapseControl>
-                            )}
-                          </Fragment>
-                        ))}
-                      </SeparatedList>
-                    </DataItemValue>
-                  </>
-                )}
-                {lociCollapser.displayedData.length > 0 && (
-                  <>
-                    <DataItemLabel>Targeted Loci</DataItemLabel>
-                    <DataItemValue>
-                      <ChromosomeLocations
-                        locations={lociCollapser.displayedData}
-                      />
-                      <DataItemValueCollapseControl collapser={lociCollapser}>
-                        <DataItemValueControlLabel collapser={lociCollapser} />
-                      </DataItemValueCollapseControl>
-                    </DataItemValue>
                   </>
                 )}
               </FileSetDataItems>

--- a/pages/rodent-donors/[uuid].js
+++ b/pages/rodent-donors/[uuid].js
@@ -20,10 +20,7 @@ import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildBreadcrumbs from "../../lib/breadcrumbs";
-import {
-  requestDocuments,
-  requestPhenotypicFeatures,
-} from "../../lib/common-requests";
+import { requestDocuments } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import buildAttribution from "../../lib/attribution";
@@ -36,7 +33,6 @@ export default function RodentDonor({
   donor,
   documents,
   attribution = null,
-  phenotypicFeatures = [],
   sources = null,
   isJson,
 }) {
@@ -83,10 +79,12 @@ export default function RodentDonor({
               </DonorDataItems>
             </DataArea>
           </DataPanel>
-          {phenotypicFeatures.length > 0 && (
+          {donor.phenotypic_features?.length > 0 && (
             <>
               <DataAreaTitle>Phenotypic Features</DataAreaTitle>
-              <PhenotypicFeatureTable phenotypicFeatures={phenotypicFeatures} />
+              <PhenotypicFeatureTable
+                phenotypicFeatures={donor.phenotypic_features}
+              />
             </>
           )}
           <ExternalResources resources={donor.external_resources} />
@@ -110,8 +108,6 @@ RodentDonor.propTypes = {
   documents: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Attribution for this donor
   attribution: PropTypes.object,
-  // Phenotypic Features of this donor
-  phenotypicFeatures: PropTypes.arrayOf(PropTypes.object),
   // Source of donor
   sources: PropTypes.arrayOf(PropTypes.object),
   // Is the format JSON?
@@ -127,9 +123,6 @@ export async function getServerSideProps({ params, req, query }) {
   if (FetchRequest.isResponseSuccess(donor)) {
     const documents = donor.documents
       ? await requestDocuments(donor.documents, request)
-      : [];
-    const phenotypicFeatures = donor.phenotypic_features
-      ? await requestPhenotypicFeatures(donor.phenotypic_features, request)
       : [];
     let sources = [];
     if (donor.sources?.length > 0) {
@@ -150,7 +143,6 @@ export async function getServerSideProps({ params, req, query }) {
       props: {
         donor,
         documents,
-        phenotypicFeatures,
         sources,
         pageContext: { title: donor.accession },
         breadcrumbs,

--- a/pages/sample-terms/[name].js
+++ b/pages/sample-terms/[name].js
@@ -34,7 +34,10 @@ export default function SampleOntologyTerm({ sampleOntologyTerm, isJson }) {
                 <>
                   <DataItemLabel>External Resources</DataItemLabel>
                   <DataItemValue>
-                    <DbxrefList dbxrefs={sampleOntologyTerm.dbxrefs} />
+                    <DbxrefList
+                      dbxrefs={sampleOntologyTerm.dbxrefs}
+                      isCollapsible
+                    />
                   </DataItemValue>
                 </>
               )}

--- a/pages/signal-files/[...id].js
+++ b/pages/signal-files/[...id].js
@@ -73,7 +73,7 @@ export default function SignalFile({
                 <>
                   <DataItemLabel>Reference Files</DataItemLabel>
                   <DataItemValue>
-                    <SeparatedList>
+                    <SeparatedList isCollapsible>
                       {referenceFiles.map((file) => (
                         <Link href={file["@id"]} key={file["@id"]}>
                           {file.accession}

--- a/pages/software/[id].js
+++ b/pages/software/[id].js
@@ -67,7 +67,10 @@ export default function Software({
                 <>
                   <DataItemLabel>Publication Identifiers</DataItemLabel>
                   <DataItemValue>
-                    <DbxrefList dbxrefs={software.publication_identifiers} />
+                    <DbxrefList
+                      dbxrefs={software.publication_identifiers}
+                      isCollapsible
+                    />
                   </DataItemValue>
                 </>
               )}

--- a/pages/workflows/[id].js
+++ b/pages/workflows/[id].js
@@ -9,6 +9,7 @@ import {
   DataArea,
   DataAreaTitle,
   DataItemLabel,
+  DataItemList,
   DataItemValue,
   DataItemValueUrl,
   DataPanel,
@@ -91,27 +92,28 @@ export default function Workflow({
               {workflow.workflow_repositories?.length > 0 && (
                 <>
                   <DataItemLabel>Workflow Repositories</DataItemLabel>
-                  <DataItemValue>
-                    <SeparatedList>
-                      {workflow.workflow_repositories.map((repository) => (
-                        <a
-                          key={repository}
-                          href={repository}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          {repository}
-                        </a>
-                      ))}
-                    </SeparatedList>
-                  </DataItemValue>
+                  <DataItemList isCollapsible>
+                    {workflow.workflow_repositories.map((repository) => (
+                      <a
+                        key={repository}
+                        href={repository}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {repository}
+                      </a>
+                    ))}
+                  </DataItemList>
                 </>
               )}
               {workflow.publication_identifiers?.length > 0 && (
                 <>
                   <DataItemLabel>Publication Identifiers</DataItemLabel>
                   <DataItemValue>
-                    <DbxrefList dbxrefs={workflow.publication_identifiers} />
+                    <DbxrefList
+                      dbxrefs={workflow.publication_identifiers}
+                      isCollapsible
+                    />
                   </DataItemValue>
                 </>
               )}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -48,6 +48,10 @@
   --color-data-background: #ffffff;
   --color-data-header-background: #e0e0e0;
   --color-data-border: #c0c0c0;
+  --color-data-list-item-border: #e5e7eb;
+  --color-collapse-ctrl-border: #e5e7eb;
+  --color-collapse-ctrl-text: #374151;
+  --color-collapse-ctrl-background: #f3f4f6;
 
   --color-panel-background: #fff;
   --color-panel-border: #d0d0d0;
@@ -230,6 +234,11 @@
   --color-highlight: #2c3f66;
   --color-highlight-border: #45629f;
   --color-title-border: #6b7280;
+
+  --color-data-list-item-border: #374151;
+  --color-collapse-ctrl-border: #374151;
+  --color-collapse-ctrl-text: #9ca3af;
+  --color-collapse-ctrl-background: #1f2937;
 
   --color-panel-background: #000205;
   --color-panel-border: #4e5b75;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,6 +39,8 @@ module.exports = {
         panel: "var(--color-panel-background)",
         "form-element": "var(--color-form-element-background)",
 
+        "collapse-ctrl": "var(--color-collapse-ctrl-background)",
+
         "button-primary": "var(--color-button-primary-background)",
         "button-secondary": "var(--color-button-secondary-background)",
         "button-warning": "var(--color-button-warning-background)",
@@ -89,6 +91,10 @@ module.exports = {
         panel: "var(--color-panel-border)",
         "form-element": "var(--color-form-element-border)",
         "form-element-disabled": "var(--color-form-element-border-disabled)",
+
+        "data-list-item": "var(--color-data-list-item-border)",
+
+        "collapse-ctrl": "var(--color-collapse-ctrl-border)",
 
         "button-primary": "var(--color-button-primary-border)",
         "button-secondary": "var(--color-button-secondary-border)",
@@ -157,6 +163,8 @@ module.exports = {
           "var(--color-button-selected-label-disabled)",
         "form-element": "var(--color-form-element-label)",
         "form-element-disabled": "var(--color-form-element-label-disabled)",
+
+        "collapse-ctrl": "var(--color-collapse-ctrl-text)",
 
         "button-facet-group": "var(--color-button-facet-group-text)",
         "button-facet-group-selected":


### PR DESCRIPTION
* I had made an overcomplicated mechanism for collapsible lists. That’s all gone in this branch, and now certain existing components handle the collapsing themselves, including `<SeparatedList>`, `<DbxrefList>`, and `<ChromosomeLocations>`. I still them _not_ be collapsible by default. That’s why I needed to add the `isCollapsible` property in so many, but not all, places.
* I still have two types: Inline and Vertical. Inline is mostly for comma-separated collapsible lists. Vertical is for a list of items stacked vertically.
* During development, I noticed a few properties the UI tries to display but that simply don’t exist in the schema anymore, so you’ll see some changes involving deleting lines of code from pages.