### PR TITLE
IGVF-1536 Display markdown for audit text

### DIFF
--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,6 +53,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
+            'backend_url': 'https://igvf-ui-igvf-1536-audit-markdown.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,6 +53,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
+            'backend_url': 'https://igvfd-igvf-1456-refactor-audits.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,7 +53,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvf-ui-igvf-1536-audit-markdown.demo.igvf.org',
+            'backend_url': 'https://igvfd-igvf-1456-refactor-audits.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,7 +53,6 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-igvf-1456-refactor-audits.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/components/__tests__/audit.test.js
+++ b/components/__tests__/audit.test.js
@@ -28,7 +28,7 @@ const demoAudit = {
     {
       category: "extremely low read depth",
       detail:
-        "Alignment file {ENCFF557RSA|/files/ENCFF557RSA/} processed by ATAC-seq ENCODE4 v2.1.1 GRCh38 pipeline has 8585759 usable fragments. According to ENCODE4 standards, ATAC-seq assays processed by the uniform processing pipeline should have > 25 million usable fragments. 20-25 million is acceptable and < 15 million is not compliant.",
+        "Alignment file [ENCFF557RSA](/files/ENCFF557RSA/) processed by ATAC-seq ENCODE4 v2.1.1 GRCh38 pipeline has 8585759 usable fragments. According to ENCODE4 standards, ATAC-seq assays processed by the uniform processing pipeline should have > 25 million usable fragments. 20-25 million is acceptable and < 15 million is not compliant.",
       level: 60,
       level_name: "ERROR",
       path: "/analyses/ENCAN615CMZ/",
@@ -39,7 +39,7 @@ const demoAudit = {
     {
       category: "mixed read lengths",
       detail:
-        "Biological replicate 1 in experiment {ENCSR859USB|/experiments/ENCSR859USB/} has mixed sequencing read lengths (33, 36).",
+        "Biological replicate 1 in experiment [ENCSR859USB](/experiments/ENCSR859USB/) has mixed sequencing read lengths (33, 36).",
       level: 40,
       level_name: "WARNING",
       path: "/experiments/ENCSR859USB/",
@@ -48,7 +48,7 @@ const demoAudit = {
     {
       category: "moderate number of reproducible peaks",
       detail:
-        "According to ENCODE4 standards, ATAC-seq assays processed by the uniform processing pipeline should have either >150k reproducible peaks in an overlap peaks file, or >70k in an IDR thresholded peaks file. 100-150k or 50-70k peaks respectively is acceptable, and <100k or <50k respectively is not compliant. File(s) {ENCFF055NNT|/files/ENCFF055NNT/} (overlap peaks) and {ENCFF926KTI|/files/ENCFF926KTI/} (IDR thresholded peaks) processed by ATAC-seq ENCODE4 v2.1.1 GRCh38 pipeline have 99862 and 55575 peaks.",
+        "According to ENCODE4 standards, ATAC-seq assays processed by the uniform processing pipeline should have either >150k reproducible peaks in an overlap peaks file, or >70k in an IDR thresholded peaks file. 100-150k or 50-70k peaks respectively is acceptable, and <100k or <50k respectively is not compliant. File(s) [ENCFF055NNT](/files/ENCFF055NNT/) (overlap peaks) and [ENCFF926KTI](/files/ENCFF926KTI/) (IDR thresholded peaks) processed by ATAC-seq ENCODE4 v2.1.1 GRCh38 pipeline have 99862 and 55575 peaks.",
       level: 40,
       level_name: "WARNING",
       path: "/analyses/ENCAN615CMZ/",
@@ -70,7 +70,7 @@ const demoAudit = {
     {
       category: "mismatched status",
       detail:
-        "{ENCAN615CMZ|/analyses/ENCAN615CMZ/} has in progress subobject quality standard {encode4-atac-seq|/quality-standards/encode4-atac-seq/}",
+        "[ENCAN615CMZ](/analyses/ENCAN615CMZ/) has in progress subobject quality standard [encode4-atac-seq](quality-standards). See [IGVF](https://igvf.org) for information.",
       level: 30,
       level_name: "INTERNAL_ACTION",
       path: "/analyses/ENCAN615CMZ/",

--- a/lib/__tests__/general.test.js
+++ b/lib/__tests__/general.test.js
@@ -1,6 +1,7 @@
 import {
   abbreviateNumber,
   dataSize,
+  isValidPath,
   isValidUrl,
   itemId,
   nullOnError,
@@ -21,6 +22,15 @@ describe("Test the pathToType utility function", () => {
     ).toBe("primary-cells");
     expect(pathToType("/labs/j-michael-cherry/")).toBe("labs");
     expect(pathToType("j-michael-cherry/")).toBe("");
+  });
+});
+
+describe("Test the isValidPath utility function", () => {
+  it("should return true if the given string is a valid path", () => {
+    expect(isValidPath("/labs/j-michael-cherry/")).toBe(true);
+    expect(isValidPath("/labs/j-michael-cherry")).toBe(true);
+    expect(isValidPath("labs/j-michael-cherry/")).toBe(false);
+    expect(isValidPath("labs/j-michael-cherry")).toBe(false);
   });
 });
 

--- a/lib/general.ts
+++ b/lib/general.ts
@@ -15,6 +15,15 @@ export function pathToType(path: string): string {
 }
 
 /**
+ * Check whether the input string is a path or not.
+ * @param input String to check if it is a path
+ * @returns True if the input is a path
+ */
+export function isValidPath(input: string): boolean {
+  return input.startsWith("/");
+}
+
+/**
  * Checks whether the given string is a valid URL. Paths with no protocol aren't considered valid
  * URLs.
  * @param {string} url The URL to check

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
         "marked": "^12.0.0",
+        "marked-react": "^2.0.0",
         "next": "13.4.12",
         "pretty-format": "^29.5.0",
         "prop-types": "^15.8.1",
@@ -8867,6 +8868,28 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/marked-react": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/marked-react/-/marked-react-2.0.0.tgz",
+      "integrity": "sha512-Mp5HqfONf/RDqFtA+6xw2EjKkSbA8/xNPwyJ8ewLy/q3v21lRsPA7h+HUndVAW/yEIoebvcyzzSDpbjzL/xjZg==",
+      "dependencies": {
+        "marked": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || >=17.0.0"
+      }
+    },
+    "node_modules/marked-react/node_modules/marked": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-6.0.0.tgz",
+      "integrity": "sha512-7E3m/xIlymrFL5gWswIT4CheIE3fDeh51NV09M4x8iOc7NDYlyERcQMLAIHcSlrvwliwbPQ4OGD+MpPSYiQcqw==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/merge-stream": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
     "marked": "^12.0.0",
+    "marked-react": "^2.0.0",
     "next": "13.4.12",
     "pretty-format": "^29.5.0",
     "prop-types": "^15.8.1",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -366,7 +366,7 @@
   --color-nav-collapse: #4b627a;
 
   /** Typography */
-  --color-code-background: #192339;
+  --color-code-background: #334155;
   --color-code-text: #e5e7eb;
 
   /** Modal borders */


### PR DESCRIPTION
In IGVF–1456, Ian and I agreed to display real markdown in the audit text instead of the weird form of markdown I made up for ENCODE that got carried over to igvfd. This branch makes the UI changes needed for that.

This means we now have both “marked” and “marked-react” npm packages in the build to render markdown. I’ll fix that in IGVF–1488. I felt it was too much to merge them in this ticket because this branch and IGVF–1456 have to be in the same release, and getting rid of “marked” from all usage won’t be trivial. For now, only audits use “marked-react.” The schema changelogs and documentation pages still use “marked.”