### PR TITLE
IGVF-1647 Scrollable report-view column-selection modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+/cypress/downloads
 /cypress/videos
 /cypress/screenshots
 cypress.env.json

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,6 +53,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
+            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,7 +53,6 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/components/grid-scroll-indicators.js
+++ b/components/grid-scroll-indicators.js
@@ -13,7 +13,7 @@ import { useState } from "react";
  * Renders a single left- or right-pointing scroll indicator that fades out after appearing. Don't
  * attempt to compose the left-5 and right-5 Tailwind CSS classes or they'll get tree shaken.
  */
-function ScrollIndicator({ direction, children }) {
+function GridScrollIndicator({ direction, children }) {
   return (
     <motion.div
       initial="visible"
@@ -30,7 +30,7 @@ function ScrollIndicator({ direction, children }) {
   );
 }
 
-ScrollIndicator.propTypes = {
+GridScrollIndicator.propTypes = {
   // Direction of the scroll indicator
   direction: PropTypes.oneOf(["left", "right"]).isRequired,
 };
@@ -39,7 +39,7 @@ ScrollIndicator.propTypes = {
  * Wrapper around the data grid to show scroll indicators when the table is horizontally scrollable.
  */
 // coverage:ignore-line to ignore one line.
-export default function ScrollIndicators({ gridRef, children }) {
+export default function GridScrollIndicators({ gridRef, children }) {
   // True if the table can be scrolled to the right
   const [isScrollableRight, setIsScrollableRight] = useState(false);
   // True if the table can be scrolled to the left
@@ -76,21 +76,21 @@ export default function ScrollIndicators({ gridRef, children }) {
       onPointerLeave={onPointerLeave}
     >
       {isScrollableLeft && (
-        <ScrollIndicator direction="left">
+        <GridScrollIndicator direction="left">
           <ChevronLeftIcon className="fill-white" />
-        </ScrollIndicator>
+        </GridScrollIndicator>
       )}
       {isScrollableRight && (
-        <ScrollIndicator direction="right">
+        <GridScrollIndicator direction="right">
           <ChevronRightIcon className="fill-white" />
-        </ScrollIndicator>
+        </GridScrollIndicator>
       )}
       {children}
     </div>
   );
 }
 
-ScrollIndicators.propTypes = {
+GridScrollIndicators.propTypes = {
   // Ref to the table DOM element
   gridRef: PropTypes.object.isRequired,
 };

--- a/components/modal.js
+++ b/components/modal.js
@@ -121,9 +121,18 @@ Header.propTypes = {
  * Wraps the contents of a modal to provide a standard padding. You can skip using this if you
  * don't want padding, or non-standard padding.
  */
-function Body({ children }) {
-  return <div className="p-2">{children}</div>;
+function Body({ className = null, children }) {
+  return (
+    <div className={className}>
+      <div className="p-2">{children}</div>
+    </div>
+  );
 }
+
+Body.propTypes = {
+  // Tailwind CSS classes to add to the body wrapper div
+  className: PropTypes.string,
+};
 
 /**
  * Footer for the modal. This is typically used to provide an action button, or a close button.

--- a/components/report/column-selector.js
+++ b/components/report/column-selector.js
@@ -1,11 +1,12 @@
 // node_modules
 import PropTypes from "prop-types";
-import { useContext, useState } from "react";
+import { useContext, useRef, useState } from "react";
 // components
 import { Button } from "../form-elements";
 import Checkbox from "../checkbox";
 import Modal from "../modal";
 import SessionContext from "../session-context";
+import VerticalScrollIndicators from "../vertical-scroll-indicators";
 // components/report
 import HiddenColumnsIndicator from "./hidden-columns-indicator";
 
@@ -36,10 +37,20 @@ ChangeAllControls.propTypes = {
  * to hide.
  */
 function CheckboxArea({ className = "", children }) {
+  const scrollAreaRef = useRef(null);
+
   return (
-    <fieldset className={`md:flex md:flex-wrap ${className}`}>
-      {children}
-    </fieldset>
+    <div className="relative">
+      <div
+        ref={scrollAreaRef}
+        className="scroll-area max-h-column-select-modal min-h-36 overflow-y-auto p-2"
+      >
+        <VerticalScrollIndicators scrollAreaRef={scrollAreaRef} />
+        <fieldset className={`md:flex md:flex-wrap ${className}`}>
+          {children}
+        </fieldset>
+      </div>
+    </div>
   );
 }
 
@@ -105,8 +116,8 @@ export default function ColumnSelector({
             </div>
           </Modal.Header>
 
-          <Modal.Body>
-            <div className="mb-3 md:flex md:items-center">
+          <Modal.Body className="[&>div]:p-0">
+            <div className="border-b border-modal-border p-1 md:flex md:items-center">
               <ChangeAllControls onChangeAll={onChangeAll} />
               <Note className="md:ml-2">
                 The <i>ID</i> column cannot be hidden

--- a/components/sortable-grid.js
+++ b/components/sortable-grid.js
@@ -13,7 +13,7 @@ import { Children, cloneElement, useRef, useState } from "react";
 // components
 import DataGrid, { DataGridContainer } from "./data-grid";
 import Pager from "./pager";
-import ScrollIndicators from "./scroll-indicators";
+import GridScrollIndicators from "./grid-scroll-indicators";
 import TableCount from "./table-count";
 
 /**
@@ -97,7 +97,7 @@ function HeaderSortIcon({ columnConfiguration, sortBy, sortDirection }) {
   return (
     <SortIcon
       className={`h-5 w-5${
-        sortBy === columnConfiguration.id ? "" : " invisible"
+        sortBy === columnConfiguration.id ? "" : "invisible"
       }`}
     />
   );
@@ -389,7 +389,7 @@ export default function SortableGrid({
           maxItemsPerPage={maxItemsPerPage}
         />
       )}
-      <ScrollIndicators gridRef={gridRef}>
+      <GridScrollIndicators gridRef={gridRef}>
         <DataGridContainer ref={gridRef}>
           <DataGrid
             data={headerRow.concat(dataRows)}
@@ -403,7 +403,7 @@ export default function SortableGrid({
             }}
           />
         </DataGridContainer>
-      </ScrollIndicators>
+      </GridScrollIndicators>
     </div>
   );
 }

--- a/components/vertical-scroll-indicators.js
+++ b/components/vertical-scroll-indicators.js
@@ -1,0 +1,213 @@
+// node_modules
+import { ChevronUpIcon, ChevronDownIcon } from "@heroicons/react/20/solid";
+import PropTypes from "prop-types";
+import { Children, useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Number of milliseconds to wait before hiding the scroll indicators.
+ */
+const SCROLL_INDICATOR_TIMEOUT = 2000;
+
+/**
+ * Display either the top or bottom scroll indicators.
+ */
+function ScrollIndicator({ className = "", children }) {
+  // Add common Tailwind CSS classes to each child button.
+  const childrenWithStyles = Children.map(children, (child) => {
+    return child && typeof child === "object"
+      ? {
+          ...child,
+          props: {
+            ...child.props,
+            className:
+              "h-8 w-8 text-white rounded-full bg-brand opacity-70 hover:opacity-100 focus:opacity-100 focus:outline-none",
+          },
+        }
+      : child;
+  });
+
+  // Easier ways to horizontally center the scroll indicators exist than using a transform, but
+  // they prevent the user from clicking checkboxes to the left or right of either indicator.
+  return (
+    <div
+      className={`absolute left-1/2 -translate-x-1/2 transform ${className}`}
+    >
+      {childrenWithStyles}
+    </div>
+  );
+}
+
+ScrollIndicator.propTypes = {
+  // Tailwind CSS classes to add to the scroll indicator wrapper
+  className: PropTypes.string,
+};
+
+/**
+ * Display the top scroll indicator to show the user that more content exists above the current
+ * view.
+ */
+function ScrollIndicatorTop({ onClick, onHover }) {
+  return (
+    <ScrollIndicator className="top-2">
+      <button
+        onClick={onClick}
+        onMouseEnter={() => onHover(true)}
+        onMouseLeave={() => onHover(false)}
+        aria-label="Scroll column selector to the top"
+      >
+        <ChevronUpIcon />
+      </button>
+    </ScrollIndicator>
+  );
+}
+
+ScrollIndicatorTop.propTypes = {
+  // Called when the user clicks the up scroll indicator
+  onClick: PropTypes.func.isRequired,
+  // Called when the user hovers over the scroll indicator, or stops hovering
+  onHover: PropTypes.func.isRequired,
+};
+
+/**
+ * Display the bottom scroll indicator to show the user that more content exists below the current
+ * view.
+ */
+function ScrollIndicatorBottom({ onClick, onHover }) {
+  return (
+    <ScrollIndicator className="bottom-2">
+      <button
+        onClick={onClick}
+        onMouseEnter={() => onHover(true)}
+        onMouseLeave={() => onHover(false)}
+        aria-label="Scroll column selector to the bottom"
+      >
+        <ChevronDownIcon />
+      </button>
+    </ScrollIndicator>
+  );
+}
+
+ScrollIndicatorBottom.propTypes = {
+  // Called when the user clicks the bottom scroll indicator
+  onClick: PropTypes.func.isRequired,
+  // Called when the user hovers over the bottom scroll indicator, or stops hovering
+  onHover: PropTypes.func.isRequired,
+};
+
+/**
+ * Code to use to scroll to the top of the page.
+ */
+const SCROLL_DIRECTION_TOP = "SCROLL_TO_TOP";
+
+/**
+ * Code to scroll to the bottom of the page.
+ */
+const SCROLL_DIRECTION_BOTTOM = "SCROLL_TO_BOTTOM";
+
+/**
+ * Display the scroll indicators to show the user that there is more content above or below the
+ * current view.
+ */
+export default function VerticalScrollIndicators({ scrollAreaRef }) {
+  // True if content exists above the scrollable checkbox area
+  const [isScrollableUp, setIsScrollableUp] = useState(false);
+  // True if content exists below the scrollable checkbox area
+  const [isScrollableDown, setIsScrollableDown] = useState(false);
+
+  const scrollTimer = useRef(null);
+  const isHoveringOverScrollIndicators = useRef(false);
+
+  // Use a ref to store the parent scroll area ref to avoid a stale closure when adding or
+  // removing event listeners.
+  const localScrollAreaRef = useRef(scrollAreaRef.current);
+
+  // Scroll the checkbox area to the top or bottom when the user clicks the scroll indicators.
+  function scrollIndicatorClick(scrollDirection) {
+    let topCoordinate;
+    if (scrollDirection === SCROLL_DIRECTION_TOP) {
+      topCoordinate = 0;
+    } else {
+      topCoordinate = scrollAreaRef.current.scrollHeight;
+    }
+    scrollAreaRef.current.scrollTo({ top: topCoordinate, behavior: "smooth" });
+    isHoveringOverScrollIndicators.current = false;
+  }
+
+  // Update the visibility of the scroll indicators based on the current scroll position. Manage
+  // the timer to hide the scroll indicators when the user hasn't scrolled for a while. Cache this
+  // function because we need the same function instance to add and remove as an event listener.
+  const onUpdateScroll = useCallback(() => {
+    // Clear the scroll timer when the user scrolls.
+    if (scrollTimer.current) {
+      clearTimeout(scrollTimer.current);
+      scrollTimer.current = null;
+    }
+
+    // Don't restart the timer while the user hovers over the scroll indicators.
+    if (!isHoveringOverScrollIndicators.current) {
+      scrollTimer.current = setTimeout(() => {
+        // The timer has expired with no scrolling, so hide the scroll indicators.
+        scrollTimer.current = null;
+        setIsScrollableUp(false);
+        setIsScrollableDown(false);
+      }, SCROLL_INDICATOR_TIMEOUT);
+    }
+
+    // Determine which scroll indicators to display based on the current scroll position.
+    setIsScrollableUp(scrollAreaRef.current.scrollTop > 0);
+    setIsScrollableDown(
+      scrollAreaRef.current.scrollTop + scrollAreaRef.current.clientHeight <
+        scrollAreaRef.current.scrollHeight
+    );
+  }, []);
+
+  // Update the scroll indicators when the user hovers over either one, or stops hovering over them.
+  function onHoverOverScrollIndicators(isHovering) {
+    isHoveringOverScrollIndicators.current = isHovering;
+    onUpdateScroll();
+  }
+
+  // Update the local scroll area ref when the parent scroll area ref changes so that closures get
+  // the current parent DOM ref.
+  useEffect(() => {
+    localScrollAreaRef.current = scrollAreaRef.current;
+  }, [scrollAreaRef]);
+
+  // Add scroll and resize event handlers to know whether to display the scroll indicators.
+  useEffect(() => {
+    // Install the scroll event listener and element resize observer.
+    localScrollAreaRef.current.addEventListener("scroll", onUpdateScroll);
+    const resizeObserver = new ResizeObserver(() => {
+      onUpdateScroll();
+    });
+    resizeObserver.observe(localScrollAreaRef.current);
+
+    // Clean up the event listeners when the component is unmounted.
+    return () => {
+      localScrollAreaRef.current.removeEventListener("scroll", onUpdateScroll);
+      resizeObserver.disconnect();
+    };
+  }, [localScrollAreaRef]);
+
+  return (
+    <>
+      {isScrollableUp && (
+        <ScrollIndicatorTop
+          onClick={() => scrollIndicatorClick(SCROLL_DIRECTION_TOP)}
+          onHover={onHoverOverScrollIndicators}
+        />
+      )}
+      {isScrollableDown && (
+        <ScrollIndicatorBottom
+          onClick={() => scrollIndicatorClick(SCROLL_DIRECTION_BOTTOM)}
+          onHover={onHoverOverScrollIndicators}
+        />
+      )}
+    </>
+  );
+}
+
+VerticalScrollIndicators.propTypes = {
+  // DOM reference to the scrollable area that these indicators appear in and control
+  scrollAreaRef: PropTypes.object.isRequired,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "@floating-ui/react": "^0.26.4",
         "@headlessui/react": "^2.0.1",
         "@heroicons/react": "^2.0.10",
-        "@nivo/bar": "^0.84.0",
-        "@nivo/core": "^0.84.0",
-        "@nivo/line": "^0.84.0",
+        "@nivo/bar": "^0.87.0",
+        "@nivo/core": "^0.87.0",
+        "@nivo/line": "^0.87.0",
         "@tailwindcss/container-queries": "^0.1.1",
         "@testing-library/user-event": "^14.5.1",
         "@types/node": "^20.4.2",
@@ -60,7 +60,7 @@
         "jest-environment-jsdom": "^29.0.2",
         "postcss": "^8.4.14",
         "prettier": "^3.0.3",
-        "prettier-plugin-tailwindcss": "^0.5.4",
+        "prettier-plugin-tailwindcss": "^0.6.5",
         "pretty-format": "^29.5.0",
         "tailwindcss": "^3.1.8"
       }
@@ -890,9 +890,9 @@
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.26.16",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.16.tgz",
-      "integrity": "sha512-HEf43zxZNAI/E781QIVpYSF3K2VH4TTYZpqecjdsFkjsaU1EbaWcM++kw0HXFffj7gDUcBFevX8s0rQGQpxkow==",
+      "version": "0.26.17",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.17.tgz",
+      "integrity": "sha512-ESD+jYWwqwVzaIgIhExrArdsCL1rOAzryG/Sjlu8yaD3Mtqi3uVyhbE2V7jD58Mo52qbzKz2eUY/Xgh5I86FCQ==",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.0",
         "@floating-ui/utils": "^0.2.0",
@@ -939,9 +939,9 @@
       }
     },
     "node_modules/@heroicons/react": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.1.3.tgz",
-      "integrity": "sha512-fEcPfo4oN345SoqdlCDdSa4ivjaKbk0jTd+oubcgNxnNgAfzysfwWfQUr+51wigiWHQQRiZNd1Ao0M5Y3M2EGg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.1.4.tgz",
+      "integrity": "sha512-ju0wj0wwrUTMQ2Yceyrma7TKuI3BpSjp+qKqV81K9KGcUHdvTMdiwfRc2cwXBp3uXtKuDZkh0v03nWOQnJFv2Q==",
       "peerDependencies": {
         "react": ">= 16"
       }
@@ -1511,9 +1511,9 @@
       "integrity": "sha512-RmHanbV21saP/6OEPBJ7yJMuys68cIf8OBBWd7+uj40LdpmswVAwe1uzeuFyUsd6SfeITWT3XnQfn6wULeKwDQ=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.3.tgz",
-      "integrity": "sha512-L3oDricIIjgj1AVnRdRor21gI7mShlSwU/1ZGHmqM3LzHhXXhdkrfeNY5zif25Bi5Dd7fiJHsbhoZCHfXYvlAw==",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.4.tgz",
+      "integrity": "sha512-svSFxW9f3xDaZA3idQmlFw7SusOuWTpDTAeBlO3AEPDltrraV+lqs7mAc6A27YdnpQVVIA3sODqUAAHdWhVWsA==",
       "dev": true,
       "dependencies": {
         "glob": "10.3.10"
@@ -1655,76 +1655,80 @@
       }
     },
     "node_modules/@nivo/annotations": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.84.0.tgz",
-      "integrity": "sha512-g3n+WaZgRza7fZVQZrrxq1cLS+6vmjhWGmQqEynFmKM2f11F7gdkHLhGMYosayjZ0Sb/bMUXvBSkUbyKli7NVw==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.87.0.tgz",
+      "integrity": "sha512-4Xk/soEmi706iOKszjX1EcGLBNIvhMifCYXOuLIFlMAXqhw1x2YS7PxickVSskdSzJCwJX4NgQ/R/9u6nxc5OA==",
       "dependencies": {
-        "@nivo/colors": "0.84.0",
-        "@nivo/core": "0.84.0",
+        "@nivo/colors": "0.87.0",
+        "@nivo/core": "0.87.0",
         "@react-spring/web": "9.4.5 || ^9.7.2",
-        "@types/prop-types": "^15.7.2",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
-    "node_modules/@nivo/axes": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.84.0.tgz",
-      "integrity": "sha512-bC9Rx5ixGJiupTRXSnATIVRLPcx0HR8yXGBuO8GTy6K1DDnhaNWfhErnBLYbB9Sq13WQGrS2he6uvLVLd23CtA==",
-      "dependencies": {
-        "@nivo/core": "0.84.0",
-        "@nivo/scales": "0.84.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2",
-        "@types/d3-format": "^1.4.1",
-        "@types/d3-time-format": "^2.3.1",
-        "@types/prop-types": "^15.7.2",
-        "d3-format": "^1.4.4",
-        "d3-time-format": "^3.0.0",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
-    "node_modules/@nivo/bar": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@nivo/bar/-/bar-0.84.0.tgz",
-      "integrity": "sha512-sOiC980VKS+SOnVSGPlG/nd2ssmz4b6iqIZY/POvwSkB8gvUFz6Bk6lBGXlVNxh1xHaYplVhyl1Tp2NpIWPcAA==",
-      "dependencies": {
-        "@nivo/annotations": "0.84.0",
-        "@nivo/axes": "0.84.0",
-        "@nivo/colors": "0.84.0",
-        "@nivo/core": "0.84.0",
-        "@nivo/legends": "0.84.0",
-        "@nivo/scales": "0.84.0",
-        "@nivo/tooltip": "0.84.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2",
-        "@types/d3-scale": "^3.2.3",
-        "@types/d3-shape": "^2.0.0",
-        "d3-scale": "^3.2.3",
-        "d3-shape": "^1.3.5",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
-    "node_modules/@nivo/colors": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.84.0.tgz",
-      "integrity": "sha512-wNG1uYyDP5Owc1Pdkz0zesdZCrPAywmSssNzQ2Aju7nVs7Ru7iHNBIvOAGgyXTe2gcrIO9VSasXWR+jEYyxN2Q==",
+    "node_modules/@nivo/axes": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.87.0.tgz",
+      "integrity": "sha512-zCRBfiRKJi+xOxwxH5Pxq/8+yv3fAYDl4a1F2Ssnp5gMIobwzVsdearvsm5B04e9bfy3ZXTL7KgbkEkSAwu6SA==",
       "dependencies": {
-        "@nivo/core": "0.84.0",
-        "@types/d3-color": "^2.0.0",
-        "@types/d3-scale": "^3.2.3",
-        "@types/d3-scale-chromatic": "^2.0.0",
+        "@nivo/core": "0.87.0",
+        "@nivo/scales": "0.87.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-format": "^1.4.1",
+        "@types/d3-time-format": "^2.3.1",
+        "d3-format": "^1.4.4",
+        "d3-time-format": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/bar": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/bar/-/bar-0.87.0.tgz",
+      "integrity": "sha512-r/MEVCNAHKfmsy1Fb+JztVczOhIEtAx4VFs2XUbn9YpEDgxydavUJyfoy5/nGq6h5jG1/t47cfB4nZle7c0fyQ==",
+      "dependencies": {
+        "@nivo/annotations": "0.87.0",
+        "@nivo/axes": "0.87.0",
+        "@nivo/colors": "0.87.0",
+        "@nivo/core": "0.87.0",
+        "@nivo/legends": "0.87.0",
+        "@nivo/scales": "0.87.0",
+        "@nivo/tooltip": "0.87.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-shape": "^3.1.6",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/bar/node_modules/@types/d3-shape": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@nivo/colors": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.87.0.tgz",
+      "integrity": "sha512-S4pZzRGKK23t8XAjQMhML6wwsfKO9nH03xuyN4SvCodNA/Dmdys9xV+9Dg/VILTzvzsBTBGTX0dFBg65WoKfVg==",
+      "dependencies": {
+        "@nivo/core": "0.87.0",
+        "@types/d3-color": "^3.0.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-scale-chromatic": "^3.0.0",
         "@types/prop-types": "^15.7.2",
         "d3-color": "^3.1.0",
-        "d3-scale": "^3.2.3",
-        "d3-scale-chromatic": "^2.0.0",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2"
       },
@@ -1733,104 +1737,82 @@
       }
     },
     "node_modules/@nivo/core": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.84.0.tgz",
-      "integrity": "sha512-HyQM4x4B7d4X9+xLPKkPxqIxhSDzbJUywGTDWHWx1daeX9VP8O+MqkTBsNsoB+tjxrbKrRJ0+ceS2w89JB+qrA==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.87.0.tgz",
+      "integrity": "sha512-yEQWJn7QjWnbmCZccBCo4dligNyNyz3kgyV9vEtcaB1iGeKhg55RJEAlCOul+IDgSCSPFci2SxTmipE6LZEZCg==",
       "dependencies": {
-        "@nivo/recompose": "0.84.0",
-        "@nivo/tooltip": "0.84.0",
+        "@nivo/tooltip": "0.87.0",
         "@react-spring/web": "9.4.5 || ^9.7.2",
-        "@types/d3-shape": "^2.0.0",
+        "@types/d3-shape": "^3.1.6",
         "d3-color": "^3.1.0",
         "d3-format": "^1.4.4",
         "d3-interpolate": "^3.0.1",
-        "d3-scale": "^3.2.3",
+        "d3-scale": "^4.0.2",
         "d3-scale-chromatic": "^3.0.0",
-        "d3-shape": "^1.3.5",
+        "d3-shape": "^3.2.0",
         "d3-time-format": "^3.0.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/nivo/donate"
       },
       "peerDependencies": {
-        "prop-types": ">= 15.5.10 < 16.0.0",
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
-    "node_modules/@nivo/core/node_modules/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+    "node_modules/@nivo/core/node_modules/@types/d3-shape": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
       "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-interpolate": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
+        "@types/d3-path": "*"
       }
     },
     "node_modules/@nivo/legends": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.84.0.tgz",
-      "integrity": "sha512-o0s1cXoIH6Km9A2zoKB8Ey99Oc1w5nymz0j8s7hR2B0EHo5HgVbYjSs2sZD7NSwLt3QM57Nzxw9VzJ+sqfV30Q==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.87.0.tgz",
+      "integrity": "sha512-bVJCeqEmK4qHrxNaPU/+hXUd/yaKlcQ0yrsR18ewoknVX+pgvbe/+tRKJ+835JXlvRijYIuqwK1sUJQIxyB7oA==",
       "dependencies": {
-        "@nivo/colors": "0.84.0",
-        "@nivo/core": "0.84.0",
-        "@types/d3-scale": "^3.2.3",
-        "@types/prop-types": "^15.7.2",
-        "d3-scale": "^3.2.3",
-        "prop-types": "^15.7.2"
+        "@nivo/colors": "0.87.0",
+        "@nivo/core": "0.87.0",
+        "@types/d3-scale": "^4.0.8",
+        "d3-scale": "^4.0.2"
       },
       "peerDependencies": {
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
     "node_modules/@nivo/line": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@nivo/line/-/line-0.84.0.tgz",
-      "integrity": "sha512-QE0JwZ7oIwMnsDQeSr1Q6iyqD2UBVLtBMdfMsJLhnlI3V62VkY98/L3o8M7+7Wy/V2UiEMJ+14C2qhXd+XLgsA==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/line/-/line-0.87.0.tgz",
+      "integrity": "sha512-Ki/WDd8ZU8VWScW4ZeKUFCXRdAEg8nrS+F+jdfJDPxyxUMHZJCAbrXrnsExcEQLOaDQ2aU/bijEMiDS8/dJzuA==",
       "dependencies": {
-        "@nivo/annotations": "0.84.0",
-        "@nivo/axes": "0.84.0",
-        "@nivo/colors": "0.84.0",
-        "@nivo/core": "0.84.0",
-        "@nivo/legends": "0.84.0",
-        "@nivo/scales": "0.84.0",
-        "@nivo/tooltip": "0.84.0",
-        "@nivo/voronoi": "0.84.0",
+        "@nivo/annotations": "0.87.0",
+        "@nivo/axes": "0.87.0",
+        "@nivo/colors": "0.87.0",
+        "@nivo/core": "0.87.0",
+        "@nivo/legends": "0.87.0",
+        "@nivo/scales": "0.87.0",
+        "@nivo/tooltip": "0.87.0",
+        "@nivo/voronoi": "0.87.0",
         "@react-spring/web": "9.4.5 || ^9.7.2",
-        "d3-shape": "^1.3.5",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
-    "node_modules/@nivo/recompose": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@nivo/recompose/-/recompose-0.84.0.tgz",
-      "integrity": "sha512-Odb+r0pEmGt4RV020jwvngF7PxBgxS1e1sy8bWlZKc5qkm6k3eVlZNuYU+zGbDxHMigImvrx5KfUv5iUqtQBZA==",
-      "dependencies": {
-        "@types/prop-types": "^15.7.2",
-        "@types/react-lifecycles-compat": "^3.0.1",
-        "prop-types": "^15.7.2",
-        "react-lifecycles-compat": "^3.0.4"
+        "d3-shape": "^3.2.0"
       },
       "peerDependencies": {
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
     "node_modules/@nivo/scales": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.84.0.tgz",
-      "integrity": "sha512-Cayo9jFMpoF7Ha7eqOAucHLUG6zZLGpxiAtyZ/vTUCkRZPHmd/YMvrm8E6OyQCTBVf+aRtOKk9tQnMv8E9fWiw==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.87.0.tgz",
+      "integrity": "sha512-IHdY9w2em/xpWurcbhUR3cUA1dgbY06rU8gmA/skFCwf3C4Da3Rqwr0XqvxmkDC+EdT/iFljMbLst7VYiCnSdw==",
       "dependencies": {
-        "@types/d3-scale": "^3.2.3",
+        "@types/d3-scale": "^4.0.8",
         "@types/d3-time": "^1.1.1",
         "@types/d3-time-format": "^3.0.0",
-        "d3-scale": "^3.2.3",
+        "d3-scale": "^4.0.2",
         "d3-time": "^1.0.11",
         "d3-time-format": "^3.0.0",
         "lodash": "^4.17.21"
@@ -1842,24 +1824,28 @@
       "integrity": "sha512-or9DiDnYI1h38J9hxKEsw513+KVuFbEVhl7qdxcaudoiqWWepapUen+2vAriFGexr6W5+P4l9+HJrB39GG+oRg=="
     },
     "node_modules/@nivo/tooltip": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.84.0.tgz",
-      "integrity": "sha512-x/6Vk4RXKHkG9q5dk4uFYwEfbMoIvJd5ahhVQ6bskuLks5FZoS6bkKoNggjxwmHbIWOVITGUXuykOfC54EWSpw==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.87.0.tgz",
+      "integrity": "sha512-nZJWyRIt/45V/JBdJ9ksmNm1LFfj59G1Dy9wB63Icf2YwyBT+J+zCzOGXaY7gxCxgF1mnSL3dC7fttcEdXyN/g==",
       "dependencies": {
-        "@nivo/core": "0.84.0",
+        "@nivo/core": "0.87.0",
         "@react-spring/web": "9.4.5 || ^9.7.2"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
       }
     },
     "node_modules/@nivo/voronoi": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@nivo/voronoi/-/voronoi-0.84.0.tgz",
-      "integrity": "sha512-CJTb0sQWYNbfjjrCEK3W0jt1v+hqAd4fDUNJxB3SNRHEEQtF+MCr2EG3p/CWyxIb3avjF4N53/03tQpnuDwBvQ==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/voronoi/-/voronoi-0.87.0.tgz",
+      "integrity": "sha512-Tg+9YnCX8LKsEwZMY1Q83mWiVFiyU2smxrO3JaC9vzjIh/2A/bkNPwC6BdmRaQMvY1jngKs+WKDnNxSQWFSOEg==",
       "dependencies": {
-        "@nivo/core": "0.84.0",
-        "@types/d3-delaunay": "^5.3.0",
-        "@types/d3-scale": "^3.2.3",
-        "d3-delaunay": "^5.3.0",
-        "d3-scale": "^3.2.3"
+        "@nivo/core": "0.87.0",
+        "@nivo/tooltip": "0.87.0",
+        "@types/d3-delaunay": "^6.0.4",
+        "@types/d3-scale": "^4.0.8",
+        "d3-delaunay": "^6.0.4",
+        "d3-scale": "^4.0.2"
       },
       "peerDependencies": {
         "react": ">= 16.14.0 < 19.0.0"
@@ -2350,14 +2336,14 @@
       }
     },
     "node_modules/@types/d3-color": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.6.tgz",
-      "integrity": "sha512-tbaFGDmJWHqnenvk3QGSvD3RVwr631BjKRD7Sc7VLRgrdX5mk5hTyoeBL6rXZaeoXzmZwIl1D2HPogEdt1rHBg=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
     },
     "node_modules/@types/d3-delaunay": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-5.3.4.tgz",
-      "integrity": "sha512-GEQuDXVKQvHulQ+ecKyCubOmVjXrifAj7VR26rWVAER/IbWemaT/Tmo84ESiTtoDghg5ILdMZH7pYXQEt/Vu9A=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="
     },
     "node_modules/@types/d3-format": {
       "version": "1.4.5",
@@ -2370,30 +2356,17 @@
       "integrity": "sha512-jjZVLBjEX4q6xneKMmv62UocaFJFOTQSb/1aTzs3m3ICTOFoVaqGBHpNLm/4dVi0/FTltfBKgmOK1ECj3/gGjA=="
     },
     "node_modules/@types/d3-scale": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.5.tgz",
-      "integrity": "sha512-YOpKj0kIEusRf7ofeJcSZQsvKbnTwpe1DUF+P2qsotqG53kEsjm7EzzliqQxMkAWdkZcHrg5rRhB4JiDOQPX+A==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
       "dependencies": {
-        "@types/d3-time": "^2"
+        "@types/d3-time": "*"
       }
     },
     "node_modules/@types/d3-scale-chromatic": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-2.0.4.tgz",
-      "integrity": "sha512-OUgfg6wmoZVhs0/pV8HZhsMw7pYJnS6smfNK2S5ogMaPHfDUaTMu7JA5ssZrRupwf2vWI+haPAuUpsz+M1BOKA=="
-    },
-    "node_modules/@types/d3-scale/node_modules/@types/d3-time": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.4.tgz",
-      "integrity": "sha512-BTfLsxTeo7yFxI/haOOf1ZwJ6xKgQLT9dCp+EcmQv87Gox6X+oKl4mLKfO6fnWm3P22+A6DknMNEZany8ql2Rw=="
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.7.tgz",
-      "integrity": "sha512-HedHlfGHdwzKqX9+PiQVXZrdmGlwo7naoefJP7kCNk4Y7qcpQt1tUaoRa6qn0kbTdlaIHGO7111qLtb/6J8uuw==",
-      "dependencies": {
-        "@types/d3-path": "^2"
-      }
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.3.tgz",
+      "integrity": "sha512-laXM4+1o5ImZv3RpFAsTRn3TEkzqkytiOY0Dz0sq5cnd1dtNlk6sHLon4OvqaiJb28T0S/TdsBI3Sjsy+keJrw=="
     },
     "node_modules/@types/d3-time": {
       "version": "1.1.4",
@@ -2494,9 +2467,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
-      "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+      "version": "20.14.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.5.tgz",
+      "integrity": "sha512-aoRR+fJkZT2l0aGOJhuA8frnCSoNX6W7U2mpNq63+BxBIj5BQFt8rHy627kijCmm63ijdSdwvGgpUsU6MBsZZA==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2519,14 +2492,6 @@
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-1CM48Y9ztL5S4wjt7DK2izrkgPp/Ql0zCJu/vHzhgl7J+BD4UbSGjHN1M2TlePms472JvOazUtAO1/G3oFZqIQ==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -2597,15 +2562,15 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.0.tgz",
-      "integrity": "sha512-FX1X6AF0w8MdVFLSdqwqN/me2hyhuQg4ykN6ZpVhh1ij/80pTvDKclX1sZB9iqex8SjQfVhwMKs3JtnnMLzG9w==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.1.tgz",
+      "integrity": "sha512-kZqi+WZQaZfPKnsflLJQCz6Ze9FFSMfXrrIOcyargekQxG37ES7DJNpJUE9Q/X5n3yTIP/WPutVNzgknQ7biLg==",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.13.0",
-        "@typescript-eslint/type-utils": "7.13.0",
-        "@typescript-eslint/utils": "7.13.0",
-        "@typescript-eslint/visitor-keys": "7.13.0",
+        "@typescript-eslint/scope-manager": "7.13.1",
+        "@typescript-eslint/type-utils": "7.13.1",
+        "@typescript-eslint/utils": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -2629,14 +2594,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.0.tgz",
-      "integrity": "sha512-EjMfl69KOS9awXXe83iRN7oIEXy9yYdqWfqdrFAYAAr6syP8eLEFI7ZE4939antx2mNgPRW/o1ybm2SFYkbTVA==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.1.tgz",
+      "integrity": "sha512-1ELDPlnLvDQ5ybTSrMhRTFDfOQEOXNM+eP+3HT/Yq7ruWpciQw+Avi73pdEbA4SooCawEWo3dtYbF68gN7Ed1A==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.13.0",
-        "@typescript-eslint/types": "7.13.0",
-        "@typescript-eslint/typescript-estree": "7.13.0",
-        "@typescript-eslint/visitor-keys": "7.13.0",
+        "@typescript-eslint/scope-manager": "7.13.1",
+        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/typescript-estree": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2656,12 +2621,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.0.tgz",
-      "integrity": "sha512-ZrMCe1R6a01T94ilV13egvcnvVJ1pxShkE0+NDjDzH4nvG1wXpwsVI5bZCvE7AEDH1mXEx5tJSVR68bLgG7Dng==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.1.tgz",
+      "integrity": "sha512-adbXNVEs6GmbzaCpymHQ0MB6E4TqoiVbC0iqG3uijR8ZYfpAXMGttouQzF4Oat3P2GxDVIrg7bMI/P65LiQZdg==",
       "dependencies": {
-        "@typescript-eslint/types": "7.13.0",
-        "@typescript-eslint/visitor-keys": "7.13.0"
+        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -2672,12 +2637,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.0.tgz",
-      "integrity": "sha512-xMEtMzxq9eRkZy48XuxlBFzpVMDurUAfDu5Rz16GouAtXm0TaAoTFzqWUFPPuQYXI/CDaH/Bgx/fk/84t/Bc9A==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.1.tgz",
+      "integrity": "sha512-aWDbLu1s9bmgPGXSzNCxELu+0+HQOapV/y+60gPXafR8e2g1Bifxzevaa+4L2ytCWm+CHqpELq4CSoN9ELiwCg==",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.13.0",
-        "@typescript-eslint/utils": "7.13.0",
+        "@typescript-eslint/typescript-estree": "7.13.1",
+        "@typescript-eslint/utils": "7.13.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -2698,9 +2663,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.0.tgz",
-      "integrity": "sha512-QWuwm9wcGMAuTsxP+qz6LBBd3Uq8I5Nv8xb0mk54jmNoCyDspnMvVsOxI6IsMmway5d1S9Su2+sCKv1st2l6eA==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.1.tgz",
+      "integrity": "sha512-7K7HMcSQIAND6RBL4kDl24sG/xKM13cA85dc7JnmQXw2cBDngg7c19B++JzvJHRG3zG36n9j1i451GBzRuHchw==",
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
       },
@@ -2710,12 +2675,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.0.tgz",
-      "integrity": "sha512-cAvBvUoobaoIcoqox1YatXOnSl3gx92rCZoMRPzMNisDiM12siGilSM4+dJAekuuHTibI2hVC2fYK79iSFvWjw==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.1.tgz",
+      "integrity": "sha512-uxNr51CMV7npU1BxZzYjoVz9iyjckBduFBP0S5sLlh1tXYzHzgZ3BR9SVsNed+LmwKrmnqN3Kdl5t7eZ5TS1Yw==",
       "dependencies": {
-        "@typescript-eslint/types": "7.13.0",
-        "@typescript-eslint/visitor-keys": "7.13.0",
+        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2737,14 +2702,14 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.0.tgz",
-      "integrity": "sha512-jceD8RgdKORVnB4Y6BqasfIkFhl4pajB1wVxrF4akxD2QPM8GNYjgGwEzYS+437ewlqqrg7Dw+6dhdpjMpeBFQ==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.1.tgz",
+      "integrity": "sha512-h5MzFBD5a/Gh/fvNdp9pTfqJAbuQC4sCN2WzuXme71lqFJsZtLbjxfSk4r3p02WIArOF9N94pdsLiGutpDbrXQ==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.13.0",
-        "@typescript-eslint/types": "7.13.0",
-        "@typescript-eslint/typescript-estree": "7.13.0"
+        "@typescript-eslint/scope-manager": "7.13.1",
+        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/typescript-estree": "7.13.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -2758,11 +2723,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.0.tgz",
-      "integrity": "sha512-nxn+dozQx+MK61nn/JP+M4eCkHDSxSLDpgE3WcQo0+fkjEolnaB5jswvIKC4K56By8MMgIho7f1PVxERHEo8rw==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.1.tgz",
+      "integrity": "sha512-k/Bfne7lrP7hcb7m9zSsgcBmo+8eicqqfNAJ7uUY+jkTFpKeH2FSkWpFRtimBxgkyvqfu9jTPRbYOvud6isdXA==",
       "dependencies": {
-        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/types": "7.13.1",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -2791,9 +2756,9 @@
       "integrity": "sha512-bwDKqjqNccC/MSujqnYTeAS5dIR8UmGLP0R90mvsJY0FRC8NUWBSTfj34+EIzo2NWc/gV8IZTqv4fXaiZJpCtA=="
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
+      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2820,10 +2785,13 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
+      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
       "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3659,9 +3627,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001632",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001632.tgz",
-      "integrity": "sha512-udx3o7yHJfUxMLkGohMlVHCvFvWmirKh9JAH/d7WOLPetlH+LTL5cocMZ0t7oZx/mdlOWXti97xLZWc8uURRHg==",
+      "version": "1.0.30001636",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz",
+      "integrity": "sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4214,9 +4182,9 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/cypress": {
-      "version": "13.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.11.0.tgz",
-      "integrity": "sha512-NXXogbAxVlVje4XHX+Cx5eMFZv4Dho/2rIcdBHg9CNPFUGZdM4cRdgIgM7USmNYsC12XY0bZENEQ+KBk72fl+A==",
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.12.0.tgz",
+      "integrity": "sha512-udzS2JilmI9ApO/UuqurEwOvThclin5ntz7K0BtnHBs+tg2Bl9QShLISXpSEMDv/u8b6mqdoAdyKeZiSqKWL8g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4302,11 +4270,14 @@
       }
     },
     "node_modules/d3-delaunay": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
-      "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
       "dependencies": {
-        "delaunator": "4"
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-ease": {
@@ -4331,71 +4302,60 @@
       }
     },
     "node_modules/d3-path": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-scale": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
-      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
       "dependencies": {
-        "d3-array": "^2.3.0",
-        "d3-format": "1 - 2",
-        "d3-interpolate": "1.2.0 - 2",
-        "d3-time": "^2.1.1",
-        "d3-time-format": "2 - 3"
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-scale-chromatic": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
-      "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
       "dependencies": {
-        "d3-color": "1 - 2",
-        "d3-interpolate": "1 - 2"
-      }
-    },
-    "node_modules/d3-scale-chromatic/node_modules/d3-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
-    },
-    "node_modules/d3-scale-chromatic/node_modules/d3-interpolate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
-      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
-      "dependencies": {
-        "d3-color": "1 - 2"
-      }
-    },
-    "node_modules/d3-scale/node_modules/d3-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
-    },
-    "node_modules/d3-scale/node_modules/d3-interpolate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
-      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
-      "dependencies": {
-        "d3-color": "1 - 2"
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-scale/node_modules/d3-time": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
-      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "dependencies": {
-        "d3-array": "2"
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
       "dependencies": {
-        "d3-path": "1"
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-time": {
@@ -4599,9 +4559,12 @@
       }
     },
     "node_modules/delaunator": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
-      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -4730,9 +4693,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.798",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.798.tgz",
-      "integrity": "sha512-by9J2CiM9KPGj9qfp5U4FcPSbXJG7FNzqnYaY4WLzX+v2PHieVGmnsA4dxfpGE3QEC7JofpPZmn7Vn1B9NR2+Q==",
+      "version": "1.4.806",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.806.tgz",
+      "integrity": "sha512-nkoEX2QIB8kwCOtvtgwhXWy2IHVcOLQZu9Qo36uaGB835mdX/h8uLRlosL6QIhLVUnAiicXRW00PwaPZC74Nrg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5075,12 +5038,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.3.tgz",
-      "integrity": "sha512-ZkNztm3Q7hjqvB1rRlOX8P9E/cXRL9ajRcs8jufEtwMfTVYRqnmtnaSu57QqHyBlovMuiB8LEzfLBkh5RYV6Fg==",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.4.tgz",
+      "integrity": "sha512-Qr0wMgG9m6m4uYy2jrYJmyuNlYZzPRQq5Kvb9IDlYwn+7yq6W6sfMNFgb+9guM1KYwuIo6TIaiFhZJ6SnQ/Efw==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "14.2.3",
+        "@next/eslint-plugin-next": "14.2.4",
         "@rushstack/eslint-patch": "^1.3.3",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || 7.0.0 - 7.2.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -5449,16 +5412,16 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.34.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.34.2.tgz",
-      "integrity": "sha512-2HCmrU+/JNigDN6tg55cRDKCQWicYAPB38JGSFDQt95jDm8rrvSUo7YPkOIm5l6ts1j1zCvysNcasvfTMQzUOw==",
+      "version": "7.34.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.34.3.tgz",
+      "integrity": "sha512-aoW4MV891jkUulwDApQbPYTVZmeuSyFrudpbTAQuj5Fv8VL+o6df2xIGpw8B0hPjAaih1/Fb0om9grCdyFYemA==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
         "array.prototype.flatmap": "^1.3.2",
         "array.prototype.toreversed": "^1.1.2",
-        "array.prototype.tosorted": "^1.1.3",
+        "array.prototype.tosorted": "^1.1.4",
         "doctrine": "^2.1.0",
         "es-iterator-helpers": "^1.0.19",
         "estraverse": "^5.3.0",
@@ -6118,9 +6081,9 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -9877,9 +9840,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.14.tgz",
-      "integrity": "sha512-Puaz+wPUAhFp8Lo9HuciYKM2Y2XExESjeT+9NQoVFXZsPPnc9VYss2SpxdQ6vbatmt8/4+SN0oe0I1cPDABg9Q==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.5.tgz",
+      "integrity": "sha512-axfeOArc/RiGHjOIy9HytehlC0ZLeMaqY09mm8YCkMzznKiDkwFzOpBvtuhuv3xG5qB73+Mj7OCe2j/L1ryfuQ==",
       "dev": true,
       "engines": {
         "node": ">=14.21.3"
@@ -10173,11 +10136,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
-    },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-svg-pan-zoom": {
       "version": "3.12.1",
@@ -10554,9 +10512,9 @@
       }
     },
     "node_modules/rfdc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
-      "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true
     },
     "node_modules/rimraf": {
@@ -10613,6 +10571,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
@@ -12185,9 +12148,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "@floating-ui/react": "^0.26.4",
     "@headlessui/react": "^2.0.1",
     "@heroicons/react": "^2.0.10",
-    "@nivo/bar": "^0.84.0",
-    "@nivo/core": "^0.84.0",
-    "@nivo/line": "^0.84.0",
+    "@nivo/bar": "^0.87.0",
+    "@nivo/core": "^0.87.0",
+    "@nivo/line": "^0.87.0",
     "@tailwindcss/container-queries": "^0.1.1",
     "@testing-library/user-event": "^14.5.1",
     "@types/node": "^20.4.2",
@@ -65,7 +65,7 @@
     "jest-environment-jsdom": "^29.0.2",
     "postcss": "^8.4.14",
     "prettier": "^3.0.3",
-    "prettier-plugin-tailwindcss": "^0.5.4",
+    "prettier-plugin-tailwindcss": "^0.6.5",
     "pretty-format": "^29.5.0",
     "tailwindcss": "^3.1.8"
   }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,16 @@ module.exports = {
       center: true,
     },
     extend: {
+      animation: {
+        "scroll-fade": "scrollFade 3s linear",
+      },
+      // that is actual animation
+      keyframes: () => ({
+        scrollFade: {
+          "0%": { opacity: 1 },
+          "100%": { opacity: 0 },
+        },
+      }),
       aspectRatio: {
         hd: "16 / 9",
         cinema: "21 / 9",
@@ -249,6 +259,9 @@ module.exports = {
       gridTemplateColumns: {
         "min-2": "repeat(2, minmax(0, min-content))",
         "data-item": "fit-content(200px) 1fr",
+      },
+      maxHeight: {
+        "column-select-modal": "calc(100vh - 300px)",
       },
       stroke: {
         "nav-collapse": "var(--color-nav-collapse)",


### PR DESCRIPTION
While this ticket ostensibly has to do with working around a Safari bug, I decided to take this chance to improve the UI so that very tall column-selection modals (like you’d get with `/multireport/?type=Item`) don’t become awkwardly tall. I have defined a maximum and minimum height for the modal that adjusts itself to the height of the browser window.

I renamed the existing scroll-indicator.js used on the report-view table to grid-scroll-indicators.js to distinguish it from the new vertical-scroll-indicator.js meant for any scrollable area to indicate that the area is in fact scrollable. I might update grid-scroll-indicators.js in the future to share more with scroll-indicator.js, but that will be for another day.
