### PR TITLE
IGVF-751 Use auth.igvf.org custom domain with Auth0

### DIFF
--- a/components/navigation.js
+++ b/components/navigation.js
@@ -34,11 +34,7 @@ import Modal from "./modal";
 import SessionContext from "./session-context";
 import SiteSearchTrigger from "./site-search-trigger";
 // lib
-import {
-  loginAuthProvider,
-  logoutAuthProvider,
-  logoutDataProvider,
-} from "../lib/authentication";
+import { loginAuthProvider, logoutAuthProvider } from "../lib/authentication";
 import { UC } from "../lib/constants";
 
 /**
@@ -261,12 +257,16 @@ NavigationButton.propTypes = {
  */
 function NavigationSignInItem({ id, isNarrowNav = false, children }) {
   const { isLoading, loginWithRedirect } = useAuth0();
+  const { setAuthStageLogin } = useContext(SessionContext);
 
   return (
     <li>
       <NavigationButton
         id={id}
-        onClick={() => loginAuthProvider(loginWithRedirect)}
+        onClick={() => {
+          loginAuthProvider(loginWithRedirect);
+          setAuthStageLogin();
+        }}
         isNarrowNav={isNarrowNav}
         isDisabled={isLoading}
       >
@@ -296,9 +296,8 @@ function NavigationSignOutItem({
 }) {
   // True if sign-out warning modal open
   const [isWarningOpen, setIsWarningOpen] = useState(false);
-  // Session properties object
-  // Logged-in session-properties object
-  const { sessionProperties } = useContext(SessionContext);
+
+  const { sessionProperties, setAuthStageLogout } = useContext(SessionContext);
   const { logout } = useAuth0();
 
   /**
@@ -307,7 +306,7 @@ function NavigationSignOutItem({
    */
   function handleAuthClick() {
     logoutAuthProvider(logout);
-    logoutDataProvider();
+    setAuthStageLogout();
   }
 
   return (

--- a/components/no-collection-data.js
+++ b/components/no-collection-data.js
@@ -7,6 +7,7 @@ import { useContext } from "react";
 import { DataPanel } from "./data-area";
 import { ButtonAsLink } from "./form-elements";
 import GlobalContext from "./global-context";
+import SessionContext from "./session-context";
 // lib
 import { loginAuthProvider } from "../lib/authentication";
 import { LINK_INLINE_STYLE } from "../lib/constants";
@@ -17,6 +18,7 @@ import { LINK_INLINE_STYLE } from "../lib/constants";
 export default function NoCollectionData({ pageTitle = "" }) {
   const { page } = useContext(GlobalContext);
   const { isAuthenticated, loginWithRedirect } = useAuth0();
+  const { setAuthStageLogin } = useContext(SessionContext);
 
   return (
     <DataPanel className="my-0.5 p-4">
@@ -24,7 +26,12 @@ export default function NoCollectionData({ pageTitle = "" }) {
       {!isAuthenticated && (
         <p className="mt-4 text-sm">
           Please{" "}
-          <ButtonAsLink onClick={() => loginAuthProvider(loginWithRedirect)}>
+          <ButtonAsLink
+            onClick={() => {
+              loginAuthProvider(loginWithRedirect);
+              setAuthStageLogin();
+            }}
+          >
             sign in
           </ButtonAsLink>{" "}
           if you believe you should see {pageTitle || page.title}. See the

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -42,7 +42,7 @@ Cypress.Commands.add("loginAuth0", (username, password, isHomeFirst = true) => {
   cy.get(`[data-testid="navigation-authenticate"]`).click();
 
   // Login on Auth0 through the auth0 sign-in page.
-  cy.origin("igvf-dacc.us.auth0.com", { args }, ({ username, password }) => {
+  cy.origin("auth.igvf.org", { args }, ({ username, password }) => {
     cy.get("#1-email").type(username);
     cy.get("#1-password").type(password);
     cy.get("button[type=submit]").click();

--- a/lib/authentication.ts
+++ b/lib/authentication.ts
@@ -92,7 +92,7 @@ export async function logoutDataProvider(): Promise<
  * Log the user into the authentication provider.
  * @param {function} loginWithRedirect Auth0-react function to login
  */
-export function loginAuthProvider(
+export async function loginAuthProvider(
   loginWithRedirect: (o?: RedirectLoginOptions) => Promise<void>
 ) {
   // Get a URL to return to after logging in. If we're already on the error page, just return to
@@ -105,7 +105,7 @@ export function loginAuthProvider(
 
   // Trigger the login process. Pass the current URL as the returnTo parameter so that Auth0
   // redirects back to the current page after login.
-  loginWithRedirect({
+  return await loginWithRedirect({
     appState: {
       returnTo: returnUrl,
     },

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -27,7 +27,7 @@ export const UI_VERSION = publicRuntimeConfig.UI_VERSION as string;
  * Auth0
  */
 export const AUTH0_CLIENT_ID: string = "xaO8MMn04qlT3TUnhczmKWZgBzqRySDm";
-export const AUTH0_ISSUER_BASE_DOMAIN: string = "igvf-dacc.us.auth0.com";
+export const AUTH0_ISSUER_BASE_DOMAIN: string = "auth.igvf.org";
 export const AUTH0_AUDIENCE: string = "https://igvf-dacc.us.auth0.com/api/v2/";
 
 /**


### PR DESCRIPTION
The main point of the operational code changes (as opposed to the string changes we need to work with the new domain) are to delay logging into igvfd until we know Auth0 has completed authentication and updated the cookies in your browser to allow the igvfd login. We needed this delay to get Safari and Firefox to work.

I found this easiest by using a session variable to indicate that we are attempting to login or logout, or neither. Logging in involves either us or Auth0 reloading the page, so I found the session variable necessary.