### PR TITLE
IGVF-1626 ConfigurationFile accessory data crash fix

### DIFF
--- a/components/search/__tests__/list-renderer.test.js
+++ b/components/search/__tests__/list-renderer.test.js
@@ -622,124 +622,18 @@ describe("Test the HumanDonor component", () => {
       uuid: "ee99221f-a11a-4f8b-baf3-9919db92f2f9",
       collections: ["ENCODE"],
       phenotypic_features: [
-        "/phenotypic-features/123/",
-        "/phenotypic-features/456/",
-        "/phenotypic-features/111/",
+        {
+          "@id": "/phenotypic-features/123/",
+          feature: {
+            "@id": "/phenotype-terms/NCIT_C92648/",
+            term_id: "NCIT:C92648",
+            term_name: "Body Weight Measurement",
+          },
+          observation_date: "2022-11-15",
+          quantity: 58,
+          quantity_units: "kilogram",
+        },
       ],
-    };
-    const accessoryData = {
-      "/phenotypic-features/123/": {
-        lab: "/labs/j-michael-cherry/",
-        award: "/awards/HG012012/",
-        notes: "Phenotypic feature of body weight",
-        status: "released",
-        feature: {
-          "@id": "/phenotype-terms/NCIT_C92648/",
-          term_id: "NCIT:C92648",
-          term_name: "Body Weight Measurement",
-        },
-        quantity: 58,
-        quantity_units: "kilogram",
-        schema_version: "1",
-        observation_date: "2022-11-15",
-        creation_timestamp: "2023-03-13T23:26:17.586384+00:00",
-        "@id": "/phenotypic-features/123/",
-        "@type": ["PhenotypicFeature", "Item"],
-        uuid: "123",
-        summary: "123",
-        "@context": "/terms/",
-      },
-      "/phenotypic-features/456/": {
-        lab: "/labs/j-michael-cherry/",
-        award: "/awards/HG012012/",
-        status: "released",
-        feature: {
-          "@id": "/phenotype-terms/NCIT_C92648/",
-          term_id: "NCIT:C92648",
-          term_name: "Some other phenotype",
-        },
-        schema_version: "1",
-        observation_date: "2022-11-15",
-        creation_timestamp: "2023-03-13T23:26:17.586384+00:00",
-        "@id": "/phenotypic-features/123/",
-        "@type": ["PhenotypicFeature", "Item"],
-        uuid: "123",
-        summary: "123",
-        "@context": "/terms/",
-      },
-      "/phenotypic-features/111/": {
-        lab: "/labs/j-michael-cherry/",
-        award: "/awards/HG012012/",
-        status: "released",
-        feature: {
-          "@id": "/phenotype-terms/NCIT_C92648/",
-          term_id: "NCIT:C92648",
-          term_name: "Weight",
-        },
-        quantity: 1,
-        quantity_units: "gram",
-        schema_version: "1",
-        observation_date: "2022-11-15",
-        creation_timestamp: "2023-03-13T23:26:17.586384+00:00",
-        "@id": "/phenotypic-features/123/",
-        "@type": ["PhenotypicFeature", "Item"],
-        uuid: "123",
-        summary: "123",
-        "@context": "/terms/",
-      },
-    };
-
-    render(
-      <SessionContext.Provider value={{ profiles }}>
-        <HumanDonor item={item} accessoryData={accessoryData} />
-      </SessionContext.Provider>
-    );
-
-    const uniqueId = screen.getByTestId("search-list-item-unique-id");
-    expect(uniqueId).toHaveTextContent(/^Human Donor/);
-    expect(uniqueId).toHaveTextContent(/IGVFDO856PXB$/);
-
-    const title = screen.getByTestId("search-list-item-title");
-    expect(title).toHaveTextContent(/^African American female$/);
-
-    const meta = screen.getByTestId("search-list-item-meta");
-    expect(meta).toHaveTextContent("Chongyuan Luo");
-    expect(meta).toHaveTextContent("Body Weight Measurement");
-    expect(meta).toHaveTextContent("58 kilograms");
-    expect(meta).toHaveTextContent("Some other phenotype");
-    expect(meta).toHaveTextContent("1 gram");
-    expect(meta).toHaveTextContent("ENCODE");
-
-    const status = screen.getByTestId("search-list-item-quality");
-    expect(status).toHaveTextContent("released");
-
-    const paths = HumanDonor.getAccessoryDataPaths([item]);
-    expect(paths.sort()).toEqual([
-      {
-        type: "PhenotypicFeature",
-        paths: [
-          "/phenotypic-features/123/",
-          "/phenotypic-features/456/",
-          "/phenotypic-features/111/",
-        ],
-        fields: ["quantity", "quantity_units", "feature"],
-      },
-    ]);
-  });
-
-  it("renders a human donor item without accessory data", () => {
-    const item = {
-      "@id": "/human-donors/IGVFDO856PXB/",
-      "@type": ["HumanDonor", "Donor", "Item"],
-      accession: "IGVFDO856PXB",
-      aliases: ["chongyuan-luo:AA F donor of fibroblasts"],
-      award: "/awards/1U01HG012079-01/",
-      ethnicities: ["African American"],
-      lab: { "@id": "/labs/chongyuan-luo/", title: "Chongyuan Luo" },
-      sex: "female",
-      status: "released",
-      taxa: "Homo sapiens",
-      uuid: "ee99221f-a11a-4f8b-baf3-9919db92f2f9",
     };
 
     render(
@@ -757,6 +651,8 @@ describe("Test the HumanDonor component", () => {
 
     const meta = screen.getByTestId("search-list-item-meta");
     expect(meta).toHaveTextContent("Chongyuan Luo");
+    expect(meta).toHaveTextContent("Body Weight Measurement");
+    expect(meta).toHaveTextContent("ENCODE");
 
     const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
@@ -1007,7 +903,7 @@ describe("Test the RodentDonor component", () => {
     expect(status).toHaveTextContent("released");
   });
 
-  it("renders a RodentDonor item with accessory data", () => {
+  it("renders a RodentDonor item with a phenotypic feature", () => {
     const item = {
       "@id": "/rodent-donors/IGVFDO524ORO/",
       "@type": ["RodentDonor", "Donor", "Item"],
@@ -1032,40 +928,19 @@ describe("Test the RodentDonor component", () => {
       uuid: "c37934b0-4269-4470-be53-9eac7b196447",
       collections: ["ENCODE"],
       phenotypic_features: [
-        "/phenotypic-features/abc123/",
-        "/phenotypic-features/123abc",
-        "/phenotypic-features/999",
+        {
+          feature: {
+            "@id": "/phenotypic-features/abc123/",
+            term_name: "a special feature",
+            term_id: "HELLO:12345",
+          },
+        },
       ],
-    };
-
-    const accessoryData = {
-      "/phenotypic-features/abc123/": {
-        feature: {
-          term_name: "a special feature",
-          term_id: "HELLO:12345",
-        },
-      },
-      "/phenotypic-features/123abc": {
-        feature: {
-          term_name: "another quant feature",
-          term_id: "BYE:4567",
-        },
-        quantity: 20,
-        quantity_units: "kilogram",
-      },
-      "/phenotypic-features/999": {
-        feature: {
-          term_name: "one thing",
-          term_id: "ONE:111",
-        },
-        quantity: 1,
-        quantity_units: "gram",
-      },
     };
 
     render(
       <SessionContext.Provider value={{ profiles }}>
-        <RodentDonor item={item} accessoryData={accessoryData} />
+        <RodentDonor item={item} />
       </SessionContext.Provider>
     );
 
@@ -1080,24 +955,9 @@ describe("Test the RodentDonor component", () => {
     expect(meta).toHaveTextContent("J. Michael Cherry, Stanford");
     expect(meta).toHaveTextContent("ENCODE");
     expect(meta).toHaveTextContent("a special feature");
-    expect(meta).toHaveTextContent("20 kilograms");
-    expect(meta).toHaveTextContent("1 gram");
 
     const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
-
-    const paths = RodentDonor.getAccessoryDataPaths([item]);
-    expect(paths).toEqual([
-      {
-        type: "PhenotypicFeature",
-        paths: [
-          "/phenotypic-features/abc123/",
-          "/phenotypic-features/123abc",
-          "/phenotypic-features/999",
-        ],
-        fields: ["quantity", "quantity_units", "feature"],
-      },
-    ]);
   });
 
   it("rodent donor without collection", () => {

--- a/components/search/list-renderer/file.js
+++ b/components/search/list-renderer/file.js
@@ -28,6 +28,12 @@ export default function File({ item: file, accessoryData = null }) {
   ].filter(Boolean);
   const fileSet = accessoryData?.[file.file_set];
 
+  // Get the seqspec_of objects from the accessory data.
+  let seqspecOfs = file.seqspec_of
+    ? file.seqspec_of.map((seqspecOfFile) => accessoryData?.[seqspecOfFile])
+    : [];
+  seqspecOfs = seqspecOfs.filter(Boolean);
+
   return (
     <SearchListItemContent>
       <SearchListItemMain>
@@ -48,7 +54,7 @@ export default function File({ item: file, accessoryData = null }) {
           )}
         </SearchListItemMeta>
         <SearchListItemQuality item={file} />
-        {(fileSet || file.seqspec_of?.length > 0) && (
+        {(fileSet || seqspecOfs.length > 0) && (
           <SearchListItemSupplement>
             {fileSet && (
               <SearchListItemSupplementSection>
@@ -60,18 +66,20 @@ export default function File({ item: file, accessoryData = null }) {
                 </SearchListItemSupplementContent>
               </SearchListItemSupplementSection>
             )}
-            {file.seqspec_of?.length > 0 && (
+            {seqspecOfs.length > 0 && (
               <SearchListItemSupplementSection>
                 <SearchListItemSupplementLabel>
                   Seqspec Of
                 </SearchListItemSupplementLabel>
                 <SearchListItemSupplementContent>
                   <SeparatedList>
-                    {file.seqspec_of.map((seqspecOfFile) => (
-                      <Link href={seqspecOfFile} key={seqspecOfFile}>
-                        {accessoryData[seqspecOfFile].accession}
-                      </Link>
-                    ))}
+                    {seqspecOfs.map((seqspecOf) => {
+                      return (
+                        <Link href={seqspecOf["@id"]} key={seqspecOf["@id"]}>
+                          {seqspecOf.accession}
+                        </Link>
+                      );
+                    })}
                   </SeparatedList>
                 </SearchListItemSupplementContent>
               </SearchListItemSupplementSection>

--- a/components/search/list-renderer/human-donor.js
+++ b/components/search/list-renderer/human-donor.js
@@ -1,4 +1,5 @@
 // node_modules
+import _ from "lodash";
 import PropTypes from "prop-types";
 // components/search/list-renderer
 import AlternateAccessions from "../../alternate-accessions";
@@ -12,31 +13,19 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function HumanDonor({ item: humanDonor, accessoryData = null }) {
+export default function HumanDonor({ item: humanDonor }) {
   const ethnicities =
     humanDonor.ethnicities?.length > 0 ? humanDonor.ethnicities.join(", ") : "";
   const sex = humanDonor.sex || "";
   const title = [ethnicities, sex].filter(Boolean);
   const collections =
     humanDonor.collections?.length > 0 ? humanDonor.collections.join(", ") : "";
-
-  const phenotypicFeatures = accessoryData
-    ? humanDonor.phenotypic_features
-        ?.filter((path) => {
-          const keys = Object.keys(accessoryData);
-          return keys.includes(path);
-        })
-        .map((path) => {
-          const feature = accessoryData[path];
-          if (feature.quantity) {
-            return `${feature.feature.term_name} ${feature.quantity} ${
-              feature.quantity_units
-            }${feature.quantity === 1 ? "" : "s"}`;
-          }
-          return feature.feature.term_name;
-        })
-        .join(", ")
-    : "";
+  let phenotypicFeatures = humanDonor.phenotypic_features
+    ? humanDonor.phenotypic_features.map(
+        (phenotypicFeature) => phenotypicFeature.feature.term_name
+      )
+    : [];
+  phenotypicFeatures = _.uniq(phenotypicFeatures);
 
   return (
     <SearchListItemContent>
@@ -51,8 +40,8 @@ export default function HumanDonor({ item: humanDonor, accessoryData = null }) {
         <SearchListItemMeta>
           <div key="lab">{humanDonor.lab.title}</div>
           {collections && <div key="collections">{collections}</div>}
-          {phenotypicFeatures && (
-            <div key="phenotypic-features">{phenotypicFeatures}</div>
+          {phenotypicFeatures.length > 0 && (
+            <div key="phenotypic-features">{phenotypicFeatures.join(", ")}</div>
           )}
           {humanDonor.alternate_accessions?.length > 0 && (
             <AlternateAccessions
@@ -69,21 +58,4 @@ export default function HumanDonor({ item: humanDonor, accessoryData = null }) {
 HumanDonor.propTypes = {
   // Single human-donor search-result object to display on a search-result list page
   item: PropTypes.object.isRequired,
-  // Accessory data to display for all search-result objects
-  accessoryData: PropTypes.object,
-};
-
-HumanDonor.getAccessoryDataPaths = (humanDonors) => {
-  // A list of list of phenotypic features paths
-  const phenotypicFeatures = humanDonors
-    .map((humanDonor) => humanDonor.phenotypic_features)
-    .filter(Boolean)
-    .flat(1);
-  return [
-    {
-      type: "PhenotypicFeature",
-      paths: phenotypicFeatures,
-      fields: ["quantity", "quantity_units", "feature"],
-    },
-  ];
 };

--- a/components/search/list-renderer/rodent-donor.js
+++ b/components/search/list-renderer/rodent-donor.js
@@ -1,4 +1,5 @@
 // node_modules
+import _ from "lodash";
 import PropTypes from "prop-types";
 // components/search/list-renderer
 import AlternateAccessions from "../../alternate-accessions";
@@ -12,32 +13,19 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 
-export default function RodentDonor({
-  item: rodentDonor,
-  accessoryData = null,
-}) {
+export default function RodentDonor({ item: rodentDonor }) {
   const lab = rodentDonor.lab;
   const collections =
     rodentDonor.collections?.length > 0
       ? rodentDonor.collections.join(", ")
       : "";
-  const phenotypicFeatures = accessoryData
-    ? rodentDonor.phenotypic_features
-        ?.filter((path) => {
-          const keys = Object.keys(accessoryData);
-          return keys.includes(path);
-        })
-        .map((path) => {
-          const feature = accessoryData[path];
-          if (feature.quantity) {
-            return `${feature.feature.term_name} ${feature.quantity} ${
-              feature.quantity_units
-            }${feature.quantity === 1 ? "" : "s"}`;
-          }
-          return feature.feature.term_name;
-        })
-        .join(", ")
-    : "";
+  let phenotypicFeatures = rodentDonor.phenotypic_features
+    ? rodentDonor.phenotypic_features.map(
+        (phenotypicFeature) => phenotypicFeature.feature.term_name
+      )
+    : [];
+  phenotypicFeatures = _.uniq(phenotypicFeatures);
+
   return (
     <SearchListItemContent>
       <SearchListItemMain>
@@ -51,8 +39,8 @@ export default function RodentDonor({
         <SearchListItemMeta>
           <div key="lab">{lab.title}</div>
           {collections && <div key="collections">{collections}</div>}
-          {phenotypicFeatures && (
-            <div key="phenotypes">{phenotypicFeatures}</div>
+          {phenotypicFeatures.length > 0 && (
+            <div key="phenotypes">{phenotypicFeatures.join(", ")}</div>
           )}
           {rodentDonor.alternate_accessions?.length > 0 && (
             <AlternateAccessions
@@ -69,20 +57,4 @@ export default function RodentDonor({
 RodentDonor.propTypes = {
   // Single rodent-donor search-result object to display on a search-result list page
   item: PropTypes.object.isRequired,
-  // Accessory data to display for all search-result objects
-  accessoryData: PropTypes.object,
-};
-
-RodentDonor.getAccessoryDataPaths = (rodentDonors) => {
-  const phenotypicFeatures = rodentDonors
-    .map((rodentDonor) => rodentDonor.phenotypic_features)
-    .filter(Boolean)
-    .flat(1);
-  return [
-    {
-      type: "PhenotypicFeature",
-      paths: phenotypicFeatures,
-      fields: ["quantity", "quantity_units", "feature"],
-    },
-  ];
 };


### PR DESCRIPTION
This was caused by an embedding change in the ConfigurationFile search results so that `phenotypic_features` is now embedded where it wasn’t before. The main change here is not to get accessory data for `phenotypic_features`, but to use the embedded one. I also fixed a bug in the human and rodent donor search results.