### PR TITLE
IGVF-1498-json-display

### DIFF
--- a/components/add.js
+++ b/components/add.js
@@ -13,7 +13,7 @@ import { ButtonLink } from "./form-elements";
 import SessionContext from "./session-context";
 // lib
 import FetchRequest from "../lib/fetch-request";
-import { urlWithoutParams, sortedJson } from "../lib/general";
+import { urlWithoutParams, sortObjectProps } from "../lib/general";
 import { collectionToSchema } from "../lib/schema";
 /* istanbul ignore file */
 
@@ -204,7 +204,7 @@ export function AddInstancePage({ collection }) {
       errors: [],
     });
 
-    const value = sortedJson(JSON.parse(text));
+    const value = sortObjectProps(JSON.parse(text));
     const collectPath = urlWithoutParams(collection["@id"]);
     new FetchRequest({ session })
       .postObject(collectPath, value)

--- a/components/edit.js
+++ b/components/edit.js
@@ -11,7 +11,7 @@ import SessionContext from "./session-context";
 import PagePreamble from "./page-preamble";
 // lib
 import FetchRequest from "../lib/fetch-request";
-import { sortedJson } from "../lib/general";
+import { sortObjectProps } from "../lib/general";
 import { itemToSchema } from "../lib/schema";
 /* istanbul ignore file */
 
@@ -134,7 +134,7 @@ export default function EditPage({ item }) {
   useEffect(() => {
     const getRequest = new FetchRequest({ session });
     getRequest.getObject(`${path}?frame=edit`).then((value) => {
-      setText(JSON.stringify(sortedJson(value.union()), null, 4));
+      setText(JSON.stringify(sortObjectProps(value.union()), null, 4));
     });
   }, [path, session]);
 
@@ -166,7 +166,7 @@ export default function EditPage({ item }) {
       canSave: false,
       errors: [],
     });
-    const value = sortedJson(JSON.parse(text));
+    const value = sortObjectProps(JSON.parse(text));
     const putRequest = new FetchRequest({ session });
     putRequest.putObject(path, value).then((response) => {
       if (response.status === "success") {

--- a/components/json-display.js
+++ b/components/json-display.js
@@ -1,7 +1,9 @@
 // node_modules
 import PropTypes from "prop-types";
 // components
-import { DataPanel } from "./data-area";
+import JsonPanel from "./json-panel";
+// lib
+import { sortObjectProps } from "../lib/general";
 
 /**
  * This function will display a raw JSON view for a given object if the query is in JSON format, otherwise it will display an object view.
@@ -11,16 +13,12 @@ import { DataPanel } from "./data-area";
  * @returns either a raw JSON view or a object view
  */
 export default function JsonDisplay({ item, isJsonFormat, children }) {
+  const sortedItem = sortObjectProps(item);
+
   return (
     <>
       {isJsonFormat ? (
-        <DataPanel>
-          <div className="border border-gray-300 bg-gray-100 text-xs dark:border-gray-800 dark:bg-gray-900">
-            <pre className="overflow-x-scroll p-1">
-              {JSON.stringify(item, null, 4)}
-            </pre>
-          </div>
-        </DataPanel>
+        <JsonPanel>{JSON.stringify(sortedItem, null, 4)}</JsonPanel>
       ) : (
         <>{children}</>
       )}

--- a/components/json-panel.js
+++ b/components/json-panel.js
@@ -3,29 +3,56 @@ import PropTypes from "prop-types";
 import { useContext } from "react";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import {
+  lightfair,
   stackoverflowDark,
   stackoverflowLight,
+  tomorrowNightBright,
 } from "react-syntax-highlighter/dist/cjs/styles/hljs";
 // components
 import GlobalContext from "./global-context";
 
-// NOTE: the import of the themes for react-systax-highlighter does not follow their documentation
+// NOTE: the import of the themes for react-syntax-highlighter does not follow their documentation
 // that appears incorrect, likely due to a bug. Instead of using the `esm` path, we have to use the
 // `cjs` path.
 // https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/509
 
 /**
+ * Selects a react-syntax-highlighter theme based on the the contrast mode and light/dark mode. See
+ * the React syntax highlighter demo to try out the available themes:
+ * https://react-syntax-highlighter.github.io/react-syntax-highlighter/demo/
+ */
+const themeMap = {
+  highContrast: {
+    light: lightfair,
+    dark: tomorrowNightBright,
+  },
+  lowContrast: {
+    light: stackoverflowLight,
+    dark: stackoverflowDark,
+  },
+};
+
+/**
  * Display a JSON object as a code panel with code colorization.
  */
-export default function JsonPanel({ id = null, className = "", children }) {
+export default function JsonPanel({
+  id = null,
+  isLowContrast = false,
+  className = "",
+  children,
+}) {
   const { darkMode } = useContext(GlobalContext);
+  const modeThemes = isLowContrast
+    ? themeMap.lowContrast
+    : themeMap.highContrast;
+  const theme = darkMode.enabled ? modeThemes.dark : modeThemes.light;
 
   return (
     <SyntaxHighlighter
       id={id}
       language="json"
-      style={darkMode.enabled ? stackoverflowDark : stackoverflowLight}
-      className={`border-json-panel border text-xs ${className}`}
+      style={theme}
+      className={`border border-json-panel text-xs ${className}`}
     >
       {children}
     </SyntaxHighlighter>
@@ -35,6 +62,8 @@ export default function JsonPanel({ id = null, className = "", children }) {
 JsonPanel.propTypes = {
   // Unique identifier for the component
   id: PropTypes.string,
+  // True for low-contrast themes
+  isLowContrast: PropTypes.bool,
   // Tailwind CSS classes to apply to the JSON panel
   className: PropTypes.string,
 };

--- a/lib/__tests__/general.test.js
+++ b/lib/__tests__/general.test.js
@@ -7,7 +7,7 @@ import {
   pathToType,
   removeTrailingSlash,
   snakeCaseToHuman,
-  sortedJson,
+  sortObjectProps,
   toShishkebabCase,
   truncateJson,
   truncateText,
@@ -52,15 +52,6 @@ describe("Test the itemId utility function", () => {
   it("Should return the ID correctly", () => {
     expect(itemId("AnId")).toBe("AnId");
     expect(itemId({ "@id": "AnotherId" })).toBe("AnotherId");
-  });
-});
-
-describe("Test the sortedJson utility function", () => {
-  it("Should sort a json object's keys", () => {
-    expect(sortedJson({ z: 1, a: 5 })).toStrictEqual({ a: 5, z: 1 });
-  });
-  it("It should sort an array object", () => {
-    expect(sortedJson(["zebra", "apple"])).toStrictEqual(["apple", "zebra"]);
   });
 });
 
@@ -191,5 +182,141 @@ describe("Test the truncateText function", () => {
     expect(truncateText("Supercalifragilisticexpialidocious", 10)).toBe(
       "Supercalif…"
     );
+  });
+});
+
+describe("Test the sortObjectProps function", () => {
+  it("should sort a basic object's properties", () => {
+    const obj = {
+      z: 1,
+      a: 5,
+      c: 3,
+      b: 2,
+    };
+    const expected = {
+      a: 5,
+      b: 2,
+      c: 3,
+      z: 1,
+    };
+    // Make sure the sorted obj and sorted return the properties in the same order.
+    const sortedObj = sortObjectProps(obj);
+    expect(JSON.stringify(sortedObj)).toEqual(JSON.stringify(expected));
+  });
+
+  it("should sort an object's properties as well as those of its nested objects", () => {
+    const obj = {
+      z: 1,
+      a: 5,
+      c: 3,
+      b: 2,
+      d: {
+        z: 1,
+        a: 5,
+        c: 3,
+        b: 2,
+      },
+    };
+    const expected = {
+      a: 5,
+      b: 2,
+      c: 3,
+      d: {
+        a: 5,
+        b: 2,
+        c: 3,
+        z: 1,
+      },
+      z: 1,
+    };
+    const sortedObj = sortObjectProps(obj);
+    expect(JSON.stringify(sortedObj)).toEqual(JSON.stringify(expected));
+  });
+
+  it("should sort an object's properties, but not sort an array", () => {
+    const obj = {
+      z: 1,
+      a: 5,
+      c: 3,
+      b: 2,
+      d: [1, 5, 3, 2, 4],
+    };
+    const expected = {
+      a: 5,
+      b: 2,
+      c: 3,
+      d: [1, 5, 3, 2, 4],
+      z: 1,
+    };
+    const sortedObj = sortObjectProps(obj);
+    expect(JSON.stringify(sortedObj)).toEqual(JSON.stringify(expected));
+  });
+
+  it("should sort an object's properties as well as those of the objects within an array", () => {
+    const obj = {
+      z: 1,
+      a: 5,
+      c: 3,
+      b: 2,
+      d: [
+        {
+          d: 1,
+          a: 5,
+          c: 3,
+          b: 2,
+        },
+        {
+          z: 1,
+          w: 5,
+          y: 3,
+          x: 2,
+        },
+      ],
+    };
+    const expected = {
+      a: 5,
+      b: 2,
+      c: 3,
+      d: [
+        {
+          a: 5,
+          b: 2,
+          c: 3,
+          d: 1,
+        },
+        {
+          w: 5,
+          x: 2,
+          y: 3,
+          z: 1,
+        },
+      ],
+      z: 1,
+    };
+    const sortedObj = sortObjectProps(obj);
+    expect(JSON.stringify(sortedObj)).toEqual(JSON.stringify(expected));
+  });
+
+  it("handles empty arrays, and ignores arrays of arrays of objects", () => {
+    const obj = {
+      b: [],
+      a: [
+        [
+          { z: 2, a: 1 },
+          { z: 4, a: 3 },
+        ],
+      ],
+    };
+    const expected = {
+      a: [
+        [
+          { z: 2, a: 1 },
+          { z: 4, a: 3 },
+        ],
+      ],
+      b: [],
+    };
+    const sortedObj = sortObjectProps(obj);
+    expect(JSON.stringify(sortedObj)).toEqual(JSON.stringify(expected));
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1823,9 +1823,9 @@
       }
     },
     "node_modules/@nivo/core/node_modules/d3-scale-chromatic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
-      "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
@@ -2459,15 +2459,15 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.202",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
-      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
-      "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
+      "version": "20.11.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.27.tgz",
+      "integrity": "sha512-qyUZfMnCg1KEz57r7pzFtSGt49f6RPkPBis3Vo4PbS7roQEDn22hiHzl/Lo1q4i4hDEgBJmBF/NTNg2XR0HbFg==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2478,9 +2478,9 @@
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.64",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.64.tgz",
-      "integrity": "sha512-MlmPvHgjj2p3vZaxbQgFUQFvD8QiZwACfGqEdDSWou5yISWxDQ4/74nCAwsUiX7UFLKZz3BbVSPj+YxeoGGCfg==",
+      "version": "18.2.65",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.65.tgz",
+      "integrity": "sha512-98TsY0aW4jqx/3RqsUXwMDZSWR1Z4CUlJNue8ueS2/wcxZOsz4xmW1X8ieaWVRHcmmQM3R8xVA4XWB3dJnWwDQ==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2488,9 +2488,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.2.21",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.21.tgz",
-      "integrity": "sha512-gnvBA/21SA4xxqNXEwNiVcP0xSGHh/gi1VhWv9Bl46a0ItbTT5nFY+G9VSQpaG/8N/qdJpJ+vftQ4zflTtnjLw==",
+      "version": "18.2.22",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.22.tgz",
+      "integrity": "sha512-fHkBXPeNtfvri6gdsMYyW+dW7RXFo6Ad09nLFK0VQWR7yGLai/Cyvyj696gbwYvBnhGtevUG9cET0pmUbMtoPQ==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -2573,15 +2573,15 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.1.1.tgz",
-      "integrity": "sha512-zioDz623d0RHNhvx0eesUmGfIjzrk18nSBC8xewepKXbBvN/7c1qImV7Hg8TI1URTxKax7/zxfxj3Uph8Chcuw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.2.0.tgz",
+      "integrity": "sha512-mdekAHOqS9UjlmyF/LSs6AIEvfceV749GFxoBAjwAv0nkevfKHWQFDMcBZWUiIC5ft6ePWivXoS36aKQ0Cy3sw==",
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "7.1.1",
-        "@typescript-eslint/type-utils": "7.1.1",
-        "@typescript-eslint/utils": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1",
+        "@typescript-eslint/scope-manager": "7.2.0",
+        "@typescript-eslint/type-utils": "7.2.0",
+        "@typescript-eslint/utils": "7.2.0",
+        "@typescript-eslint/visitor-keys": "7.2.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -2607,14 +2607,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.1.1.tgz",
-      "integrity": "sha512-ZWUFyL0z04R1nAEgr9e79YtV5LbafdOtN7yapNbn1ansMyaegl2D4bL7vHoJ4HPSc4CaLwuCVas8CVuneKzplQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.2.0.tgz",
+      "integrity": "sha512-5FKsVcHTk6TafQKQbuIVkXq58Fnbkd2wDL4LB7AURN7RUOu1utVP+G8+6u3ZhEroW3DF6hyo3ZEXxgKgp4KeCg==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.1.1",
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/typescript-estree": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1",
+        "@typescript-eslint/scope-manager": "7.2.0",
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/typescript-estree": "7.2.0",
+        "@typescript-eslint/visitor-keys": "7.2.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2634,12 +2634,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.1.1.tgz",
-      "integrity": "sha512-cirZpA8bJMRb4WZ+rO6+mnOJrGFDd38WoXCEI57+CYBqta8Yc8aJym2i7vyqLL1vVYljgw0X27axkUXz32T8TA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.2.0.tgz",
+      "integrity": "sha512-Qh976RbQM/fYtjx9hs4XkayYujB/aPwglw2choHmf3zBjB4qOywWSdt9+KLRdHubGcoSwBnXUH2sR3hkyaERRg==",
       "dependencies": {
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1"
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/visitor-keys": "7.2.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2650,12 +2650,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.1.1.tgz",
-      "integrity": "sha512-5r4RKze6XHEEhlZnJtR3GYeCh1IueUHdbrukV2KSlLXaTjuSfeVF8mZUVPLovidCuZfbVjfhi4c0DNSa/Rdg5g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.2.0.tgz",
+      "integrity": "sha512-xHi51adBHo9O9330J8GQYQwrKBqbIPJGZZVQTHHmy200hvkLZFWJIFtAG/7IYTWUyun6DE6w5InDReePJYJlJA==",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.1.1",
-        "@typescript-eslint/utils": "7.1.1",
+        "@typescript-eslint/typescript-estree": "7.2.0",
+        "@typescript-eslint/utils": "7.2.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -2676,9 +2676,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.1.1.tgz",
-      "integrity": "sha512-KhewzrlRMrgeKm1U9bh2z5aoL4s7K3tK5DwHDn8MHv0yQfWFz/0ZR6trrIHHa5CsF83j/GgHqzdbzCXJ3crx0Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.2.0.tgz",
+      "integrity": "sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==",
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
       },
@@ -2688,12 +2688,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.1.1.tgz",
-      "integrity": "sha512-9ZOncVSfr+sMXVxxca2OJOPagRwT0u/UHikM2Rd6L/aB+kL/QAuTnsv6MeXtjzCJYb8PzrXarypSGIPx3Jemxw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.2.0.tgz",
+      "integrity": "sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==",
       "dependencies": {
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/visitor-keys": "7.1.1",
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/visitor-keys": "7.2.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2715,16 +2715,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.1.1.tgz",
-      "integrity": "sha512-thOXM89xA03xAE0lW7alstvnyoBUbBX38YtY+zAUcpRPcq9EIhXPuJ0YTv948MbzmKh6e1AUszn5cBFK49Umqg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.2.0.tgz",
+      "integrity": "sha512-YfHpnMAGb1Eekpm3XRK8hcMwGLGsnT6L+7b2XyRv6ouDuJU1tZir1GS2i0+VXRatMwSI1/UfcyPe53ADkU+IuA==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "7.1.1",
-        "@typescript-eslint/types": "7.1.1",
-        "@typescript-eslint/typescript-estree": "7.1.1",
+        "@typescript-eslint/scope-manager": "7.2.0",
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/typescript-estree": "7.2.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -2739,11 +2739,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.1.1.tgz",
-      "integrity": "sha512-yTdHDQxY7cSoCcAtiBzVzxleJhkGB9NncSIyMYe2+OGON1ZsP9zOPws/Pqgopa65jvknOjlk/w7ulPlZ78PiLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.2.0.tgz",
+      "integrity": "sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==",
       "dependencies": {
-        "@typescript-eslint/types": "7.1.1",
+        "@typescript-eslint/types": "7.2.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -3656,9 +3656,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001596",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001596.tgz",
-      "integrity": "sha512-zpkZ+kEr6We7w63ORkoJ2pOfBwBkY/bJrG/UZ90qNb45Isblu8wzDgevEOrRL1r9dWayHjYiiyCMEXPn4DweGQ==",
+      "version": "1.0.30001597",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001597.tgz",
+      "integrity": "sha512-7LjJvmQU6Sj7bL0j5b5WY/3n7utXUJvAe1lxhsHDbLmwX9mdL86Yjtr+5SRCyf8qME4M7pU2hswj0FpyBVCv9w==",
       "funding": [
         {
           "type": "opencollective",
@@ -4426,9 +4426,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.3.1.tgz",
-      "integrity": "sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.4.0.tgz",
+      "integrity": "sha512-Akz4R8J9MXBsOgF1QeWeCsbv6pntT5KCPjU0Q9prBxVmWJYPLhwAIsNg3b0QAdr0ttiozYLD3L/af7Ra0jqYXw==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4691,9 +4691,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.699",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.699.tgz",
-      "integrity": "sha512-I7q3BbQi6e4tJJN5CRcyvxhK0iJb34TV8eJQcgh+fR2fQ8miMgZcEInckCo1U9exDHbfz7DLDnFn8oqH/VcRKw==",
+      "version": "1.4.703",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.703.tgz",
+      "integrity": "sha512-094ZZC4nHXPKl/OwPinSMtLN9+hoFkdfQGKnvXbY+3WEAYtVDpz9UhJIViiY6Zb8agvqxiaJzNG9M+pRZWvSZw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4731,9 +4731,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.1.tgz",
-      "integrity": "sha512-3d3JRbwsCLJsYgvb6NuWEG44jjPSOMuS73L/6+7BZuoKm3W+qXnSoIYVHi8dG7Qcg4inAY4jbzkZ7MnskePeDg==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.0.tgz",
+      "integrity": "sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -6568,9 +6568,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
-      "integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -9742,9 +9742,9 @@
       }
     },
     "node_modules/postcss-nested/node_modules/postcss-selector-parser": {
-      "version": "6.0.15",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz",
-      "integrity": "sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==",
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
+      "integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -10565,13 +10565,13 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
-      "integrity": "sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+      "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.5",
-        "get-intrinsic": "^1.2.2",
+        "call-bind": "^1.0.7",
+        "get-intrinsic": "^1.2.4",
         "has-symbols": "^1.0.3",
         "isarray": "^2.0.5"
       },
@@ -10674,16 +10674,16 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/set-function-length": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
-      "integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dependencies": {
-        "define-data-property": "^1.1.2",
+        "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.3",
+        "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.1"
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11265,9 +11265,9 @@
       }
     },
     "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
-      "version": "6.0.15",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz",
-      "integrity": "sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==",
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
+      "integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11457,9 +11457,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
-      "integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
       "engines": {
         "node": ">=16"
       },
@@ -11939,29 +11939,32 @@
       }
     },
     "node_modules/which-collection": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dependencies": {
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
-        "is-weakmap": "^2.0.1",
-        "is-weakset": "^2.0.1"
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.14.tgz",
-      "integrity": "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
       "dependencies": {
-        "available-typed-arrays": "^1.0.6",
-        "call-bind": "^1.0.5",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.1"
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"

--- a/pages/[...path].js
+++ b/pages/[...path].js
@@ -9,9 +9,9 @@ import { isJsonFormat } from "../lib/query-utils";
 // components
 import { AddableItem } from "../components/add";
 import Breadcrumbs from "../components/breadcrumbs";
-import { DataPanel } from "../components/data-area";
 import { EditableItem } from "../components/edit";
 import JsonDisplay from "../components/json-display";
+import JsonPanel from "../components/json-panel";
 import ObjectPageHeader from "../components/object-page-header";
 import Page from "../components/page";
 import PagePreamble from "../components/page-preamble";
@@ -55,11 +55,7 @@ export default function FallbackObject({
         <>
           <PagePreamble />
           <AddableItem collection={generic}>
-            <DataPanel>
-              <div className="overflow-x-auto border border-gray-300 bg-gray-100 text-xs dark:border-gray-800 dark:bg-gray-900">
-                <pre className="p-1">{JSON.stringify(generic, null, 4)}</pre>
-              </div>
-            </DataPanel>
+            <JsonPanel>{JSON.stringify(generic, null, 4)}</JsonPanel>
           </AddableItem>
         </>
       );

--- a/pages/analysis-steps/[id].js
+++ b/pages/analysis-steps/[id].js
@@ -1,6 +1,7 @@
 // node_modules
 import Link from "next/link";
 import PropTypes from "prop-types";
+import { Fragment } from "react";
 // components
 import Attribution from "../../components/attribution";
 import Breadcrumbs from "../../components/breadcrumbs";
@@ -64,13 +65,17 @@ export default function AnalysisStep({
               <DataItemLabel>Input Content Types</DataItemLabel>
               <DataItemValue>
                 <SeparatedList isCollapsible>
-                  {analysisStep.input_content_types}
+                  {analysisStep.input_content_types.map((type) => (
+                    <Fragment key={type}>{type}</Fragment>
+                  ))}
                 </SeparatedList>
               </DataItemValue>
               <DataItemLabel>Output Content Types</DataItemLabel>
               <DataItemValue>
                 <SeparatedList isCollapsible>
-                  {analysisStep.output_content_types}
+                  {analysisStep.output_content_types.map((type) => (
+                    <Fragment key={type}>{type}</Fragment>
+                  ))}
                 </SeparatedList>
               </DataItemValue>
               {analysisStep.parents?.length > 0 && (

--- a/pages/profiles/[profile].js
+++ b/pages/profiles/[profile].js
@@ -73,7 +73,8 @@ function SchemaJsonPanel({ property, panelId, isJsonDetailOpen }) {
         >
           <JsonPanel
             id={`schema-json-${panelId}`}
-            className="ml-5 border border-gray-300 text-xs"
+            className="ml-5 border border-panel text-xs"
+            isLowContrast
           >
             {JSON.stringify(property, null, 2)}
           </JsonPanel>
@@ -435,7 +436,7 @@ function SchemaProperties({ properties, searchTerm, setSearchTerm }) {
 
   return (
     <>
-      <section className="bg-schema-search sticky top-0 border-b border-panel px-4 py-2">
+      <section className="sticky top-0 border-b border-panel bg-schema-search px-4 py-2">
         <FormLabel>Search Schema Properties</FormLabel>
         <div className="mb-4">
           <SchemaSearchField


### PR DESCRIPTION
While all JSON displays use the new colorization, only some get sorted, specifically the JSON displays on summary pages. It seemed unexpected to sort the properties of schemas, so those stay unsorted.

Eric had added a function to sort object properties, but it didn’t handle embedded objects, and couldn’t successfully handle objects within arrays. The new function handles both these cases, though not arrays of arrays of objects — it simply doesn’t sort those properties. I don’t think we have these right now. The new Jest tests show how arrays of arrays of objects get ignored.

I also fixed a couple missing-key warnings on the AnalysisStep page; unrelated, but simple to fix.