### PR TITLE
IGVF-1656 Rewrite report cell renderer for properties not in schema

### DIFF
--- a/components/__tests__/unspecified-property.test.js
+++ b/components/__tests__/unspecified-property.test.js
@@ -3,47 +3,35 @@ import UnspecifiedProperty from "../unspecified-property";
 
 describe("Test UnspecifiedProperty component", () => {
   it("renders strings and numbers", () => {
-    render(<UnspecifiedProperty property="hello" />);
+    render(<UnspecifiedProperty properties={["hello"]} />);
     expect(screen.getByText("hello")).toBeInTheDocument();
 
-    render(<UnspecifiedProperty property={5} />);
+    render(<UnspecifiedProperty properties={["5"]} />);
     expect(screen.getByText("5")).toBeInTheDocument();
   });
 
   it("renders booleans", () => {
-    render(<UnspecifiedProperty property={true} />);
+    render(<UnspecifiedProperty properties={["true"]} />);
     expect(screen.getByText("true")).toBeInTheDocument();
 
-    render(<UnspecifiedProperty property={false} />);
+    render(<UnspecifiedProperty properties={["false"]} />);
     expect(screen.getByText("false")).toBeInTheDocument();
   });
 
   it("renders arrays of strings and numbers", () => {
-    render(<UnspecifiedProperty property={["hello", 5]} />);
-    expect(screen.getByText("5, hello")).toBeInTheDocument();
+    render(<UnspecifiedProperty properties={["hello", "5"]} />);
+    expect(screen.getByText("hello, 5")).toBeInTheDocument();
   });
 
   it("renders an embedded object with an @id", () => {
-    const property = {
-      "@id": "/example/path/",
-      title: "Example",
-    };
-    render(<UnspecifiedProperty property={property} />);
+    const properties = ["/example/path/"];
+    render(<UnspecifiedProperty properties={properties} />);
     expect(screen.getByRole("link")).toHaveTextContent("/example/path/");
   });
 
   it("renders an array of embedded objects with @ids", () => {
-    const property = [
-      {
-        "@id": "/example/path/",
-        title: "Example",
-      },
-      {
-        "@id": "/example/path2/",
-        title: "Example 2",
-      },
-    ];
-    render(<UnspecifiedProperty property={property} />);
+    const properties = ["/example/path/", "/example/path2/"];
+    render(<UnspecifiedProperty properties={properties} />);
     expect(
       screen.getByRole("link", { name: "/example/path/" })
     ).toBeInTheDocument();
@@ -52,26 +40,9 @@ describe("Test UnspecifiedProperty component", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders an embedded object without an @id as JSON", () => {
-    const property = {
-      title: "Example",
-    };
-    render(<UnspecifiedProperty property={property} />);
-    expect(screen.getByText('{"title":"Example"}')).toBeInTheDocument();
-  });
-
-  it("renders an array of embedded objects without @ids as JSON", () => {
-    const property = [
-      {
-        title: "Example",
-      },
-      {
-        title: "Example 2",
-      },
-    ];
-    render(<UnspecifiedProperty property={property} />);
-    expect(
-      screen.getByText('[{"title":"Example"},{"title":"Example 2"}]')
-    ).toBeInTheDocument();
+  it("renders a URL as a link", () => {
+    const properties = ["http://example.com"];
+    render(<UnspecifiedProperty properties={properties} />);
+    expect(screen.getByRole("link")).toHaveTextContent("http://example.com");
   });
 });

--- a/components/report/__tests__/cell-renderers.test.js
+++ b/components/report/__tests__/cell-renderers.test.js
@@ -189,7 +189,7 @@ describe("Test cell renderers in search results", () => {
 
       // Check unknown object array has JSON string.
       const objectArrayList = cells[COLUMN_OBJECT_ARRAY];
-      expect(objectArrayList).toHaveTextContent('[{"object":"object1"}]');
+      expect(objectArrayList).toHaveTextContent('{"object":"object1"}');
 
       // Check PI column has two linked paths with the correct text.
       const piLinks = within(cells[COLUMN_PI]).getAllByRole("link");
@@ -1533,7 +1533,7 @@ describe("Unknown-field cell-rendering tests", () => {
 
     // Test that the unknown field has the correct contents.
     expect(cells[COLUMN_UNKNOWN]).toHaveTextContent(
-      `[{"assembly":"GRCh38","chromosome":"chr1","end":10,"start":1}]`
+      `{"assembly":"GRCh38","chromosome":"chr1","end":10,"start":1}`
     );
   });
 

--- a/components/report/cell-renderers.js
+++ b/components/report/cell-renderers.js
@@ -337,12 +337,12 @@ SimpleArray.propTypes = {
  * properties.
  */
 function UnknownObject({ id, source }) {
-  const property = getUnknownProperty(id, source);
+  const properties = getUnknownProperty(id, source);
 
-  if (property) {
+  if (properties.length > 0) {
     return (
       <div data-testid="cell-type-unknown-object">
-        <UnspecifiedProperty property={property} />
+        <UnspecifiedProperty properties={properties} />
       </div>
     );
   }
@@ -529,7 +529,7 @@ export const typeRenderers = {
  * @returns {string} The type of the property; see `typeRenderers`
  */
 export function detectPropertyTypes(property, profile) {
-  const propertyDefinition = profile[property];
+  const propertyDefinition = profile?.[property];
   let propertyType = "unknown";
   if (propertyDefinition) {
     if (propertyDefinition.type === "array" && propertyDefinition.items) {

--- a/components/report/generate-columns.js
+++ b/components/report/generate-columns.js
@@ -33,10 +33,7 @@ function getColumnRenderer(types, property, schemaProperties) {
 
   // No custom renderer based on property name, so detect the property type and use a generic
   // renderer appropriate for that type.
-  let detectedType;
-  if (schemaProperties) {
-    detectedType = detectPropertyTypes(property, schemaProperties);
-  }
+  const detectedType = detectPropertyTypes(property, schemaProperties);
   return typeRenderers[detectedType];
 }
 


### PR DESCRIPTION
I think the vast majority of the changes involve the Jest tests. The main functionality change is in `getUnknownProperty()` which I rewrote to handle the crashing case in `<UnknownTypePanel>`, and instead of returning any type it comes across, it always returns an array of strings, or an empty array. That way `<UnknownTypePanel>` only needs to special case URLs and paths.