### PR TITLE
IGVF-1560 Display short statuses in tables

### DIFF
--- a/components/biomarker-table.js
+++ b/components/biomarker-table.js
@@ -1,8 +1,8 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import { DataAreaTitle } from "./data-area";
+import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
 import { AliasesCell } from "./table-cells";
 
@@ -12,9 +12,9 @@ const biomarkersColumns = [
     title: "Biomarker",
     display: ({ source }) => {
       return (
-        <Link href={source["@id"]}>
+        <LinkedIdAndStatus item={source}>
           {source.name} {source.quantification}
-        </Link>
+        </LinkedIdAndStatus>
       );
     },
     sorter: (item) => item.name,

--- a/components/derived-from-table.js
+++ b/components/derived-from-table.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import Link from "next/link";
 // components
 import { DataAreaTitle } from "./data-area";
+import { FileAccessionAndDownload } from "./file-download";
 import SortableGrid from "./sortable-grid";
 import Status from "./status";
 // lib
@@ -15,9 +16,8 @@ const columns = [
   {
     id: "@id",
     title: "Accession",
-    display: (source) => {
-      const accession = source.source.accession;
-      return <Link href={source.source["@id"]}>{accession}</Link>;
+    display: ({ source }) => {
+      return <FileAccessionAndDownload file={source} />;
     },
   },
   {
@@ -55,11 +55,6 @@ const columns = [
     title: "File Size",
     display: ({ source }) =>
       truthyOrZero(source.file_size) ? dataSize(source.file_size) : "",
-  },
-  {
-    id: "status",
-    title: "Status",
-    display: ({ source }) => <Status status={source.status} />,
   },
   {
     id: "upload_status",

--- a/components/file-download.js
+++ b/components/file-download.js
@@ -1,7 +1,8 @@
 // node_modules
 import { ArrowDownTrayIcon } from "@heroicons/react/20/solid";
-import Link from "next/link";
 import PropTypes from "prop-types";
+// components
+import LinkedIdAndStatus from "./linked-id-and-status";
 // lib
 import { API_URL } from "../lib/constants";
 import { ButtonLink } from "./form-elements";
@@ -65,7 +66,7 @@ export function FileAccessionAndDownload({ file }) {
   return (
     <div>
       <div className="flex items-center gap-1">
-        <Link href={file["@id"]}>{file.accession}</Link>
+        <LinkedIdAndStatus item={file}>{file.accession}</LinkedIdAndStatus>
         <FileDownload file={file} />
       </div>
     </div>

--- a/components/file-set-table.js
+++ b/components/file-set-table.js
@@ -1,11 +1,10 @@
 // node_modules
 import { TableCellsIcon } from "@heroicons/react/20/solid";
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
+import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
-import Status from "./status";
 import { AliasesCell } from "./table-cells";
 // lib
 import { encodeUriElement } from "../lib/query-encoding";
@@ -15,7 +14,7 @@ const fileSetColumns = [
     id: "accession",
     title: "Accession",
     display: ({ source }) => (
-      <Link href={source["@id"]}>{source.accession}</Link>
+      <LinkedIdAndStatus item={source}>{source.accession}</LinkedIdAndStatus>
     ),
   },
   {
@@ -33,13 +32,6 @@ const fileSetColumns = [
     title: "Lab",
     display: ({ source }) => source.lab?.title || null,
     sorter: (item) => (item.lab?.title ? item.lab.title.toLowerCase() : ""),
-  },
-  {
-    id: "status",
-    title: "Status",
-    display: ({ source }) => {
-      return <Status status={source.status} />;
-    },
   },
 ];
 

--- a/components/file-table.js
+++ b/components/file-table.js
@@ -37,13 +37,6 @@ const filesColumns = [
       truthyOrZero(source.file_size) ? dataSize(source.file_size) : "",
   },
   {
-    id: "status",
-    title: "Status",
-    display: ({ source }) => {
-      return <Status status={source.status} />;
-    },
-  },
-  {
     id: "upload_status",
     title: "Upload Status",
     display: ({ source }) => <Status status={source.upload_status} />,

--- a/components/file-table.js
+++ b/components/file-table.js
@@ -29,6 +29,7 @@ const filesColumns = [
     id: "lab",
     title: "Lab",
     display: ({ source }) => source.lab?.title,
+    sorter: (item) => (item.lab ? item.lab.title.toLowerCase() : ""),
   },
   {
     id: "file_size",

--- a/components/linked-id-and-status.js
+++ b/components/linked-id-and-status.js
@@ -1,0 +1,33 @@
+// node_modules
+import Link from "next/link";
+import PropTypes from "prop-types";
+// components
+import Status from "./status";
+
+/**
+ * Display a link to an item's summary page along with its abbreviated status.
+ */
+export default function LinkedIdAndStatus({
+  item,
+  status = "",
+  className = "",
+  children,
+}) {
+  return (
+    <div className={`flex items-center gap-1 ${className}`}>
+      <Link href={item["@id"]} className="block">
+        {children}
+      </Link>
+      <Status status={status || item.status} isAbbreviated />
+    </div>
+  );
+}
+
+LinkedIdAndStatus.propTypes = {
+  // Item to display the accession and status of
+  item: PropTypes.object.isRequired,
+  // Status to display if not using `item.status`
+  status: PropTypes.string,
+  // Additional Tailwind CSS classes for the wrapper div
+  className: PropTypes.string,
+};

--- a/components/modification-table.js
+++ b/components/modification-table.js
@@ -1,29 +1,21 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import { DataAreaTitle } from "./data-area";
+import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
-import Status from "./status";
 
 const modificationsColumns = [
   {
-    id: "modality",
-    title: "Modality",
-  },
-  {
     id: "summary",
     title: "Summary",
-    display: ({ source }) => {
-      return <Link href={source["@id"]}>{source.summary}</Link>;
-    },
+    display: ({ source }) => (
+      <LinkedIdAndStatus item={source}>{source.summary}</LinkedIdAndStatus>
+    ),
   },
   {
-    id: "status",
-    title: "Status",
-    display: ({ source }) => {
-      return <Status status={source.status} />;
-    },
+    id: "modality",
+    title: "Modality",
   },
 ];
 

--- a/components/phenotypic-feature-table.js
+++ b/components/phenotypic-feature-table.js
@@ -3,7 +3,10 @@ import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import { DataAreaTitle } from "./data-area";
+import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
+// lib
+import { formatDate } from "../lib/dates";
 
 const phenotypicFeaturesColumns = [
   {
@@ -11,7 +14,11 @@ const phenotypicFeaturesColumns = [
     title: "Feature Name",
     display: ({ source }) => {
       const featureTerm = source.feature;
-      return <Link href={source["@id"]}>{featureTerm.term_name}</Link>;
+      return (
+        <LinkedIdAndStatus item={source}>
+          {featureTerm.term_name}
+        </LinkedIdAndStatus>
+      );
     },
     sorter: (item) => item.feature.term_name.toLowerCase(),
   },
@@ -48,6 +55,7 @@ const phenotypicFeaturesColumns = [
   {
     id: "observation_date",
     title: "Observation Date",
+    display: ({ source }) => formatDate(source.observation_date),
   },
 ];
 

--- a/components/related-donors-table.js
+++ b/components/related-donors-table.js
@@ -1,22 +1,52 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import { DataAreaTitle } from "./data-area";
+import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
+
+/**
+ * The relationship type exists along side the donor objects embedded related_donors objects, but
+ * does not exist in the separately retrieved related donor objects. Find the embedded
+ * related_donors object that matches the given retrieved related donor object.
+ * @param {object} donor Retrieved donor object to find in embeddedDonors
+ * @param {array} embeddedDonors related_donors objects including donor object and relationship_type
+ * @returns {object} Embedded related_donors object corresponding to the related donor object
+ */
+function findMatchingEmbeddedDonor(donor, embeddedDonors) {
+  return embeddedDonors.find(
+    (embeddedDonor) => embeddedDonor.donor["@id"] === donor["@id"]
+  );
+}
 
 const relatedDonorsColumns = [
   {
     id: "related_donor_id",
     title: "Donor",
     display: ({ source }) => {
-      return <Link href={source.donor["@id"]}>{source.donor.accession}</Link>;
+      return (
+        <LinkedIdAndStatus item={source}>{source.accession}</LinkedIdAndStatus>
+      );
     },
-    sorter: (item) => item.donor.accession,
+    sorter: (item) => item.accession,
   },
   {
     id: "relationship_type",
     title: "Relationship Type",
+    display: ({ source, meta }) => {
+      const matchingEmbeddedDonor = findMatchingEmbeddedDonor(
+        source,
+        meta.embeddedDonors
+      );
+      return matchingEmbeddedDonor?.relationship_type;
+    },
+    sorter: (relatedDonor, meta) => {
+      const matchingEmbeddedDonor = findMatchingEmbeddedDonor(
+        relatedDonor,
+        meta.embeddedDonors
+      );
+      return matchingEmbeddedDonor?.relationship_type || "";
+    },
   },
 ];
 
@@ -25,6 +55,7 @@ const relatedDonorsColumns = [
  */
 export default function RelatedDonorsTable({
   relatedDonors,
+  embeddedDonors,
   title = "Related Donors",
 }) {
   return (
@@ -33,6 +64,7 @@ export default function RelatedDonorsTable({
       <SortableGrid
         data={relatedDonors}
         columns={relatedDonorsColumns}
+        meta={{ embeddedDonors }}
         pager={{}}
       />
     </>
@@ -42,6 +74,8 @@ export default function RelatedDonorsTable({
 RelatedDonorsTable.propTypes = {
   // Related donors to display
   relatedDonors: PropTypes.arrayOf(PropTypes.object).isRequired,
+  // Related donor objects embedded in the displayed donor object; includes relationship type
+  embeddedDonors: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Title of the table if not "Related Donors"
   title: PropTypes.string,
 };

--- a/components/sample-table.js
+++ b/components/sample-table.js
@@ -4,9 +4,9 @@ import PropTypes from "prop-types";
 import Link from "next/link";
 // components
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
+import LinkedIdAndStatus from "./linked-id-and-status";
 import SeparatedList from "./separated-list";
 import SortableGrid from "./sortable-grid";
-import Status from "./status";
 
 /**
  * Columns for samples
@@ -16,7 +16,9 @@ const sampleColumns = [
     id: "accession",
     title: "Accession",
     display: ({ source }) => {
-      return <Link href={source["@id"]}>{source.accession}</Link>;
+      return (
+        <LinkedIdAndStatus item={source}>{source.accession}</LinkedIdAndStatus>
+      );
     },
   },
   {
@@ -102,13 +104,6 @@ const sampleColumns = [
       }
     },
     isSortable: false,
-  },
-  {
-    id: "status",
-    title: "Status",
-    display: ({ source }) => {
-      return <Status status={source.status} />;
-    },
   },
 ];
 

--- a/components/search/__tests__/list-renderer.test.js
+++ b/components/search/__tests__/list-renderer.test.js
@@ -1436,7 +1436,7 @@ it("renders a seqspec configuration File item with accessory data", () => {
       dbxrefs: ["SRA:SRR12345"],
       illumina_read_type: "R1",
       sequencing_run: 1,
-      seqspec: "/configuration-file/IGVFFI1234CONF/",
+      seqspecs: ["/configuration-file/IGVFFI1234CONF/"],
     },
     "/sequence-files/IGVFDS8812ASDF/": {
       "@id": "/sequence-file/IGVFDS8812ASDF/",
@@ -1455,7 +1455,7 @@ it("renders a seqspec configuration File item with accessory data", () => {
       dbxrefs: ["SRA:SRR12346"],
       illumina_read_type: "R2",
       sequencing_run: 1,
-      seqspec: "/configuration-file/IGVFFI1234CONF/",
+      seqspecs: ["/configuration-file/IGVFFI1234CONF/"],
     },
   };
 

--- a/components/sequencing-file-table.js
+++ b/components/sequencing-file-table.js
@@ -56,9 +56,10 @@ const filesColumns = [
           return (
             <SeparatedList>
               {matchingSeqspecs.map((matchingSeqspec) => (
-                <Link key={matchingSeqspec["@id"]} href={matchingSeqspec.href}>
-                  {matchingSeqspec.accession}
-                </Link>
+                <FileAccessionAndDownload
+                  key={matchingSeqspec["@id"]}
+                  file={matchingSeqspec}
+                />
               ))}
             </SeparatedList>
           );

--- a/components/sequencing-file-table.js
+++ b/components/sequencing-file-table.js
@@ -5,7 +5,6 @@ import PropTypes from "prop-types";
 // components
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import { FileAccessionAndDownload } from "./file-download";
-import SeparatedList from "./separated-list";
 import SortableGrid from "./sortable-grid";
 import Status from "./status";
 // lib
@@ -53,14 +52,16 @@ const filesColumns = [
         if (matchingSeqspecs.length > 0) {
           matchingSeqspecs = _.sortBy(matchingSeqspecs, "accession");
           return (
-            <SeparatedList>
+            <div>
               {matchingSeqspecs.map((matchingSeqspec) => (
-                <FileAccessionAndDownload
+                <div
+                  className="my-1.5 first:mt-0 last:mb-0"
                   key={matchingSeqspec["@id"]}
-                  file={matchingSeqspec}
-                />
+                >
+                  <FileAccessionAndDownload file={matchingSeqspec} />
+                </div>
               ))}
-            </SeparatedList>
+            </div>
           );
         }
       }

--- a/components/sequencing-file-table.js
+++ b/components/sequencing-file-table.js
@@ -1,6 +1,5 @@
 // node_modules
 import { TableCellsIcon } from "@heroicons/react/20/solid";
-import Link from "next/link";
 import _ from "lodash";
 import PropTypes from "prop-types";
 // components

--- a/components/software-version-table.js
+++ b/components/software-version-table.js
@@ -2,7 +2,7 @@
 import PropTypes from "prop-types";
 // components
 import { DataAreaTitle } from "./data-area";
-import ItemLink from "./item-link";
+import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
 
 /**
@@ -15,10 +15,9 @@ const columns = [
     isSortable: false,
     display: ({ source }) => {
       return (
-        <ItemLink
-          href={source["@id"]}
-          label={`View page for software version ${source.version}`}
-        />
+        <LinkedIdAndStatus item={source}>
+          {source.name || source["@id"]}
+        </LinkedIdAndStatus>
       );
     },
   },
@@ -49,7 +48,7 @@ export default function SoftwareVersionTable({
   return (
     <>
       <DataAreaTitle>{title}</DataAreaTitle>
-      <SortableGrid data={versions} columns={columns} pager={{}} />;
+      <SortableGrid data={versions} columns={columns} pager={{}} />
     </>
   );
 }

--- a/components/treatment-table.js
+++ b/components/treatment-table.js
@@ -1,12 +1,23 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import { DataAreaTitle } from "./data-area";
+import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
-import Status from "./status";
 
 const treatmentColumns = [
+  {
+    id: "treatment_term_name",
+    title: "Term Name",
+    display: ({ source }) => {
+      return (
+        <LinkedIdAndStatus item={source}>
+          {source.treatment_term_name}
+        </LinkedIdAndStatus>
+      );
+    },
+    sorter: (item) => item.treatment_term_name.toLowerCase(),
+  },
   {
     id: "purpose",
     title: "Purpose",
@@ -18,17 +29,7 @@ const treatmentColumns = [
   {
     id: "summary",
     title: "Summary",
-    display: ({ source }) => {
-      return <Link href={source["@id"]}>{source.summary}</Link>;
-    },
     isSortable: false,
-  },
-  {
-    id: "status",
-    title: "Status",
-    display: ({ source }) => {
-      return <Status status={source.status} />;
-    },
   },
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -925,9 +925,9 @@
       "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
     },
     "node_modules/@headlessui/react": {
-      "version": "1.7.18",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.18.tgz",
-      "integrity": "sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==",
+      "version": "1.7.19",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.19.tgz",
+      "integrity": "sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==",
       "dependencies": {
         "@tanstack/react-virtual": "^3.0.0-beta.60",
         "client-only": "^0.0.1"
@@ -1510,9 +1510,9 @@
       "integrity": "sha512-RmHanbV21saP/6OEPBJ7yJMuys68cIf8OBBWd7+uj40LdpmswVAwe1uzeuFyUsd6SfeITWT3XnQfn6wULeKwDQ=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.0.tgz",
-      "integrity": "sha512-QkM01VPhwcupezVevy9Uyl1rmpg2PimhMjkb+ySmnPgSKUUM/PGGRQxdFgMpHv/JzQoC8kRySgKeM441GiizcA==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.1.tgz",
+      "integrity": "sha512-Fp+mthEBjkn8r9qd6o4JgxKp0IDEzW0VYHD8ZC05xS5/lFNwHKuOdr2kVhWG7BQCO9L6eeepshM1Wbs2T+LgSg==",
       "dev": true,
       "dependencies": {
         "glob": "10.3.10"
@@ -2027,11 +2027,11 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.2.1.tgz",
-      "integrity": "sha512-i9Nt0ssIh2bSjomJZlr6Iq5usT/9+ewo2/fKHRNk6kjVKS8jrhXbnO8NEawarCuBx/efv0xpoUUKKGxa0cQb4Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.3.0.tgz",
+      "integrity": "sha512-QFxmTSZBniq15S0vSZ55P4ToXquMXwJypPXyX/ux7sYo6a2FX3/zWoRLLc4eIOGWTjvzqcIVNKhcuFb+OZL3aQ==",
       "dependencies": {
-        "@tanstack/virtual-core": "3.2.1"
+        "@tanstack/virtual-core": "3.3.0"
       },
       "funding": {
         "type": "github",
@@ -2043,9 +2043,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.2.1.tgz",
-      "integrity": "sha512-nO0d4vRzsmpBQCJYyClNHPPoUMI4nXNfrm6IcCRL33ncWMoNVpURh9YebEHPw8KrtsP2VSJIHE4gf4XFGk1OGg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.3.0.tgz",
+      "integrity": "sha512-A0004OAa1FcUkPHeeGoKgBrAgjH+uHdDPrw1L7RpkwnODYqRvoilqsHPs8cyTjMg1byZBbiNpQAq2TlFLIaQag==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -2163,9 +2163,9 @@
       "dev": true
     },
     "node_modules/@testing-library/react": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-15.0.1.tgz",
-      "integrity": "sha512-I8u4qqGAuBg7C1/kRB9n7Oz9Pc/UHEkmiQRbJziSG8B13eZfAcAUn8TSP26ZIvfSeb68CngmtZbKKcRqcQKa3g==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-15.0.2.tgz",
+      "integrity": "sha512-5mzIpuytB1ctpyywvyaY2TAAUQVCZIGqwiqFQf6u9lvj/SJQepGUzNV18Xpk+NLCaCE2j7CWrZE0tEf9xLZYiQ==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -2414,9 +2414,9 @@
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.77",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.77.tgz",
-      "integrity": "sha512-CUT9KUUF+HytDM7WiXKLF9qUSg4tGImwy4FXTlfEDPEkkNUzJ7rVFolYweJ9fS1ljoIaP7M7Rdjc5eUm/Yu5AA==",
+      "version": "18.2.79",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.79.tgz",
+      "integrity": "sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2503,15 +2503,15 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.6.0.tgz",
-      "integrity": "sha512-gKmTNwZnblUdnTIJu3e9kmeRRzV2j1a/LUO27KNNAnIC5zjy1aSvXSRp4rVNlmAoHlQ7HzX42NbKpcSr4jF80A==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.7.0.tgz",
+      "integrity": "sha512-GJWR0YnfrKnsRoluVO3PRb9r5aMZriiMMM/RHj5nnTrBy1/wIgk76XCtCKcnXGjpZQJQRFtGV9/0JJ6n30uwpQ==",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.6.0",
-        "@typescript-eslint/type-utils": "7.6.0",
-        "@typescript-eslint/utils": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0",
+        "@typescript-eslint/scope-manager": "7.7.0",
+        "@typescript-eslint/type-utils": "7.7.0",
+        "@typescript-eslint/utils": "7.7.0",
+        "@typescript-eslint/visitor-keys": "7.7.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
@@ -2537,14 +2537,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.6.0.tgz",
-      "integrity": "sha512-usPMPHcwX3ZoPWnBnhhorc14NJw9J4HpSXQX4urF2TPKG0au0XhJoZyX62fmvdHONUkmyUe74Hzm1//XA+BoYg==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.7.0.tgz",
+      "integrity": "sha512-fNcDm3wSwVM8QYL4HKVBggdIPAy9Q41vcvC/GtDobw3c4ndVT3K6cqudUmjHPw8EAp4ufax0o58/xvWaP2FmTg==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.6.0",
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/typescript-estree": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0",
+        "@typescript-eslint/scope-manager": "7.7.0",
+        "@typescript-eslint/types": "7.7.0",
+        "@typescript-eslint/typescript-estree": "7.7.0",
+        "@typescript-eslint/visitor-keys": "7.7.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2564,12 +2564,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.6.0.tgz",
-      "integrity": "sha512-ngttyfExA5PsHSx0rdFgnADMYQi+Zkeiv4/ZxGYUWd0nLs63Ha0ksmp8VMxAIC0wtCFxMos7Lt3PszJssG/E6w==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.7.0.tgz",
+      "integrity": "sha512-/8INDn0YLInbe9Wt7dK4cXLDYp0fNHP5xKLHvZl3mOT5X17rK/YShXaiNmorl+/U4VKCVIjJnx4Ri5b0y+HClw==",
       "dependencies": {
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0"
+        "@typescript-eslint/types": "7.7.0",
+        "@typescript-eslint/visitor-keys": "7.7.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -2580,12 +2580,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.6.0.tgz",
-      "integrity": "sha512-NxAfqAPNLG6LTmy7uZgpK8KcuiS2NZD/HlThPXQRGwz6u7MDBWRVliEEl1Gj6U7++kVJTpehkhZzCJLMK66Scw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.7.0.tgz",
+      "integrity": "sha512-bOp3ejoRYrhAlnT/bozNQi3nio9tIgv3U5C0mVDdZC7cpcQEDZXvq8inrHYghLVwuNABRqrMW5tzAv88Vy77Sg==",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.6.0",
-        "@typescript-eslint/utils": "7.6.0",
+        "@typescript-eslint/typescript-estree": "7.7.0",
+        "@typescript-eslint/utils": "7.7.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -2606,9 +2606,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.6.0.tgz",
-      "integrity": "sha512-h02rYQn8J+MureCvHVVzhl69/GAfQGPQZmOMjG1KfCl7o3HtMSlPaPUAPu6lLctXI5ySRGIYk94clD/AUMCUgQ==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.7.0.tgz",
+      "integrity": "sha512-G01YPZ1Bd2hn+KPpIbrAhEWOn5lQBrjxkzHkWvP6NucMXFtfXoevK82hzQdpfuQYuhkvFDeQYbzXCjR1z9Z03w==",
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
       },
@@ -2618,12 +2618,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.6.0.tgz",
-      "integrity": "sha512-+7Y/GP9VuYibecrCQWSKgl3GvUM5cILRttpWtnAu8GNL9j11e4tbuGZmZjJ8ejnKYyBRb2ddGQ3rEFCq3QjMJw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.7.0.tgz",
+      "integrity": "sha512-8p71HQPE6CbxIBy2kWHqM1KGrC07pk6RJn40n0DSc6bMOBBREZxSDJ+BmRzc8B5OdaMh1ty3mkuWRg4sCFiDQQ==",
       "dependencies": {
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0",
+        "@typescript-eslint/types": "7.7.0",
+        "@typescript-eslint/visitor-keys": "7.7.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2645,16 +2645,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.6.0.tgz",
-      "integrity": "sha512-x54gaSsRRI+Nwz59TXpCsr6harB98qjXYzsRxGqvA5Ue3kQH+FxS7FYU81g/omn22ML2pZJkisy6Q+ElK8pBCA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.7.0.tgz",
+      "integrity": "sha512-LKGAXMPQs8U/zMRFXDZOzmMKgFv3COlxUQ+2NMPhbqgVm6R1w+nU1i4836Pmxu9jZAuIeyySNrN/6Rc657ggig==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.15",
         "@types/semver": "^7.5.8",
-        "@typescript-eslint/scope-manager": "7.6.0",
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/typescript-estree": "7.6.0",
+        "@typescript-eslint/scope-manager": "7.7.0",
+        "@typescript-eslint/types": "7.7.0",
+        "@typescript-eslint/typescript-estree": "7.7.0",
         "semver": "^7.6.0"
       },
       "engines": {
@@ -2669,11 +2669,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.6.0.tgz",
-      "integrity": "sha512-4eLB7t+LlNUmXzfOu1VAIAdkjbu5xNSerURS9X/S5TUKWFRpXRQZbmtPqgKmYx8bj3J0irtQXSiWAOY82v+cgw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.7.0.tgz",
+      "integrity": "sha512-h0WHOj8MhdhY8YWkzIF30R379y0NqyOHExI9N9KCzvmu05EgG4FumeYa3ccfKUSphyWkWQE1ybVrgz/Pbam6YA==",
       "dependencies": {
-        "@typescript-eslint/types": "7.6.0",
+        "@typescript-eslint/types": "7.7.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -3567,9 +3567,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001609",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001609.tgz",
-      "integrity": "sha512-JFPQs34lHKx1B5t1EpQpWH4c+29zIyn/haGsbpfq3suuV9v56enjFt23zqijxGTMwy1p/4H2tjnQMY+p1WoAyA==",
+      "version": "1.0.30001610",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001610.tgz",
+      "integrity": "sha512-QFutAY4NgaelojVMjY63o6XlZyORPaLfyMnsl3HgnWdJUcX6K0oaJymHjH8PT5Gk7sTm8rvC/c5COUQKXqmOMA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4624,9 +4624,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.735",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.735.tgz",
-      "integrity": "sha512-pkYpvwg8VyOTQAeBqZ7jsmpCjko1Qc6We1ZtZCjRyYbT5v4AIUKDy5cQTRotQlSSZmMr8jqpEt6JtOj5k7lR7A==",
+      "version": "1.4.736",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.736.tgz",
+      "integrity": "sha512-Rer6wc3ynLelKNM4lOCg7/zPQj8tPOCB2hzD32PX9wd3hgRRi9MxEbmkFCokzcEhRVMiOVLjnL9ig9cefJ+6+Q==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4969,12 +4969,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.0.tgz",
-      "integrity": "sha512-N0eQkn/wz557mIpW4JQWGEv4wGU8zvJ7emLHMS15uC18jjaU4kx6leR4U9QYT/eNghUZT7N9lBlfd8E4N0cp1w==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.1.tgz",
+      "integrity": "sha512-BgD0kPCWMlqoItRf3xe9fG0MqwObKfVch+f2ccwDpZiCJA8ghkz2wrASH+bI6nLZzGcOJOpMm1v1Q1euhfpt4Q==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "14.2.0",
+        "@next/eslint-plugin-next": "14.2.1",
         "@rushstack/eslint-patch": "^1.3.3",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || 7.0.0 - 7.2.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -5196,9 +5196,9 @@
       }
     },
     "node_modules/eslint-plugin-cypress": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.15.1.tgz",
-      "integrity": "sha512-eLHLWP5Q+I4j2AWepYq0PgFEei9/s5LvjuSqWrxurkg1YZ8ltxdvMNmdSf0drnsNo57CTgYY/NIHHLRSWejR7w==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.15.2.tgz",
+      "integrity": "sha512-CtcFEQTDKyftpI22FVGpx8bkpKyYXBlNge6zSo0pl5/qJvBAnzaD76Vu2AsP16d6mTj478Ldn2mhgrWV+Xr0vQ==",
       "dev": true,
       "dependencies": {
         "globals": "^13.20.0"
@@ -5447,9 +5447,9 @@
       }
     },
     "node_modules/eslint-plugin-testing-library": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.2.1.tgz",
-      "integrity": "sha512-CP2YV/AxtgyrXgizM4648UkuVrFGDcCA8uDmrLytGqtsa7wgC6MTuIQqEAT1Qm4/zCxnC8xRtiGgfEwEt6hmdw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.2.2.tgz",
+      "integrity": "sha512-1E94YOTUDnOjSLyvOwmbVDzQi/WkKm3WVrMXu6SmBr6DN95xTGZmI6HJ/eOkSXh/DlheRsxaPsJvZByDBhWLVQ==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.58.0"
@@ -9758,9 +9758,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.13.tgz",
-      "integrity": "sha512-2tPWHCFNC+WRjAC4SIWQNSOdcL1NNkydXim8w7TDqlZi+/ulZYz2OouAI6qMtkggnPt7lGamboj6LcTMwcCvoQ==",
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.14.tgz",
+      "integrity": "sha512-Puaz+wPUAhFp8Lo9HuciYKM2Y2XExESjeT+9NQoVFXZsPPnc9VYss2SpxdQ6vbatmt8/4+SN0oe0I1cPDABg9Q==",
       "dev": true,
       "engines": {
         "node": ">=14.21.3"
@@ -9972,9 +9972,9 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
-      "integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
       "dev": true,
       "dependencies": {
         "side-channel": "^1.0.6"

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -22,11 +22,11 @@ import FileTable from "../../components/file-table";
 import FileSetTable from "../../components/file-set-table";
 import Checkbox from "../../components/checkbox";
 import JsonDisplay from "../../components/json-display";
+import LinkedIdAndStatus from "../../components/linked-id-and-status";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SeparatedList from "../../components/separated-list";
 import SortableGrid from "../../components/sortable-grid";
-import Status from "../../components/status";
 // lib
 import buildAttribution from "../../lib/attribution";
 import buildBreadcrumbs from "../../lib/breadcrumbs";
@@ -42,25 +42,6 @@ import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import { pathToType } from "../../lib/general";
 import { isJsonFormat } from "../../lib/query-utils";
-
-/**
- * Display an object's accession and an abbreviated status.
- */
-function AccessionAndStatus({ item }) {
-  return (
-    <div className="mb-1 flex gap-1">
-      <Link href={item["@id"]} className="block">
-        {item.accession}
-      </Link>
-      <Status status={item.status} isAbbreviated />
-    </div>
-  );
-}
-
-AccessionAndStatus.propTypes = {
-  // Item to display the accession and status of
-  item: PropTypes.object.isRequired,
-};
 
 /**
  * Columns for the measurement sets table.
@@ -90,7 +71,9 @@ const fileSetColumns = [
         <div>
           {measurementSetSamples.map((sample) => (
             <div key={sample["@id"]} className="my-5 first:mt-0 last:mb-0">
-              <AccessionAndStatus item={sample} />
+              <LinkedIdAndStatus item={sample}>
+                {sample.accession}
+              </LinkedIdAndStatus>
               {sample.summary}
             </div>
           ))}
@@ -140,7 +123,9 @@ const fileSetColumns = [
     display: ({ source }) => {
       return (
         <div>
-          <AccessionAndStatus item={source} />
+          <LinkedIdAndStatus item={source}>
+            {source.accession}
+          </LinkedIdAndStatus>
           {source.summary}
         </div>
       );
@@ -181,7 +166,9 @@ const fileSetColumns = [
           return (
             <div>
               {controlFileSets.map((controlSet) => (
-                <AccessionAndStatus item={controlSet} key={controlSet["@id"]} />
+                <LinkedIdAndStatus item={controlSet} key={controlSet["@id"]}>
+                  {controlSet.accession}
+                </LinkedIdAndStatus>
               ))}
             </div>
           );
@@ -210,10 +197,9 @@ const fileSetColumns = [
         return (
           <div>
             {auxiliarySets.map((auxiliarySet) => (
-              <AccessionAndStatus
-                item={auxiliarySet}
-                key={auxiliarySet["@id"]}
-              />
+              <LinkedIdAndStatus item={auxiliarySet} key={auxiliarySet["@id"]}>
+                {auxiliarySet.accession}
+              </LinkedIdAndStatus>
             ))}
           </div>
         );
@@ -250,7 +236,9 @@ const fileSetColumns = [
         return (
           <div>
             {constructLibrarySets.map((cls) => (
-              <AccessionAndStatus item={cls} key={cls["@id"]} />
+              <LinkedIdAndStatus item={cls} key={cls["@id"]}>
+                {cls.accession}
+              </LinkedIdAndStatus>
             ))}
           </div>
         );

--- a/pages/auxiliary-sets/[id].js
+++ b/pages/auxiliary-sets/[id].js
@@ -29,6 +29,7 @@ import {
   requestFiles,
   requestFileSets,
   requestOntologyTerms,
+  requestSeqspecFiles,
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
@@ -229,18 +230,8 @@ export async function getServerSideProps({ params, req, query }) {
         ? await requestOntologyTerms(uniqueSequencingPlatformPaths, request)
         : [];
 
-    // Use the files to retrieve all the seqspec files they might link to.
-    let seqspecFiles = [];
-    if (files.length > 0) {
-      const seqspecPaths = files
-        .map((file) => file.seqspec)
-        .filter((seqspec) => seqspec);
-      const uniqueSeqspecPaths = [...new Set(seqspecPaths)];
-      seqspecFiles =
-        uniqueSeqspecPaths.length > 0
-          ? await requestFiles(uniqueSeqspecPaths, request)
-          : [];
-    }
+    const seqspecFiles =
+      files.length > 0 ? await requestSeqspecFiles(files, request) : [];
 
     let controlForSets = [];
     if (auxiliarySet.control_for.length > 0) {

--- a/pages/configuration-files/[...id].js
+++ b/pages/configuration-files/[...id].js
@@ -67,8 +67,8 @@ export default function ConfigurationFile({
               title="seqspec File Of"
               sequencingPlatforms={sequencingPlatforms}
               itemPath={configurationFile["@id"]}
-              itemPathProp="seqspec"
-              isSeqspecHidden={true}
+              itemPathProp="seqspecs"
+              isSeqspecHidden
             />
           )}
           {derivedFrom.length > 0 && (

--- a/pages/construct-library-sets/[id].js
+++ b/pages/construct-library-sets/[id].js
@@ -32,6 +32,7 @@ import {
   requestFiles,
   requestOntologyTerms,
   requestFileSets,
+  requestSeqspecFiles,
 } from "../../lib/common-requests";
 import { UC } from "../../lib/constants";
 import { errorObjectToProps } from "../../lib/errors";
@@ -75,12 +76,12 @@ function LibraryDetails({ library }) {
               <DataItemLabel>Small Scale Loci List</DataItemLabel>
               <DataItemValue>
                 <SeparatedList isCollapsible>
-                  {library.small_scale_loci_list.map((loci) => (
-                    <>
+                  {library.small_scale_loci_list.map((loci, index) => (
+                    <Fragment key={index}>
                       {loci.assembly} {loci.chromosome} {loci.start}
                       {"-"}
                       {loci.end}
-                    </>
+                    </Fragment>
                   ))}
                 </SeparatedList>
               </DataItemValue>
@@ -394,6 +395,7 @@ export async function getServerSideProps({ params, req, query }) {
       );
       controlForSets = await requestFileSets(controlForPaths, request);
     }
+
     // Request files and their sequencing platforms.
     const filePaths = constructLibrarySet.files.map((file) => file["@id"]);
     const files =
@@ -412,18 +414,8 @@ export async function getServerSideProps({ params, req, query }) {
           request
         )
       : [];
-    // Use the files to retrieve all the seqspec files they might link to.
-    let seqspecFiles = [];
-    if (files.length > 0) {
-      const seqspecPaths = files
-        .map((file) => file.seqspec)
-        .filter((seqspec) => seqspec);
-      const uniqueSeqspecPaths = [...new Set(seqspecPaths)];
-      seqspecFiles =
-        uniqueSeqspecPaths.length > 0
-          ? await requestFiles(uniqueSeqspecPaths, request)
-          : [];
-    }
+    const seqspecFiles =
+      files.length > 0 ? await requestSeqspecFiles(files, request) : [];
 
     const breadcrumbs = await buildBreadcrumbs(
       constructLibrarySet,

--- a/pages/measurement-sets/[id].js
+++ b/pages/measurement-sets/[id].js
@@ -34,6 +34,7 @@ import {
   requestFiles,
   requestFileSets,
   requestOntologyTerms,
+  requestSeqspecFiles,
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
@@ -385,17 +386,8 @@ export async function getServerSideProps({ params, req, query }) {
     }
 
     // Use the files to retrieve all the seqspec files they might link to.
-    let seqspecFiles = [];
-    if (files.length > 0) {
-      const seqspecPaths = files
-        .map((file) => file.seqspec)
-        .filter((seqspec) => seqspec);
-      const uniqueSeqspecPaths = [...new Set(seqspecPaths)];
-      seqspecFiles =
-        uniqueSeqspecPaths.length > 0
-          ? await requestFiles(uniqueSeqspecPaths, request)
-          : [];
-    }
+    const seqspecFiles =
+      files.length > 0 ? await requestSeqspecFiles(files, request) : [];
 
     // Use the files to retrieve all the sequencing platform objects they link to.
     const sequencingPlatformPaths = files

--- a/pages/primary-cells/[uuid].js
+++ b/pages/primary-cells/[uuid].js
@@ -30,6 +30,7 @@ import {
   requestDonors,
   requestFileSets,
   requestOntologyTerms,
+  requestTreatments,
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
@@ -50,6 +51,7 @@ export default function PrimaryCell({
   pooledIn,
   sortedFractions,
   sources,
+  treatments,
   attribution = null,
   isJson,
 }) {
@@ -105,9 +107,7 @@ export default function PrimaryCell({
             <ModificationTable modifications={primaryCell.modifications} />
           )}
           {biomarkers.length > 0 && <BiomarkerTable biomarkers={biomarkers} />}
-          {primaryCell.treatments?.length > 0 && (
-            <TreatmentTable treatments={primaryCell.treatments} />
-          )}
+          {treatments.length > 0 && <TreatmentTable treatments={treatments} />}
           {documents.length > 0 && <DocumentTable documents={documents} />}
           <Attribution attribution={attribution} />
         </JsonDisplay>
@@ -141,6 +141,8 @@ PrimaryCell.propTypes = {
   sortedFractions: PropTypes.arrayOf(PropTypes.object),
   // Source lab or source for this sample
   sources: PropTypes.arrayOf(PropTypes.object),
+  // Treatments associated with the sample
+  treatments: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Attribution for this sample
   attribution: PropTypes.object,
   // Is the format JSON?
@@ -199,6 +201,13 @@ export async function getServerSideProps({ params, req, query }) {
         })
       );
     }
+    let treatments = [];
+    if (primaryCell.treatments?.length > 0) {
+      const treatmentPaths = primaryCell.treatments.map(
+        (treatment) => treatment["@id"]
+      );
+      treatments = await requestTreatments(treatmentPaths, request);
+    }
     const constructLibrarySets = primaryCell.construct_library_sets
       ? await requestFileSets(primaryCell.construct_library_sets, request)
       : [];
@@ -222,6 +231,7 @@ export async function getServerSideProps({ params, req, query }) {
         pooledIn,
         sortedFractions,
         sources,
+        treatments,
         pageContext: {
           title: `${primaryCell.sample_terms[0].term_name} — ${primaryCell.accession}`,
         },

--- a/pages/software/[id].js
+++ b/pages/software/[id].js
@@ -76,9 +76,7 @@ export default function Software({
             </DataArea>
           </DataPanel>
 
-          {software.versions?.length > 0 && (
-            <SoftwareVersionTable versions={versions} />
-          )}
+          {versions?.length > 0 && <SoftwareVersionTable versions={versions} />}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/tissues/[uuid].js
+++ b/pages/tissues/[uuid].js
@@ -31,6 +31,7 @@ import {
   requestDonors,
   requestFileSets,
   requestOntologyTerms,
+  requestTreatments,
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
@@ -50,6 +51,7 @@ export default function Tissue({
   pooledIn,
   sortedFractions,
   sources,
+  treatments,
   attribution = null,
   isJson,
 }) {
@@ -134,9 +136,7 @@ export default function Tissue({
             <ModificationTable modifications={tissue.modifications} />
           )}
           {biomarkers.length > 0 && <BiomarkerTable biomarkers={biomarkers} />}
-          {tissue.treatments?.length > 0 && (
-            <TreatmentTable treatments={tissue.treatments} />
-          )}
+          {treatments.length > 0 && <TreatmentTable treatments={treatments} />}
           {documents.length > 0 && <DocumentTable documents={documents} />}
           <Attribution attribution={attribution} />
         </JsonDisplay>
@@ -170,6 +170,8 @@ Tissue.propTypes = {
   sortedFractions: PropTypes.arrayOf(PropTypes.object),
   // Source lab or source for this sample
   sources: PropTypes.arrayOf(PropTypes.object),
+  // Treatments associated with the sample
+  treatments: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Attribution for this sample
   attribution: PropTypes.object,
   // Is the format JSON?
@@ -224,6 +226,13 @@ export async function getServerSideProps({ params, req, query }) {
         })
       );
     }
+    let treatments = [];
+    if (tissue.treatments?.length > 0) {
+      const treatmentPaths = tissue.treatments.map(
+        (treatment) => treatment["@id"]
+      );
+      treatments = await requestTreatments(treatmentPaths, request);
+    }
     const constructLibrarySets = tissue.construct_library_sets
       ? await requestFileSets(tissue.construct_library_sets, request)
       : [];
@@ -247,6 +256,7 @@ export async function getServerSideProps({ params, req, query }) {
         pooledIn,
         sortedFractions,
         sources,
+        treatments,
         pageContext: {
           title: `${tissue.sample_terms[0].term_name} — ${tissue.accession}`,
         },


### PR DESCRIPTION
Most of the changes involve the repeated deletion of status columns in table configuration objects, and adding `<LinkedIdAndStatus>` to the first column, or `<FileAccessionAndDownload>` for tables of files. Both these components display a linked ID to a summary page, and that object’s status. The latter adds a file-download button to the combination.

You’ll also see changes for the `seqspec` property having changed to `seqspecs` in the SequenceFile schema, and its associated change from a path to an array of ConfigurationFile paths.
