### PR TITLE
IGVF-1770 Update UI for CrisprModification and DegronModification objects

### DIFF
--- a/components/common-data-items.js
+++ b/components/common-data-items.js
@@ -430,7 +430,7 @@ BiosampleDataItems.propTypes = {
   // Object derived from the biosample.json schema
   item: PropTypes.object.isRequired,
   // Classifications if this biosample has at least one
-  classifications: PropTypes.string,
+  classifications: PropTypes.arrayOf(PropTypes.string),
   // Construct library sets for this biosample
   constructLibrarySets: PropTypes.arrayOf(PropTypes.object),
   // Disease ontology for the biosample

--- a/components/sample-table.js
+++ b/components/sample-table.js
@@ -94,6 +94,7 @@ const sampleColumns = [
 export default function SampleTable({
   samples,
   reportLink = null,
+  reportLabel = null,
   title = "Samples",
 }) {
   const { collectionTitles } = useContext(SessionContext);
@@ -102,11 +103,8 @@ export default function SampleTable({
     <>
       <DataAreaTitle>
         {title}
-        {reportLink && (
-          <DataAreaTitleLink
-            href={reportLink}
-            label="Report of multiplexed samples that have this item as their multiplexed sample"
-          >
+        {reportLink && reportLabel && (
+          <DataAreaTitleLink href={reportLink} label={reportLabel}>
             <TableCellsIcon className="h-4 w-4" />
           </DataAreaTitleLink>
         )}
@@ -127,6 +125,8 @@ SampleTable.propTypes = {
   samples: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Link to the report page containing the same samples as this table
   reportLink: PropTypes.string,
+  // Label for the report link
+  reportLabel: PropTypes.string,
   // Title of the table if not "Samples"
   title: PropTypes.string,
 };

--- a/components/search/list-renderer/crispr-modification.js
+++ b/components/search/list-renderer/crispr-modification.js
@@ -8,7 +8,7 @@ import {
 } from "./search-list-item";
 import { PropTypes } from "prop-types";
 
-export default function Modification({ item: modification }) {
+export default function CrisprModification({ item: modification }) {
   return (
     <SearchListItemContent>
       <SearchListItemMain>
@@ -19,12 +19,14 @@ export default function Modification({ item: modification }) {
         <SearchListItemTitle>{modification.summary}</SearchListItemTitle>
         <SearchListItemMeta>
           <span key="lab">{modification.lab.title}</span>
+          <span key="species">{modification.cas_species}</span>
+          <span key="cas">{modification.cas}</span>
         </SearchListItemMeta>
       </SearchListItemMain>
     </SearchListItemContent>
   );
 }
 
-Modification.propTypes = {
+CrisprModification.propTypes = {
   item: PropTypes.object.isRequired,
 };

--- a/components/search/list-renderer/degron-modification.js
+++ b/components/search/list-renderer/degron-modification.js
@@ -1,0 +1,31 @@
+import {
+  SearchListItemContent,
+  SearchListItemMain,
+  SearchListItemMeta,
+  SearchListItemTitle,
+  SearchListItemType,
+  SearchListItemUniqueId,
+} from "./search-list-item";
+import { PropTypes } from "prop-types";
+
+export default function DegronModification({ item: modification }) {
+  return (
+    <SearchListItemContent>
+      <SearchListItemMain>
+        <SearchListItemUniqueId>
+          <SearchListItemType item={modification} />
+          {modification.uuid}
+        </SearchListItemUniqueId>
+        <SearchListItemTitle>{modification.summary}</SearchListItemTitle>
+        <SearchListItemMeta>
+          <span key="lab">{modification.lab.title}</span>
+          <span key="system">{modification.degron_system}</span>
+        </SearchListItemMeta>
+      </SearchListItemMain>
+    </SearchListItemContent>
+  );
+}
+
+DegronModification.propTypes = {
+  item: PropTypes.object.isRequired,
+};

--- a/components/search/list-renderer/index.js
+++ b/components/search/list-renderer/index.js
@@ -54,6 +54,8 @@ import AuxiliarySet from "./auxiliary-set";
 import Biomarker from "./biomarker";
 import Biosample from "./biosample";
 import ConstructLibrarySet from "./construct-library-set";
+import CrisprModification from "./crispr-modification";
+import DegronModification from "./degron-modification";
 import CuratedSet from "./curated-set";
 import Document from "./document";
 import Gene from "./gene";
@@ -76,7 +78,6 @@ import Treatment from "./treatment";
 import User from "./user";
 import File from "./file";
 import Source from "./source";
-import Modification from "./modification";
 import Workflow from "./workflow";
 
 const renderers = {
@@ -89,6 +90,8 @@ const renderers = {
   Biomarker,
   ConfigurationFile: File,
   ConstructLibrarySet,
+  CrisprModification,
+  DegronModification,
   CuratedSet,
   Document,
   Gene,
@@ -99,7 +102,6 @@ const renderers = {
   MatrixFile: File,
   MeasurementSet,
   ModelSet,
-  Modification,
   MultiplexedSample,
   OpenReadingFrame,
   Page,

--- a/lib/common-requests.ts
+++ b/lib/common-requests.ts
@@ -289,6 +289,7 @@ export async function requestSamples(
       "accession",
       "construct_library_sets",
       "protocols",
+      "sample_terms",
       "status",
       "summary",
     ])

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -102,6 +102,7 @@ export default function AnalysisSet({
             <SampleTable
               samples={analysisSet.samples}
               reportLink={`/multireport/?type=Sample&file_sets.@id=${analysisSet["@id"]}`}
+              reportLabel="Report of samples in this analysis set"
             />
           )}
 

--- a/pages/auxiliary-sets/[id].js
+++ b/pages/auxiliary-sets/[id].js
@@ -82,6 +82,7 @@ export default function AuxiliarySet({
             <SampleTable
               samples={auxiliarySet.samples}
               reportLink={`/multireport/?type=Sample&file_sets.@id=${auxiliarySet["@id"]}`}
+              reportLabel="Report of samples in this auxiliary set"
             />
           )}
           {auxiliarySet.donors?.length > 0 && (

--- a/pages/construct-library-sets/[id].js
+++ b/pages/construct-library-sets/[id].js
@@ -329,6 +329,7 @@ export default function ConstructLibrarySet({
             <SampleTable
               samples={constructLibrarySet.applied_to_samples}
               reportLink={`/multireport/?type=Sample&construct_library_sets=${constructLibrarySet["@id"]}`}
+              reportLabel="Report of samples that link to this construct library set"
               title="Applied to Samples"
             />
           )}

--- a/pages/crispr-modifications/[uuid].js
+++ b/pages/crispr-modifications/[uuid].js
@@ -1,0 +1,203 @@
+// node_modules
+import Link from "next/link";
+import PropTypes from "prop-types";
+// components
+import AliasList from "../../components/alias-list";
+import Attribution from "../../components/attribution";
+import Breadcrumbs from "../../components/breadcrumbs";
+import {
+  DataArea,
+  DataItemLabel,
+  DataItemValue,
+  DataPanel,
+} from "../../components/data-area";
+import DocumentTable from "../../components/document-table";
+import { EditableItem } from "../../components/edit";
+import ProductInfo from "../../components/product-info";
+import JsonDisplay from "../../components/json-display";
+import ObjectPageHeader from "../../components/object-page-header";
+import PagePreamble from "../../components/page-preamble";
+import SampleTable from "../../components/sample-table";
+// lib
+import buildAttribution from "../../lib/attribution";
+import buildBreadcrumbs from "../../lib/breadcrumbs";
+import { requestDocuments, requestSamples } from "../../lib/common-requests";
+import { errorObjectToProps } from "../../lib/errors";
+import FetchRequest from "../../lib/fetch-request";
+import { isJsonFormat } from "../../lib/query-utils";
+import { Ok } from "../../lib/result";
+
+export default function CrisprModification({
+  modification,
+  gene,
+  biosamplesModified,
+  sources,
+  documents,
+  isJson,
+  attribution = null,
+}) {
+  return (
+    <>
+      <Breadcrumbs />
+      <EditableItem item={modification}>
+        <PagePreamble />
+        <ObjectPageHeader item={modification} isJsonFormat={isJson} />
+        <JsonDisplay item={modification} isJsonFormat={isJson}>
+          <DataPanel>
+            <DataArea>
+              <DataItemLabel>Modality</DataItemLabel>
+              <DataItemValue>{modification.modality}</DataItemValue>
+              <DataItemLabel>Cas</DataItemLabel>
+              <DataItemValue>{modification.cas}</DataItemValue>
+              <DataItemLabel>Cas Species</DataItemLabel>
+              <DataItemValue>{modification.cas_species}</DataItemValue>
+              {modification.fused_domain && (
+                <>
+                  <DataItemLabel>Fused Domain</DataItemLabel>
+                  <DataItemValue>{modification.fused_domain}</DataItemValue>
+                </>
+              )}
+              {modification.tagged_protein && (
+                <>
+                  <DataItemLabel>Tagged Protein</DataItemLabel>
+                  <DataItemValue>
+                    <Link href={modification.tagged_protein}>
+                      {gene.symbol}
+                    </Link>
+                  </DataItemValue>
+                </>
+              )}
+              {modification.description && (
+                <>
+                  <DataItemLabel>Description</DataItemLabel>
+                  <DataItemValue>{modification.description}</DataItemValue>
+                </>
+              )}
+              {modification.product_id && (
+                <>
+                  <DataItemLabel>Product ID</DataItemLabel>
+                  <DataItemValue>
+                    <Link
+                      href={`https://www.addgene.org/${
+                        modification.product_id.split(":")[1]
+                      }/`}
+                    >
+                      {modification.product_id}
+                    </Link>
+                  </DataItemValue>
+                </>
+              )}
+              {(modification.lot_id ||
+                modification.product_id ||
+                sources.length > 0) && (
+                <>
+                  <DataItemLabel>Sources</DataItemLabel>
+                  <DataItemValue>
+                    <ProductInfo
+                      lotId={modification.lot_id}
+                      productId={modification.product_id}
+                      sources={sources}
+                    />
+                  </DataItemValue>
+                </>
+              )}
+              {modification.aliases?.length > 0 && (
+                <>
+                  <DataItemLabel>Aliases</DataItemLabel>
+                  <DataItemValue>
+                    <AliasList aliases={modification.aliases} />
+                  </DataItemValue>
+                </>
+              )}
+              <DataItemLabel>Summary</DataItemLabel>
+              <DataItemValue>{modification.summary}</DataItemValue>
+            </DataArea>
+          </DataPanel>
+          {biosamplesModified.length > 0 && (
+            <SampleTable
+              samples={biosamplesModified}
+              reportLink={`/multireport/?type=Biosample&modifications.@id=${modification["@id"]}`}
+              reportLabel="Report of biosamples that have this modification"
+              title="Biosamples modified by this Modification"
+            />
+          )}
+          {documents.length > 0 && <DocumentTable documents={documents} />}
+          <Attribution attribution={attribution} />
+        </JsonDisplay>
+      </EditableItem>
+    </>
+  );
+}
+
+CrisprModification.propTypes = {
+  // Modification to display
+  modification: PropTypes.object.isRequired,
+  // Biosamples modified by the modification
+  biosamplesModified: PropTypes.arrayOf(PropTypes.object).isRequired,
+  // Documents treatment
+  documents: PropTypes.arrayOf(PropTypes.object).isRequired,
+  // The gene referenced by the Modification
+  gene: PropTypes.object,
+  // Attribution for the modification
+  attribution: PropTypes.object,
+  // Source lab or source for this sample
+  sources: PropTypes.arrayOf(PropTypes.object),
+  // Is the format JSON?
+  isJson: PropTypes.bool.isRequired,
+};
+
+export async function getServerSideProps({ params, req, query }) {
+  const isJson = isJsonFormat(query);
+  const request = new FetchRequest({ cookie: req.headers.cookie });
+  const modification = (
+    await request.getObject(`/crispr-modifications/${params.uuid}/`)
+  ).union();
+  if (FetchRequest.isResponseSuccess(modification)) {
+    const gene = modification.tagged_protein
+      ? (await request.getObject(modification.tagged_protein)).optional()
+      : null;
+
+    let sources = [];
+    if (modification.sources?.length > 0) {
+      sources = Ok.all(
+        await request.getMultipleObjects(modification.sources, {
+          filterErrors: true,
+        })
+      );
+    }
+
+    const biosamplesModified =
+      modification.biosamples_modified.length > 0
+        ? await requestSamples(modification.biosamples_modified, request)
+        : [];
+
+    const documents = modification.documents
+      ? await requestDocuments(modification.documents, request)
+      : [];
+    const breadcrumbs = await buildBreadcrumbs(
+      modification,
+      modification.summary,
+      req.headers.cookie
+    );
+    const attribution = await buildAttribution(
+      modification,
+      req.headers.cookie
+    );
+    return {
+      props: {
+        modification,
+        biosamplesModified,
+        documents,
+        gene,
+        breadcrumbs,
+        sources,
+        pageContext: {
+          title: modification.summary,
+        },
+        attribution,
+        isJson,
+      },
+    };
+  }
+  return errorObjectToProps(modification);
+}

--- a/pages/crispr-modifications/[uuid].js
+++ b/pages/crispr-modifications/[uuid].js
@@ -73,20 +73,6 @@ export default function CrisprModification({
                   <DataItemValue>{modification.description}</DataItemValue>
                 </>
               )}
-              {modification.product_id && (
-                <>
-                  <DataItemLabel>Product ID</DataItemLabel>
-                  <DataItemValue>
-                    <Link
-                      href={`https://www.addgene.org/${
-                        modification.product_id.split(":")[1]
-                      }/`}
-                    >
-                      {modification.product_id}
-                    </Link>
-                  </DataItemValue>
-                </>
-              )}
               {(modification.lot_id ||
                 modification.product_id ||
                 sources.length > 0) && (

--- a/pages/curated-sets/[id].js
+++ b/pages/curated-sets/[id].js
@@ -89,6 +89,7 @@ export default function CuratedSet({
             <SampleTable
               samples={curatedSet.samples}
               reportLink={`/multireport/?type=Sample&file_sets.@id=${curatedSet["@id"]}`}
+              reportLabel="Report of samples in this curated set"
             />
           )}
           {curatedSet.donors?.length > 0 && (

--- a/pages/degron-modifications/[uuid].js
+++ b/pages/degron-modifications/[uuid].js
@@ -72,20 +72,6 @@ export default function DegronModification({
                   <DataItemValue>{modification.description}</DataItemValue>
                 </>
               )}
-              {modification.product_id && (
-                <>
-                  <DataItemLabel>Product ID</DataItemLabel>
-                  <DataItemValue>
-                    <Link
-                      href={`https://www.addgene.org/${
-                        modification.product_id.split(":")[1]
-                      }/`}
-                    >
-                      {modification.product_id}
-                    </Link>
-                  </DataItemValue>
-                </>
-              )}
               {(modification.lot_id ||
                 modification.product_id ||
                 sources.length > 0) && (

--- a/pages/in-vitro-systems/[id].js
+++ b/pages/in-vitro-systems/[id].js
@@ -166,6 +166,7 @@ export default function InVitroSystem({
             <SampleTable
               samples={multiplexedInSamples}
               reportLink={`/multireport/?type=MultiplexedSample&multiplexed_samples.@id=${inVitroSystem["@id"]}`}
+              reportLabel="Report of multiplexed samples in which this sample is included"
               title="Multiplexed In Samples"
             />
           )}
@@ -173,6 +174,7 @@ export default function InVitroSystem({
             <SampleTable
               samples={pooledFrom}
               reportLink={`/multireport/?type=Sample&pooled_in=${inVitroSystem["@id"]}`}
+              reportLabel="Report of samples this biosample is pooled from"
               title="Biosamples Pooled From"
             />
           )}
@@ -180,6 +182,7 @@ export default function InVitroSystem({
             <SampleTable
               samples={pooledIn}
               reportLink={`/multireport/?type=Biosample&pooled_from=${inVitroSystem["@id"]}`}
+              reportLabel="Report of pooled biosamples in which this sample is included"
               title="Pooled In"
             />
           )}
@@ -187,6 +190,7 @@ export default function InVitroSystem({
             <SampleTable
               samples={demultiplexedTo}
               reportLink={`/multireport/?type=Biosample&demultiplexed_from=${inVitroSystem["@id"]}`}
+              reportLabel="Report of parts into which this sample has been demultiplexed"
               title="Demultiplexed To Sample"
             />
           )}
@@ -194,6 +198,7 @@ export default function InVitroSystem({
             <SampleTable
               samples={parts}
               reportLink={`/multireport/?type=Biosample&part_of=${inVitroSystem["@id"]}`}
+              reportLabel="Report of parts into which this sample has been divided"
               title="Sample Parts"
             />
           )}
@@ -201,6 +206,7 @@ export default function InVitroSystem({
             <SampleTable
               samples={originOf}
               reportLink={`/multireport/?type=Biosample&originated_from.@id=${inVitroSystem["@id"]}`}
+              reportLabel="Report of samples which originate from this sample"
               title="Origin Sample Of"
             />
           )}
@@ -215,6 +221,7 @@ export default function InVitroSystem({
             <SampleTable
               samples={sortedFractions}
               reportLink={`/multireport/?type=Sample&sorted_from.@id=${inVitroSystem["@id"]}`}
+              reportLabel="Report of fractions into which this sample has been sorted"
               title="Sorted Fractions of Sample"
             />
           )}

--- a/pages/measurement-sets/[id].js
+++ b/pages/measurement-sets/[id].js
@@ -244,6 +244,7 @@ export default function MeasurementSet({
             <SampleTable
               samples={measurementSet.samples}
               reportLink={`/multireport/?type=Sample&file_sets.@id=${measurementSet["@id"]}`}
+              reportLabel="Report of samples in this file set"
             />
           )}
           {measurementSet.donors?.length > 0 && (

--- a/pages/multiplexed-samples/[uuid].js
+++ b/pages/multiplexed-samples/[uuid].js
@@ -109,6 +109,7 @@ export default function MultiplexedSample({
             <SampleTable
               samples={multiplexedSample.multiplexed_samples}
               reportLink={reportLink}
+              reportLabel="Report of samples multiplexed together to produce this sample"
               title="Multiplexed Samples"
             />
           )}
@@ -116,6 +117,7 @@ export default function MultiplexedSample({
             <SampleTable
               samples={multiplexedInSamples}
               reportLink={`/multireport/?type=MultiplexedSample&multiplexed_samples.@id=${multiplexedSample["@id"]}`}
+              reportLabel="Report of multiplexed samples in which this sample is included"
               title="Multiplexed In Samples"
             />
           )}
@@ -128,6 +130,7 @@ export default function MultiplexedSample({
             <SampleTable
               samples={sortedFractions}
               reportLink={`/multireport/?type=Sample&sorted_from.@id=${multiplexedSample["@id"]}`}
+              reportLabel="Report of fractions into which this sample has been sorted"
               title="Sorted Fractions of Sample"
             />
           )}

--- a/pages/prediction-sets/[id].js
+++ b/pages/prediction-sets/[id].js
@@ -148,6 +148,7 @@ export default function PredictionSet({
             <SampleTable
               samples={predictionSet.samples}
               reportLink={`/multireport/?type=Sample&file_sets.@id=${predictionSet["@id"]}`}
+              reportLabel="Report of samples in this prediction set"
             />
           )}
           {predictionSet.donors?.length > 0 && (

--- a/pages/primary-cells/[uuid].js
+++ b/pages/primary-cells/[uuid].js
@@ -106,6 +106,7 @@ export default function PrimaryCell({
             <SampleTable
               samples={multiplexedInSamples}
               reportLink={`/multireport/?type=MultiplexedSample&multiplexed_samples.@id=${primaryCell["@id"]}`}
+              reportLabel="Report of multiplexed samples in which this sample is included"
               title="Multiplexed In Samples"
             />
           )}
@@ -113,6 +114,7 @@ export default function PrimaryCell({
             <SampleTable
               samples={pooledFrom}
               reportLink={`/multireport/?type=Sample&pooled_in=${primaryCell["@id"]}`}
+              reportLabel="Report of biosamples this sample is pooled from"
               title="Biosamples Pooled From"
             />
           )}
@@ -120,6 +122,7 @@ export default function PrimaryCell({
             <SampleTable
               samples={pooledIn}
               reportLink={`/multireport/?type=Biosample&pooled_from=${primaryCell["@id"]}`}
+              reportLabel="Report of pooled samples in which this sample is included"
               title="Pooled In"
             />
           )}
@@ -127,6 +130,7 @@ export default function PrimaryCell({
             <SampleTable
               samples={parts}
               reportLink={`/multireport/?type=Biosample&part_of=${primaryCell["@id"]}`}
+              reportLabel="Report of parts into which this sample has been divided"
               title="Sample Parts"
             />
           )}
@@ -141,6 +145,7 @@ export default function PrimaryCell({
             <SampleTable
               samples={sortedFractions}
               reportLink={`/multireport/?type=Sample&sorted_from.@id=${primaryCell["@id"]}`}
+              reportLabel="Report of fractions into which this sample has been sorted"
               title="Sorted Fractions of Sample"
             />
           )}

--- a/pages/technical-samples/[uuid].js
+++ b/pages/technical-samples/[uuid].js
@@ -85,6 +85,7 @@ export default function TechnicalSample({
             <SampleTable
               samples={multiplexedInSamples}
               reportLink={`/multireport/?type=MultiplexedSample&multiplexed_samples.@id=${sample["@id"]}`}
+              reportLabel="Report of multiplexed samples in which this sample is included"
               title="Multiplexed In Samples"
             />
           )}
@@ -92,6 +93,7 @@ export default function TechnicalSample({
             <SampleTable
               samples={sortedFractions}
               reportLink={`/multireport/?type=Sample&sorted_from.@id=${sample["@id"]}`}
+              reportLabel="Report of fractions into which this sample has been sorted"
               title="Sorted Fractions of Sample"
             />
           )}

--- a/pages/tissues/[uuid].js
+++ b/pages/tissues/[uuid].js
@@ -135,6 +135,7 @@ export default function Tissue({
             <SampleTable
               samples={multiplexedInSamples}
               reportLink={`/multireport/?type=MultiplexedSample&multiplexed_samples.@id=${tissue["@id"]}`}
+              reportLabel="Report of multiplexed samples in which this sample is included"
               title="Multiplexed In Samples"
             />
           )}
@@ -142,6 +143,7 @@ export default function Tissue({
             <SampleTable
               samples={pooledFrom}
               reportLink={`/multireport/?type=Sample&pooled_in=${tissue["@id"]}`}
+              reportLabel="Report of biosamples this biosample is pooled from"
               title="Biosamples Pooled From"
             />
           )}
@@ -149,6 +151,7 @@ export default function Tissue({
             <SampleTable
               samples={pooledIn}
               reportLink={`/multireport/?type=Biosample&pooled_from=${tissue["@id"]}`}
+              reportLabel="Report of pooled samples in which this sample is included"
               title="Pooled In"
             />
           )}
@@ -156,6 +159,7 @@ export default function Tissue({
             <SampleTable
               samples={parts}
               reportLink={`/multireport/?type=Biosample&part_of=${tissue["@id"]}`}
+              reportLabel="Report of parts into which this sample has been divided"
               title="Sample Parts"
             />
           )}
@@ -170,6 +174,7 @@ export default function Tissue({
             <SampleTable
               samples={sortedFractions}
               reportLink={`/multireport/?type=Sample&sorted_from.@id=${tissue["@id"]}`}
+              reportLabel="Report of fractions into which this sample has been sorted"
               title="Sorted Fractions of Sample"
             />
           )}

--- a/pages/whole-organisms/[id].js
+++ b/pages/whole-organisms/[id].js
@@ -91,6 +91,7 @@ export default function WholeOrganism({
             <SampleTable
               samples={multiplexedInSamples}
               reportLink={`/multireport/?type=MultiplexedSample&multiplexed_samples.@id=${sample["@id"]}`}
+              reportLabel="Report of multiplexed samples in which this sample is included"
               title="Multiplexed In Samples"
             />
           )}
@@ -98,6 +99,7 @@ export default function WholeOrganism({
             <SampleTable
               samples={pooledIn}
               reportLink={`/multireport/?type=Biosample&pooled_from=${sample["@id"]}`}
+              reportLabel="Report of pooled samples in which this sample is included"
               title="Pooled In"
             />
           )}
@@ -105,6 +107,7 @@ export default function WholeOrganism({
             <SampleTable
               samples={parts}
               reportLink={`/multireport/?type=Biosample&part_of=${sample["@id"]}`}
+              reportLabel="Report of parts into which this sample has been divided"
               title="Sample Parts"
             />
           )}
@@ -119,6 +122,7 @@ export default function WholeOrganism({
             <SampleTable
               samples={sortedFractions}
               reportLink={`/multireport/?type=Sample&sorted_from.@id=${sample["@id"]}`}
+              reportLabel="Report of fractions into which this sample has been sorted"
               title="Sorted Fractions of Sample"
             />
           )}


### PR DESCRIPTION
It’d be nice to get this into this week’s release (today evening) but if it doesn’t that’s OK. I know this is last minute, so not having this for a week won’t cause crashes.

This branch’s main purpose is to move the Modification object and list displays to new sub objects — CrisprModification and DegronModification. So these both mostly copy and alter the old Modification displays.

I noticed the SampleTable component (used on the new pages) hasn’t been flexible enough to show the correct label, so I added a label property, but now every call to SampleTable needs this property, which is why so many files got changed.