### PR TITLE
IGVF-1771 Fix CSS string from prettier change

### DIFF
--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,6 +53,7 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
+            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -53,7 +53,6 @@ config: Dict[str, Any] = {
                 'desired_count': 1,
                 'max_capacity': 4,
             },
-            'backend_url': 'https://igvfd-dev.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/components/sortable-grid.js
+++ b/components/sortable-grid.js
@@ -96,7 +96,7 @@ function HeaderSortIcon({ columnConfiguration, sortBy, sortDirection }) {
 
   return (
     <SortIcon
-      className={`h-5 w-5${
+      className={`h-5 w-5 ${
         sortBy === columnConfiguration.id ? "" : "invisible"
       }`}
     />

--- a/cypress/e2e/schema-search.cy.js
+++ b/cypress/e2e/schema-search.cy.js
@@ -13,7 +13,7 @@ describe("Test schema name search", () => {
     cy.get("#schema-search").type("analysis");
 
     // We should see exactly two highlighted schema names.
-    cy.get(".bg-schema-name-highlight").should("have.length", 2);
+    cy.get(".bg-schema-name-highlight").should("have.length", 3);
 
     // Click the first highlighted element and make sure the resulting URL does not have a hash tag.
     cy.get(".bg-schema-name-highlight").first().click();


### PR DESCRIPTION
A new version of prettier strips leading and trailing spaces. In rare cases I relied on that not happening, so going forward I’ll still need to be careful about that.

A new schema also broke a Cypress test.