### PR TITLE
IGVF-1849 ORF genes property update

### DIFF
--- a/components/search/__tests__/list-renderer.test.js
+++ b/components/search/__tests__/list-renderer.test.js
@@ -824,7 +824,7 @@ describe("Test OpenReadingFrame component", () => {
       "@id": "/open-reading-frames/CCSBORF1234/",
       "@type": ["OpenReadingFrame", "Item"],
       dbxrefs: ["hORFeome:8945"],
-      gene: [
+      genes: [
         {
           symbol: "CXXC1",
           geneid: "ENSG00000163930",
@@ -861,7 +861,7 @@ describe("Test OpenReadingFrame component", () => {
       "@id": "/open-reading-frames/CCSBORF1234/",
       "@type": ["OpenReadingFrame", "Item"],
       dbxrefs: ["hORFeome:8945"],
-      gene: [
+      genes: [
         {
           symbol: "CXXC1",
           geneid: "ENSG00000163930",

--- a/components/search/list-renderer/open-reading-frame.js
+++ b/components/search/list-renderer/open-reading-frame.js
@@ -36,7 +36,7 @@ export default function OpenReadingFrame({ item: openReadingFrame }) {
             <SearchListItemSupplementLabel>Genes</SearchListItemSupplementLabel>
             <SearchListItemSupplementContent>
               <SeparatedList isCollapsible>
-                {openReadingFrame.gene.map((gene) => (
+                {openReadingFrame.genes.map((gene) => (
                   <Link
                     href={gene["@id"]}
                     key={gene["@id"]}

--- a/pages/open-reading-frames/[uuid].js
+++ b/pages/open-reading-frames/[uuid].js
@@ -39,12 +39,12 @@ export default function OpenReadingFrame({ orf, isJson }) {
                   <DataItemValue>{orf.description}</DataItemValue>
                 </>
               )}
-              {orf.gene.length > 0 && (
+              {orf.genes.length > 0 && (
                 <>
                   <DataItemLabel>ENSEMBL GeneID</DataItemLabel>
                   <DataItemValue>
                     <SeparatedList isCollapsible>
-                      {orf.gene.map((gene) => (
+                      {orf.genes.map((gene) => (
                         <EnsemblLink key={gene} geneid={gene.geneid} />
                       ))}
                     </SeparatedList>

--- a/pages/open-reading-frames/[uuid].js
+++ b/pages/open-reading-frames/[uuid].js
@@ -41,7 +41,7 @@ export default function OpenReadingFrame({ orf, isJson }) {
               )}
               {orf.genes.length > 0 && (
                 <>
-                  <DataItemLabel>ENSEMBL GeneID</DataItemLabel>
+                  <DataItemLabel>ENSEMBL GeneIDs</DataItemLabel>
                   <DataItemValue>
                     <SeparatedList isCollapsible>
                       {orf.genes.map((gene) => (


### PR DESCRIPTION
The Cypress test fails because it needs IGVF-1792 to get merged into igvfd dev.