### PR TITLE
IGVF-1943 Collapsible tables

### DIFF
--- a/components/__tests__/data-area.test.js
+++ b/components/__tests__/data-area.test.js
@@ -172,7 +172,7 @@ describe("Test DataItemList", () => {
 describe("Test the DataAreaTitle and collapser", () => {
   it("renders a title with a collapsible control", () => {
     function TitleWithCollapser() {
-      const pagePanels = usePagePanels("/test/page/");
+      const pagePanels = usePagePanels();
 
       return (
         <>
@@ -202,7 +202,7 @@ describe("Test the DataAreaTitle and collapser", () => {
 
   it("renders multiple tables with collapsible controls", () => {
     function TitleWithCollapser() {
-      const pagePanels = usePagePanels("/test/page/");
+      const pagePanels = usePagePanels();
 
       return (
         <>

--- a/components/__tests__/data-area.test.js
+++ b/components/__tests__/data-area.test.js
@@ -9,6 +9,7 @@ import {
   DataItemValueUrl,
   DataPanel,
 } from "../data-area";
+import { usePagePanels } from "../page-panels";
 import Status from "../status";
 
 describe("Test the DataArea component", () => {
@@ -165,5 +166,91 @@ describe("Test DataItemList", () => {
     listItems.forEach((item) => {
       expect(item).toHaveClass("break-all");
     });
+  });
+});
+
+describe("Test the DataAreaTitle and collapser", () => {
+  it("renders a title with a collapsible control", () => {
+    function TitleWithCollapser() {
+      const pagePanels = usePagePanels("/test/page/");
+
+      return (
+        <>
+          <DataAreaTitle>
+            <DataAreaTitle.Expander
+              pagePanels={pagePanels}
+              pagePanelId="test-panel"
+              label="Test table"
+            >
+              Test Title
+            </DataAreaTitle.Expander>
+          </DataAreaTitle>
+          {pagePanels.isExpanded("test-panel") && <div>Expanded</div>}
+        </>
+      );
+    }
+
+    render(<TitleWithCollapser />);
+
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+    expect(screen.queryByText("Expanded")).not.toBeInTheDocument();
+
+    // Click the button to expand the panel
+    fireEvent.click(screen.getByText("Test Title"));
+    expect(screen.getByText("Expanded")).toBeInTheDocument();
+  });
+
+  it("renders multiple tables with collapsible controls", () => {
+    function TitleWithCollapser() {
+      const pagePanels = usePagePanels("/test/page/");
+
+      return (
+        <>
+          <DataAreaTitle>
+            <DataAreaTitle.Expander
+              pagePanels={pagePanels}
+              pagePanelId="test-panel-1"
+              label="Test table 1"
+            >
+              Test Title 1
+            </DataAreaTitle.Expander>
+          </DataAreaTitle>
+          {pagePanels.isExpanded("test-panel-1") && <div>Expanded 1</div>}
+          <DataAreaTitle>
+            <DataAreaTitle.Expander
+              pagePanels={pagePanels}
+              pagePanelId="test-panel-2"
+              label="Test table 2"
+            >
+              Test Title 2
+            </DataAreaTitle.Expander>
+          </DataAreaTitle>
+          {pagePanels.isExpanded("test-panel-2") && <div>Expanded 2</div>}
+        </>
+      );
+    }
+
+    render(<TitleWithCollapser />);
+
+    expect(screen.getByText("Test Title 1")).toBeInTheDocument();
+    expect(screen.getByText("Test Title 2")).toBeInTheDocument();
+    expect(screen.queryByText("Expanded 1")).not.toBeInTheDocument();
+    expect(screen.queryByText("Expanded 2")).not.toBeInTheDocument();
+
+    // Click the button to expand the first panel
+    fireEvent.click(screen.getByText("Test Title 1"));
+    expect(screen.getByText("Expanded 1")).toBeInTheDocument();
+    expect(screen.queryByText("Expanded 2")).not.toBeInTheDocument();
+
+    // Click the button to expand the second panel
+    fireEvent.click(screen.getByText("Test Title 2"));
+    expect(screen.getByText("Expanded 1")).toBeInTheDocument();
+    expect(screen.getByText("Expanded 2")).toBeInTheDocument();
+
+    // Click the button to collapse the first panel with the option key down and make sure both
+    // panels collapse. Delay a half second to allow the animations to finish.
+    fireEvent.click(screen.getByText("Test Title 1"), { altKey: true });
+    expect(screen.queryByText("Expanded 1")).not.toBeInTheDocument();
+    expect(screen.queryByText("Expanded 2")).not.toBeInTheDocument();
   });
 });

--- a/components/__tests__/data-area.test.js
+++ b/components/__tests__/data-area.test.js
@@ -172,7 +172,7 @@ describe("Test DataItemList", () => {
 describe("Test the DataAreaTitle and collapser", () => {
   it("renders a title with a collapsible control", () => {
     function TitleWithCollapser() {
-      const pagePanels = usePagePanels();
+      const pagePanels = usePagePanels("/test/page/");
 
       return (
         <>
@@ -202,7 +202,7 @@ describe("Test the DataAreaTitle and collapser", () => {
 
   it("renders multiple tables with collapsible controls", () => {
     function TitleWithCollapser() {
-      const pagePanels = usePagePanels();
+      const pagePanels = usePagePanels("/test/page/");
 
       return (
         <>

--- a/components/__tests__/document-table.test.js
+++ b/components/__tests__/document-table.test.js
@@ -59,7 +59,7 @@ describe("Test the document table", () => {
     ];
 
     function PageWithDocuments() {
-      const pagePanels = usePagePanels();
+      const pagePanels = usePagePanels("/document/parent/");
       return (
         <DocumentTable
           documents={documents}

--- a/components/__tests__/document-table.test.js
+++ b/components/__tests__/document-table.test.js
@@ -59,7 +59,7 @@ describe("Test the document table", () => {
     ];
 
     function PageWithDocuments() {
-      const pagePanels = usePagePanels("/document/parent/");
+      const pagePanels = usePagePanels();
       return (
         <DocumentTable
           documents={documents}

--- a/components/__tests__/document-table.test.js
+++ b/components/__tests__/document-table.test.js
@@ -1,7 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import DocumentTable from "../document-table";
+import { usePagePanels } from "../page-panels";
 
 describe("Test the document table", () => {
+  beforeAll(() => {
+    window.scrollTo = jest.fn();
+  });
+
   it("generates a good document table from the given documents", () => {
     /**
      * Array of test documents.
@@ -53,7 +58,28 @@ describe("Test the document table", () => {
       },
     ];
 
-    render(<DocumentTable documents={documents} />);
+    function PageWithDocuments() {
+      const pagePanels = usePagePanels("/document/parent/");
+      return (
+        <DocumentTable
+          documents={documents}
+          pagePanels={pagePanels}
+          pagePanelId="documents"
+        />
+      );
+    }
+
+    render(<PageWithDocuments />);
+
+    // Initially it should render no table.
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+
+    // Find the button to expand the table and click it.
+    const expandButton = screen.getByRole("button", {
+      name: "Documents table",
+    });
+    expect(expandButton).toBeInTheDocument();
+    fireEvent.click(expandButton);
 
     // Check the size of the table.
     const columnHeaders = screen.getAllByRole("columnheader");

--- a/components/analysis-step-table.js
+++ b/components/analysis-step-table.js
@@ -1,8 +1,13 @@
 // node_modules
+import { AnimatePresence, motion } from "framer-motion";
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import _ from "lodash";
 import PropTypes from "prop-types";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
@@ -65,23 +70,46 @@ export default function AnalysisStepTable({
   reportLink = "",
   reportLabel = "",
   title = "Analysis Steps",
+  pagePanels,
+  pagePanelId,
 }) {
+  const isExpanded = pagePanels.isExpanded(pagePanelId);
+
   return (
     <>
       <DataAreaTitle>
-        {title}
-        {reportLink && (
+        <DataAreaTitle.Expander
+          pagePanels={pagePanels}
+          pagePanelId={pagePanelId}
+          label={`${title} table`}
+        >
+          {title}
+        </DataAreaTitle.Expander>
+        {reportLink && isExpanded && (
           <DataAreaTitleLink href={reportLink} label={reportLabel}>
             <TableCellsIcon className="h-4 w-4" />
           </DataAreaTitleLink>
         )}
       </DataAreaTitle>
-      <SortableGrid
-        data={analysisSteps}
-        columns={analysisStepColumns}
-        keyProp="@id"
-        pager={{}}
-      />
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            className="overflow-hidden"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            transition={standardAnimationTransition}
+            variants={standardAnimationVariants}
+          >
+            <SortableGrid
+              data={analysisSteps}
+              columns={analysisStepColumns}
+              keyProp="@id"
+              pager={{}}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -95,4 +123,8 @@ AnalysisStepTable.propTypes = {
   reportLabel: PropTypes.string,
   // Title of the table if not "Analysis Steps"
   title: PropTypes.string,
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this table, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
 };

--- a/components/biomarker-table.js
+++ b/components/biomarker-table.js
@@ -1,7 +1,12 @@
 // node_modules
+import { AnimatePresence, motion } from "framer-motion";
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import PropTypes from "prop-types";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
@@ -47,23 +52,47 @@ export default function BiomarkerTable({
   reportLink = null,
   reportLabel = null,
   title = "Biomarkers",
+  pagePanels,
+  pagePanelId,
 }) {
+  const isExpanded = pagePanels.isExpanded(pagePanelId);
+
   return (
     <>
       <DataAreaTitle>
-        {title}
-        {reportLink && reportLabel && (
+        <DataAreaTitle.Expander
+          pagePanels={pagePanels}
+          pagePanelId={pagePanelId}
+          label={`${title} table`}
+        >
+          {title}
+        </DataAreaTitle.Expander>
+        {reportLink && reportLabel && isExpanded && (
           <DataAreaTitleLink href={reportLink} label={reportLabel}>
             <TableCellsIcon className="h-4 w-4" />
           </DataAreaTitleLink>
         )}
       </DataAreaTitle>
-      <SortableGrid
-        data={biomarkers}
-        columns={biomarkersColumns}
-        pager={{}}
-        keyProp="@id"
-      />
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            id={pagePanelId}
+            className="overflow-hidden"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            transition={standardAnimationTransition}
+            variants={standardAnimationVariants}
+          >
+            <SortableGrid
+              data={biomarkers}
+              columns={biomarkersColumns}
+              pager={{}}
+              keyProp="@id"
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -77,4 +106,8 @@ BiomarkerTable.propTypes = {
   reportLabel: PropTypes.string,
   // Title to display if not "Biomarkers"
   title: PropTypes.string,
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this table, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
 };

--- a/components/browser-storage.tsx
+++ b/components/browser-storage.tsx
@@ -14,16 +14,19 @@ import { useEffect, useState } from "react";
  * Analogous to useState, but sets new values in the browser's localStorage, and recalls them.
  * Supply a key to identify the value in localStorage.
  * @param {string} key Identifier of the given localStorage data
- * @param {*} initialValue Initial value to set for the key; including objects
+ * @param {T} initialValue Initial value to set for the key; including objects
  * @returns {array} [
  *   0: Value retrieved from localStorage
  *   1: Function to set new value in localStorage; calling component must be mounted
  * ]
  */
-export function useLocalStorage(key, initialValue) {
-  const [value, setValue] = useState(initialValue);
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T
+): [T, (value: T) => void] {
+  const [value, setValue] = useState<T>(initialValue);
 
-  function setValueMethod(valueToStore) {
+  function setValueMethod(valueToStore: T) {
     setValue(valueToStore);
     localStorage.setItem(key, JSON.stringify(valueToStore));
   }
@@ -44,16 +47,19 @@ export function useLocalStorage(key, initialValue) {
  * Analogous to useState, but sets new values in the browser's sessionStorage, and recalls them.
  * Supply a key to identify the value in sessionStorage.
  * @param {string} key Identifier of the given sessionStorage data
- * @param {*} initialValue Initial value to set for the key; including objects
+ * @param {T} initialValue Initial value to set for the key; including objects
  * @returns {array} [
  *   0: Value retrieved from sessionStorage
  *   1: Function to set new value in sessionStorage; calling component must be mounted
  * ]
  */
-export function useSessionStorage(key, initialValue) {
-  const [value, setValue] = useState(initialValue);
+export function useSessionStorage<T>(
+  key: string,
+  initialValue: T
+): [T, (value: T) => void] {
+  const [value, setValue] = useState<T>(initialValue);
 
-  function setValueMethod(valueToStore) {
+  function setValueMethod(valueToStore: T) {
     setValue(valueToStore);
     window.sessionStorage.setItem(key, JSON.stringify(valueToStore));
   }

--- a/components/data-area.js
+++ b/components/data-area.js
@@ -20,6 +20,7 @@ import {
   useCollapseControl,
 } from "./collapse-control";
 import { ButtonLink } from "./form-elements";
+import { PagePanelButton } from "./page-panels";
 
 /**
  * Displays a panel -- typically to display data items for an object, but you can use this for
@@ -78,6 +79,40 @@ DataAreaTitle.propTypes = {
   // Additional Tailwind CSS classes to apply to the <h2> element
   className: PropTypes.string,
 };
+
+/**
+ * Embed this component (or rather its alias, DataAreaTitle.Expander) inside a DataAreaTitle to
+ * add a button to collapse or expand the data area.
+ */
+function DataAreaTitleWithExpander({
+  pagePanels,
+  pagePanelId,
+  label,
+  children,
+}) {
+  return (
+    <div className="flex items-center gap-1">
+      <PagePanelButton
+        pagePanels={pagePanels}
+        pagePanelId={pagePanelId}
+        label={label}
+      >
+        {children}
+      </PagePanelButton>
+    </div>
+  );
+}
+
+DataAreaTitleWithExpander.propTypes = {
+  // Expandable panels to determine if this title should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this title, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
+  // Accessible label for the title of the table
+  label: PropTypes.string.isRequired,
+};
+
+DataAreaTitle.Expander = DataAreaTitleWithExpander;
 
 /**
  * Displays a link to the right of a data area title. This is typically used to link to a report

--- a/components/data-area.js
+++ b/components/data-area.js
@@ -88,7 +88,6 @@ function DataAreaTitleWithExpander({
   pagePanels,
   pagePanelId,
   label,
-  isDefaultExpanded = false,
   children,
 }) {
   return (
@@ -97,7 +96,6 @@ function DataAreaTitleWithExpander({
         pagePanels={pagePanels}
         pagePanelId={pagePanelId}
         label={label}
-        isDefaultExpanded={isDefaultExpanded}
       >
         {children}
       </PagePanelButton>
@@ -112,8 +110,6 @@ DataAreaTitleWithExpander.propTypes = {
   pagePanelId: PropTypes.string.isRequired,
   // Accessible label for the title of the table
   label: PropTypes.string.isRequired,
-  // True if the data area should appear expanded by default
-  isDefaultExpanded: PropTypes.bool,
 };
 
 DataAreaTitle.Expander = DataAreaTitleWithExpander;

--- a/components/data-area.js
+++ b/components/data-area.js
@@ -88,6 +88,7 @@ function DataAreaTitleWithExpander({
   pagePanels,
   pagePanelId,
   label,
+  isDefaultExpanded = false,
   children,
 }) {
   return (
@@ -96,6 +97,7 @@ function DataAreaTitleWithExpander({
         pagePanels={pagePanels}
         pagePanelId={pagePanelId}
         label={label}
+        isDefaultExpanded={isDefaultExpanded}
       >
         {children}
       </PagePanelButton>
@@ -110,6 +112,8 @@ DataAreaTitleWithExpander.propTypes = {
   pagePanelId: PropTypes.string.isRequired,
   // Accessible label for the title of the table
   label: PropTypes.string.isRequired,
+  // True if the data area should appear expanded by default
+  isDefaultExpanded: PropTypes.bool,
 };
 
 DataAreaTitle.Expander = DataAreaTitleWithExpander;

--- a/components/derived-from-table.js
+++ b/components/derived-from-table.js
@@ -1,8 +1,13 @@
 // node_modules
+import { AnimatePresence, motion } from "framer-motion";
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import PropTypes from "prop-types";
 import Link from "next/link";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import { FileAccessionAndDownload } from "./file-download";
 import SortableGrid from "./sortable-grid";
@@ -66,24 +71,47 @@ export default function DerivedFromTable({
   reportLink = null,
   reportLabel = null,
   title = "Derived From",
+  pagePanels,
+  pagePanelId,
 }) {
+  const isExpanded = pagePanels.isExpanded(pagePanelId);
+
   return (
     <>
       <DataAreaTitle>
-        {title}
-        {reportLink && reportLabel && (
+        <DataAreaTitle.Expander
+          pagePanels={pagePanels}
+          pagePanelId={pagePanelId}
+          label={`${title} table`}
+        >
+          {title}
+        </DataAreaTitle.Expander>
+        {reportLink && reportLabel && isExpanded && (
           <DataAreaTitleLink href={reportLink} label={reportLabel}>
             <TableCellsIcon className="h-4 w-4" />
           </DataAreaTitleLink>
         )}
       </DataAreaTitle>
-      <SortableGrid
-        data={derivedFrom}
-        columns={columns}
-        meta={{ derivedFromFileSets }}
-        pager={{}}
-        keyProp="@id"
-      />
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            className="overflow-hidden"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            transition={standardAnimationTransition}
+            variants={standardAnimationVariants}
+          >
+            <SortableGrid
+              data={derivedFrom}
+              columns={columns}
+              meta={{ derivedFromFileSets }}
+              pager={{}}
+              keyProp="@id"
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -99,4 +127,8 @@ DerivedFromTable.propTypes = {
   reportLabel: PropTypes.string,
   // Optional title to display if not "Derived From"
   title: PropTypes.string,
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this table, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
 };

--- a/components/document-table.js
+++ b/components/document-table.js
@@ -1,6 +1,11 @@
 // node_modules
+import { AnimatePresence, motion } from "framer-motion";
 import PropTypes from "prop-types";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import AttachmentThumbnail from "./attachment-thumbnail";
 import { DataAreaTitle } from "./data-area";
 import DocumentAttachmentLink from "./document-link";
@@ -63,11 +68,37 @@ const columns = [
  * Display the given documents in a table, useful for pages displaying objects containing document
  * arrays.
  */
-export default function DocumentTable({ documents, title = "Documents" }) {
+export default function DocumentTable({
+  documents,
+  title = "Documents",
+  pagePanels,
+  pagePanelId,
+}) {
   return (
     <>
-      <DataAreaTitle>{title}</DataAreaTitle>
-      <SortableGrid data={documents} columns={columns} pager={{}} />
+      <DataAreaTitle>
+        <DataAreaTitle.Expander
+          pagePanels={pagePanels}
+          pagePanelId={pagePanelId}
+          label={`${title} table`}
+        >
+          {title}
+        </DataAreaTitle.Expander>
+      </DataAreaTitle>
+      <AnimatePresence>
+        {pagePanels.isExpanded(pagePanelId) && (
+          <motion.div
+            className="overflow-hidden"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            transition={standardAnimationTransition}
+            variants={standardAnimationVariants}
+          >
+            <SortableGrid data={documents} columns={columns} pager={{}} />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -77,4 +108,8 @@ DocumentTable.propTypes = {
   documents: PropTypes.array.isRequired,
   // Title of the table if not "Documents"
   title: PropTypes.string,
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this table, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
 };

--- a/components/donor-table.js
+++ b/components/donor-table.js
@@ -1,7 +1,12 @@
 // node_modules
+import { AnimatePresence, motion } from "framer-motion";
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import PropTypes from "prop-types";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
@@ -40,18 +45,47 @@ export default function DonorTable({
   reportLink = null,
   reportLabel = null,
   title = "Donors",
+  pagePanels,
+  pagePanelId,
 }) {
+  const isExpanded = pagePanels.isExpanded(pagePanelId);
+
   return (
     <>
       <DataAreaTitle>
-        {title}
-        {reportLink && reportLabel && (
+        <DataAreaTitle.Expander
+          pagePanels={pagePanels}
+          pagePanelId={pagePanelId}
+          label={`${title} table`}
+        >
+          {title}
+        </DataAreaTitle.Expander>
+        {reportLink && reportLabel && isExpanded && (
           <DataAreaTitleLink href={reportLink} label={reportLabel}>
             <TableCellsIcon className="h-4 w-4" />
           </DataAreaTitleLink>
         )}
       </DataAreaTitle>
-      <SortableGrid data={donors} columns={columns} pager={{}} keyProp="@id" />
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            id={pagePanelId}
+            className="overflow-hidden"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            transition={standardAnimationTransition}
+            variants={standardAnimationVariants}
+          >
+            <SortableGrid
+              data={donors}
+              columns={columns}
+              pager={{}}
+              keyProp="@id"
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -65,4 +99,8 @@ DonorTable.propTypes = {
   reportLabel: PropTypes.string,
   // Optional title to display if not "Donors"
   title: PropTypes.string,
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this table, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
 };

--- a/components/file-set-files-tables.js
+++ b/components/file-set-files-tables.js
@@ -14,6 +14,7 @@ export default function FileSetFilesTables({
   fileSet,
   seqspecFiles,
   children,
+  pagePanels,
 }) {
   // Extract sequencing files from `files` and group them by characteristics to determine which
   // file table they should appear in, if any. Possible groups include:
@@ -55,6 +56,8 @@ export default function FileSetFilesTables({
           itemPath={fileSet["@id"]}
           seqspecFiles={seqspecFiles}
           hasReadType
+          pagePanels={pagePanels}
+          pagePanelId="sequencing-results-illumina"
         />
       )}
       {groupedFiles.sequencingOther?.length > 0 && (
@@ -64,11 +67,18 @@ export default function FileSetFilesTables({
           isIlluminaReadType={false}
           itemPath={fileSet["@id"]}
           seqspecFiles={seqspecFiles}
+          pagePanels={pagePanels}
+          pagePanelId="sequencing-results-non-illumina"
         />
       )}
       {children}
       {groupedFiles.other?.length > 0 && (
-        <FileTable files={groupedFiles.other} title="Other Raw Data Files" />
+        <FileTable
+          files={groupedFiles.other}
+          title="Other Raw Data Files"
+          pagePanels={pagePanels}
+          pagePanelId="other-raw-data-files"
+        />
       )}
     </>
   );
@@ -81,4 +91,6 @@ FileSetFilesTables.propTypes = {
   fileSet: PropTypes.object.isRequired,
   // seqspec files associated with the files
   seqspecFiles: PropTypes.arrayOf(PropTypes.object).isRequired,
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
 };

--- a/components/file-set-files-tables.js
+++ b/components/file-set-files-tables.js
@@ -13,9 +13,8 @@ export default function FileSetFilesTables({
   files = [],
   fileSet,
   seqspecFiles,
-  pagePanels,
-  isDefaultExpanded = false,
   children,
+  pagePanels,
 }) {
   // Extract sequencing files from `files` and group them by characteristics to determine which
   // file table they should appear in, if any. Possible groups include:
@@ -59,7 +58,6 @@ export default function FileSetFilesTables({
           hasReadType
           pagePanels={pagePanels}
           pagePanelId="sequencing-results-illumina"
-          isDefaultExpanded={isDefaultExpanded}
         />
       )}
       {groupedFiles.sequencingOther?.length > 0 && (
@@ -71,7 +69,6 @@ export default function FileSetFilesTables({
           seqspecFiles={seqspecFiles}
           pagePanels={pagePanels}
           pagePanelId="sequencing-results-non-illumina"
-          isDefaultExpanded={isDefaultExpanded}
         />
       )}
       {children}
@@ -81,7 +78,6 @@ export default function FileSetFilesTables({
           title="Other Raw Data Files"
           pagePanels={pagePanels}
           pagePanelId="other-raw-data-files"
-          isDefaultExpanded={isDefaultExpanded}
         />
       )}
     </>
@@ -97,6 +93,4 @@ FileSetFilesTables.propTypes = {
   seqspecFiles: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Expandable panels to determine if this table should appear collapsed or expanded
   pagePanels: PropTypes.object.isRequired,
-  // True if the tables should be expanded by default
-  isDefaultExpanded: PropTypes.bool,
 };

--- a/components/file-set-files-tables.js
+++ b/components/file-set-files-tables.js
@@ -14,7 +14,6 @@ export default function FileSetFilesTables({
   fileSet,
   seqspecFiles,
   children,
-  pagePanels,
 }) {
   // Extract sequencing files from `files` and group them by characteristics to determine which
   // file table they should appear in, if any. Possible groups include:
@@ -56,8 +55,6 @@ export default function FileSetFilesTables({
           itemPath={fileSet["@id"]}
           seqspecFiles={seqspecFiles}
           hasReadType
-          pagePanels={pagePanels}
-          pagePanelId="sequencing-results-illumina"
         />
       )}
       {groupedFiles.sequencingOther?.length > 0 && (
@@ -67,18 +64,11 @@ export default function FileSetFilesTables({
           isIlluminaReadType={false}
           itemPath={fileSet["@id"]}
           seqspecFiles={seqspecFiles}
-          pagePanels={pagePanels}
-          pagePanelId="sequencing-results-non-illumina"
         />
       )}
       {children}
       {groupedFiles.other?.length > 0 && (
-        <FileTable
-          files={groupedFiles.other}
-          title="Other Raw Data Files"
-          pagePanels={pagePanels}
-          pagePanelId="other-raw-data-files"
-        />
+        <FileTable files={groupedFiles.other} title="Other Raw Data Files" />
       )}
     </>
   );
@@ -91,6 +81,4 @@ FileSetFilesTables.propTypes = {
   fileSet: PropTypes.object.isRequired,
   // seqspec files associated with the files
   seqspecFiles: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Expandable panels to determine if this table should appear collapsed or expanded
-  pagePanels: PropTypes.object.isRequired,
 };

--- a/components/file-set-files-tables.js
+++ b/components/file-set-files-tables.js
@@ -13,8 +13,9 @@ export default function FileSetFilesTables({
   files = [],
   fileSet,
   seqspecFiles,
-  children,
   pagePanels,
+  isDefaultExpanded = false,
+  children,
 }) {
   // Extract sequencing files from `files` and group them by characteristics to determine which
   // file table they should appear in, if any. Possible groups include:
@@ -58,6 +59,7 @@ export default function FileSetFilesTables({
           hasReadType
           pagePanels={pagePanels}
           pagePanelId="sequencing-results-illumina"
+          isDefaultExpanded={isDefaultExpanded}
         />
       )}
       {groupedFiles.sequencingOther?.length > 0 && (
@@ -69,6 +71,7 @@ export default function FileSetFilesTables({
           seqspecFiles={seqspecFiles}
           pagePanels={pagePanels}
           pagePanelId="sequencing-results-non-illumina"
+          isDefaultExpanded={isDefaultExpanded}
         />
       )}
       {children}
@@ -78,6 +81,7 @@ export default function FileSetFilesTables({
           title="Other Raw Data Files"
           pagePanels={pagePanels}
           pagePanelId="other-raw-data-files"
+          isDefaultExpanded={isDefaultExpanded}
         />
       )}
     </>
@@ -93,4 +97,6 @@ FileSetFilesTables.propTypes = {
   seqspecFiles: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Expandable panels to determine if this table should appear collapsed or expanded
   pagePanels: PropTypes.object.isRequired,
+  // True if the tables should be expanded by default
+  isDefaultExpanded: PropTypes.bool,
 };

--- a/components/file-set-table.js
+++ b/components/file-set-table.js
@@ -1,9 +1,14 @@
 // node_modules
+import { AnimatePresence, motion } from "framer-motion";
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import Link from "next/link";
 import PropTypes from "prop-types";
 import { useContext } from "react";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import SeparatedList from "./separated-list";
@@ -121,25 +126,48 @@ export default function FileSetTable({
   reportLabel = "",
   title = "File Sets",
   fileSetMeta = null,
+  pagePanels,
+  pagePanelId,
 }) {
+  const isExpanded = pagePanels.isExpanded(pagePanelId);
   const { collectionTitles } = useContext(SessionContext);
+
   return (
     <>
       <DataAreaTitle>
-        {title}
-        {reportLink && (
+        <DataAreaTitle.Expander
+          pagePanels={pagePanels}
+          pagePanelId={pagePanelId}
+          label={`${title} table`}
+        >
+          {title}
+        </DataAreaTitle.Expander>
+        {reportLink && isExpanded && (
           <DataAreaTitleLink href={reportLink} label={reportLabel}>
             <TableCellsIcon className="h-4 w-4" />
           </DataAreaTitleLink>
         )}
       </DataAreaTitle>
-      <SortableGrid
-        data={fileSets}
-        columns={fileSetColumns}
-        keyProp="@id"
-        meta={{ fileSetMeta, collectionTitles }}
-        pager={{}}
-      />
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            className="overflow-hidden"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            transition={standardAnimationTransition}
+            variants={standardAnimationVariants}
+          >
+            <SortableGrid
+              data={fileSets}
+              columns={fileSetColumns}
+              keyProp="@id"
+              meta={{ fileSetMeta, collectionTitles }}
+              pager={{}}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -160,4 +188,8 @@ FileSetTable.propTypes = {
     // Function to filter the files to display
     fileFilter: PropTypes.func,
   }),
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this table, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
 };

--- a/components/file-table.js
+++ b/components/file-table.js
@@ -67,10 +67,10 @@ export default function FileTable({
   downloadQuery = null,
   isDownloadable = false,
   controllerContent = null,
-  pagePanels,
-  pagePanelId,
+  pagePanels = null,
+  pagePanelId = "",
 }) {
-  const isExpanded = pagePanels.isExpanded(pagePanelId);
+  const isExpanded = pagePanels?.isExpanded(pagePanelId) ?? true;
 
   // Compose the report link, either from the file set or the given link and label.
   const finalReportLink = fileSet
@@ -88,16 +88,29 @@ export default function FileTable({
       ? new FileSetController(fileSet, downloadQuery)
       : null;
 
+  const sortableGrid = (
+    <SortableGrid
+      data={files}
+      columns={filesColumns}
+      keyProp="@id"
+      pager={{}}
+    />
+  );
+
   return (
     <>
       <DataAreaTitle>
-        <DataAreaTitle.Expander
-          pagePanels={pagePanels}
-          pagePanelId={pagePanelId}
-          label={`${title} table`}
-        >
-          {title}
-        </DataAreaTitle.Expander>
+        {pagePanels ? (
+          <DataAreaTitle.Expander
+            pagePanels={pagePanels}
+            pagePanelId={pagePanelId}
+            label={`${title} table`}
+          >
+            {title}
+          </DataAreaTitle.Expander>
+        ) : (
+          title
+        )}
         {(controller || finalReportLink) && isExpanded && (
           <div className="align-center flex gap-1">
             {controller && (
@@ -116,25 +129,24 @@ export default function FileTable({
           </div>
         )}
       </DataAreaTitle>
-      <AnimatePresence>
-        {isExpanded && (
-          <motion.div
-            className="overflow-hidden"
-            initial="collapsed"
-            animate="open"
-            exit="collapsed"
-            transition={standardAnimationTransition}
-            variants={standardAnimationVariants}
-          >
-            <SortableGrid
-              data={files}
-              columns={filesColumns}
-              keyProp="@id"
-              pager={{}}
-            />
-          </motion.div>
-        )}
-      </AnimatePresence>
+      {pagePanels ? (
+        <AnimatePresence>
+          {isExpanded && (
+            <motion.div
+              className="overflow-hidden"
+              initial="collapsed"
+              animate="open"
+              exit="collapsed"
+              transition={standardAnimationTransition}
+              variants={standardAnimationVariants}
+            >
+              {sortableGrid}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      ) : (
+        <>{sortableGrid}</>
+      )}
     </>
   );
 }
@@ -157,7 +169,7 @@ FileTable.propTypes = {
   // Extra text or JSX content for the batch download controller
   controllerContent: PropTypes.node,
   // Expandable panels to determine if this table should appear collapsed or expanded
-  pagePanels: PropTypes.object.isRequired,
+  pagePanels: PropTypes.object,
   // ID of the panel that contains this table, unique on the page
-  pagePanelId: PropTypes.string.isRequired,
+  pagePanelId: PropTypes.string,
 };

--- a/components/file-table.js
+++ b/components/file-table.js
@@ -69,7 +69,6 @@ export default function FileTable({
   controllerContent = null,
   pagePanels,
   pagePanelId,
-  isDefaultExpanded = false,
 }) {
   const isExpanded = pagePanels.isExpanded(pagePanelId);
 
@@ -96,7 +95,6 @@ export default function FileTable({
           pagePanels={pagePanels}
           pagePanelId={pagePanelId}
           label={`${title} table`}
-          isDefaultExpanded={isDefaultExpanded}
         >
           {title}
         </DataAreaTitle.Expander>
@@ -162,6 +160,4 @@ FileTable.propTypes = {
   pagePanels: PropTypes.object.isRequired,
   // ID of the panel that contains this table, unique on the page
   pagePanelId: PropTypes.string.isRequired,
-  // True if the data area should appear expanded by default
-  isDefaultExpanded: PropTypes.bool,
 };

--- a/components/file-table.js
+++ b/components/file-table.js
@@ -69,6 +69,7 @@ export default function FileTable({
   controllerContent = null,
   pagePanels,
   pagePanelId,
+  isDefaultExpanded = false,
 }) {
   const isExpanded = pagePanels.isExpanded(pagePanelId);
 
@@ -95,6 +96,7 @@ export default function FileTable({
           pagePanels={pagePanels}
           pagePanelId={pagePanelId}
           label={`${title} table`}
+          isDefaultExpanded={isDefaultExpanded}
         >
           {title}
         </DataAreaTitle.Expander>
@@ -160,4 +162,6 @@ FileTable.propTypes = {
   pagePanels: PropTypes.object.isRequired,
   // ID of the panel that contains this table, unique on the page
   pagePanelId: PropTypes.string.isRequired,
+  // True if the data area should appear expanded by default
+  isDefaultExpanded: PropTypes.bool,
 };

--- a/components/modification-table.js
+++ b/components/modification-table.js
@@ -1,6 +1,11 @@
 // node_modules
+import { AnimatePresence, motion } from "framer-motion";
 import PropTypes from "prop-types";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import { DataAreaTitle } from "./data-area";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
@@ -25,15 +30,38 @@ const modificationsColumns = [
 export default function ModificationTable({
   modifications,
   title = "Modifications",
+  pagePanels,
+  pagePanelId,
 }) {
   return (
     <>
-      <DataAreaTitle>{title}</DataAreaTitle>
-      <SortableGrid
-        data={modifications}
-        columns={modificationsColumns}
-        keyProp="@id"
-      />
+      <DataAreaTitle>
+        <DataAreaTitle.Expander
+          pagePanels={pagePanels}
+          pagePanelId={pagePanelId}
+          label={`${title} table`}
+        >
+          {title}
+        </DataAreaTitle.Expander>
+      </DataAreaTitle>
+      <AnimatePresence>
+        {pagePanels.isExpanded(pagePanelId) && (
+          <motion.div
+            className="overflow-hidden"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            transition={standardAnimationTransition}
+            variants={standardAnimationVariants}
+          >
+            <SortableGrid
+              data={modifications}
+              columns={modificationsColumns}
+              keyProp="@id"
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -43,4 +71,8 @@ ModificationTable.propTypes = {
   modifications: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Title for the table if not "Modifications"
   title: PropTypes.string,
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this table, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
 };

--- a/components/page-panels.tsx
+++ b/components/page-panels.tsx
@@ -1,0 +1,158 @@
+// node_modules
+import { MinusIcon, PlusIcon } from "@heroicons/react/20/solid";
+import { ReactNode, useEffect, useRef } from "react";
+// components
+import { useSessionStorage } from "./browser-storage";
+
+/**
+ * Tracks the expanded/collapsed state of a panel on a page, with the panel ID as the key and its
+ * expanded state as the value. The panel ID has to be unique among all panels on a page. This
+ * object gets stored in session storage under a key unique to the page.
+ */
+type ExpandedPanelStates = Record<string, boolean>;
+
+/**
+ * Tracks the expanded/collapsed states of all panels on a page, as well as functions to set and get
+ * the expanded state of a panel, and to register a panel when its page gets rendered on page load.
+ * @property {string} pageId Unique ID of the page, often the `@id` of the page
+ * @property {ExpandedPanelStates} expandedPanels Expanded/collapsed states of all panels on a page
+ * @property {(panelId: string, expanded: boolean) => void} setExpanded Function to set the
+ *     expanded state of a panel
+ * @property {(panelId: string) => boolean} isExpanded Function to get the expanded state of a
+ *     panel
+ * @property {(panelId: string) => void} registerExpanded Function to register a panel by its ID
+ *     when its page gets rendered on page load. This lets us know all the panels on a page so that
+ *     the user can expand all of them at once if they want.
+ */
+type PagePanelStates = {
+  expandedPanels: ExpandedPanelStates;
+  setExpanded: (panelId: string, expanded: boolean) => void;
+  setAllExpanded: (expanded: boolean) => void;
+  isExpanded: (panelId: string) => boolean;
+  registerExpanded: (panelId: string) => void;
+};
+
+/**
+ * Custom hook to handle the expanded/collapsed states of panels on a page. Call this just once on
+ * a page that has collapsible panels. This hook will manage the expanded/collapsed states of all
+ * panels on the page. Use session storage to store the states of all collapsible panels on each
+ * page the user visits.
+ * @param {string} pageId Unique ID of the page, often the `@id` of object the page renders
+ */
+export function usePagePanels(pageId: string) {
+  // Collects all the panel IDs on the page when it first gets rendered so that the expanded panel
+  // states exist for every collapsible panel on the page.
+  const pagePanelIds = useRef<string[]>([]);
+
+  // Get the stored panel states from session storage for the currently viewed page.
+  const [storedPanelStates, setStoredPanelStates] = useSessionStorage(
+    `page-panel-expanded-${pageId}`,
+    JSON.stringify({})
+  );
+  const expandedPanelStates: ExpandedPanelStates =
+    JSON.parse(storedPanelStates);
+
+  function setExpanded(panelId: string, expanded: boolean) {
+    const newPagePanelStates = {
+      ...expandedPanelStates,
+      [panelId]: expanded,
+    };
+    setStoredPanelStates(JSON.stringify(newPagePanelStates));
+  }
+
+  function setAllExpanded(expanded: boolean) {
+    const newPagePanelStates = { ...expandedPanelStates };
+    pagePanelIds.current.forEach((panelId) => {
+      newPagePanelStates[panelId] = expanded;
+    });
+    setStoredPanelStates(JSON.stringify(newPagePanelStates));
+  }
+
+  function isExpanded(panelId: string) {
+    return expandedPanelStates[panelId] || false;
+  }
+
+  // `PagePanelButton` calls this function to register a panel when its page gets rendered on page
+  // load. The component that renders the panel only has to call the `PagePanelButton` component
+  // for this registration to happen, instead of calling this function directly.
+  function registerExpanded(panelId: string) {
+    if (!pagePanelIds.current.includes(panelId)) {
+      pagePanelIds.current.push(panelId);
+    }
+  }
+
+  useEffect(() => {
+    if (Object.keys(expandedPanelStates).length !== 0) {
+      // For each page panel ID that doesn't already have a state, set it to collapsed. Then save
+      // the new state to session storage.
+      const newPagePanelStates = { ...expandedPanelStates };
+      pagePanelIds.current.forEach((panelId) => {
+        if (!newPagePanelStates[panelId]) {
+          newPagePanelStates[panelId] = false;
+        }
+      });
+      setStoredPanelStates(JSON.stringify(newPagePanelStates));
+    }
+  }, [storedPanelStates]);
+
+  return {
+    expandedPanels: expandedPanelStates,
+    setExpanded,
+    setAllExpanded,
+    isExpanded,
+    registerExpanded,
+  } as PagePanelStates;
+}
+
+/**
+ * Button to expand/collapse a page panel. Use the title of the panel as the child of this
+ * component.
+ * @param {PagePanelStates} pagePanels The page panels controller
+ * @param {string} pagePanelId The ID of the panel unique on the page
+ * @param {string} label The accessible label for the button used by screen readers
+ * @param {ReactNode} children The title of the panel
+ */
+export function PagePanelButton({
+  pagePanels,
+  pagePanelId,
+  label,
+  children,
+}: {
+  pagePanels: PagePanelStates;
+  pagePanelId: string;
+  label: string;
+  children?: ReactNode;
+}) {
+  const isExpanded = pagePanels.isExpanded(pagePanelId);
+
+  // Register the panel when the page gets rendered on page load so that the expanded panel states
+  // exist for every collapsible panel on the page.
+  pagePanels.registerExpanded(pagePanelId);
+
+  // Handle a click in the button to expand/collapse the panel. If the user was holding down the
+  // control or alt key, expand/collapse all panels on the page.
+  function handleClick(event: React.MouseEvent<HTMLButtonElement>) {
+    if (event.ctrlKey || event.altKey) {
+      pagePanels.setAllExpanded(!isExpanded);
+    } else {
+      pagePanels.setExpanded(pagePanelId, !isExpanded);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      aria-expanded={pagePanels.expandedPanels[pagePanelId]}
+      aria-controls={pagePanelId}
+      aria-label={label}
+      className="flex items-center gap-1"
+    >
+      {isExpanded ? (
+        <MinusIcon className="h-6 w-6" />
+      ) : (
+        <PlusIcon className="h-6 w-6" />
+      )}
+      {children}
+    </button>
+  );
+}

--- a/components/page-panels.tsx
+++ b/components/page-panels.tsx
@@ -1,8 +1,6 @@
 // node_modules
 import { MinusIcon, PlusIcon } from "@heroicons/react/20/solid";
-import { ReactNode, useEffect, useRef } from "react";
-// components
-import { useSessionStorage } from "./browser-storage";
+import { ReactNode, useEffect, useRef, useState } from "react";
 
 /**
  * Tracks the expanded/collapsed state of a panel on a page, with the panel ID as the key and its
@@ -21,82 +19,76 @@ type ExpandedPanelStates = Record<string, boolean>;
  * @property {(panelId: string) => boolean} isExpanded Function to get the expanded state of a
  *     panel
  * @property {(panelId: string) => void} registerExpanded Function to register a panel by its ID
- *     when its page gets rendered on page load. This lets us know all the panels on a page so that
- *     the user can expand all of them at once if they want.
+ *     when its page gets rendered on page load. This lets us know all the panels on a page without
+ *     setting a React state during render. This also lets the user expand all of them at once if
+ *     they want.
  */
 type PagePanelStates = {
   expandedPanels: ExpandedPanelStates;
   setExpanded: (panelId: string, expanded: boolean) => void;
   setAllExpanded: (expanded: boolean) => void;
   isExpanded: (panelId: string) => boolean;
-  registerExpanded: (panelId: string) => void;
+  registerExpanded: (panelId: string, isExpanded: boolean) => void;
 };
 
 /**
  * Custom hook to handle the expanded/collapsed states of panels on a page. Call this just once on
  * a page that has collapsible panels. This hook will manage the expanded/collapsed states of all
- * panels on the page. Use session storage to store the states of all collapsible panels on each
- * page the user visits.
- * @param {string} pageId Unique ID of the page, often the `@id` of object the page renders
+ * panels on the page.
+ * @returns {PagePanelStates} Object with the expanded/collapsed states of all panels on the page,
+ *    as well as functions to set and get the expanded state of a panel, and to register a panel
+ *    when its page gets rendered on page load.
  */
-export function usePagePanels(pageId: string) {
+export function usePagePanels() {
   // Collects all the panel IDs on the page when it first gets rendered so that the expanded panel
   // states exist for every collapsible panel on the page.
-  const pagePanelIds = useRef<string[]>([]);
+  const pagePanelIds = useRef<ExpandedPanelStates>({});
 
   // Get the stored panel states from session storage for the currently viewed page.
-  const [storedPanelStates, setStoredPanelStates] = useSessionStorage(
-    `page-panel-expanded-${pageId}`,
-    JSON.stringify({})
-  );
-  const expandedPanelStates: ExpandedPanelStates =
-    JSON.parse(storedPanelStates);
+  const [panelStates, setPanelStates] = useState<ExpandedPanelStates>({});
 
   function setExpanded(panelId: string, expanded: boolean) {
-    const newPagePanelStates = {
-      ...expandedPanelStates,
+    const newPagePanelStates: ExpandedPanelStates = {
+      ...panelStates,
       [panelId]: expanded,
     };
-    setStoredPanelStates(JSON.stringify(newPagePanelStates));
+    setPanelStates(newPagePanelStates);
   }
 
   function setAllExpanded(expanded: boolean) {
-    const newPagePanelStates = { ...expandedPanelStates };
-    pagePanelIds.current.forEach((panelId) => {
+    const newPagePanelStates = { ...panelStates };
+    Object.keys(panelStates).forEach((panelId) => {
       newPagePanelStates[panelId] = expanded;
     });
-    setStoredPanelStates(JSON.stringify(newPagePanelStates));
+    setPanelStates(newPagePanelStates);
   }
 
   function isExpanded(panelId: string) {
-    return expandedPanelStates[panelId] || false;
+    return panelStates[panelId] || false;
   }
 
-  // `PagePanelButton` calls this function to register a panel when its page gets rendered on page
-  // load. The component that renders the panel only has to call the `PagePanelButton` component
-  // for this registration to happen, instead of calling this function directly.
-  function registerExpanded(panelId: string) {
-    if (!pagePanelIds.current.includes(panelId)) {
-      pagePanelIds.current.push(panelId);
+  function registerExpanded(panelId: string, isExpanded = false) {
+    // Check if the panel is already registered. If not, add it to the list of
+    // panel IDs for this page.
+    if (!pagePanelIds.current[panelId]) {
+      pagePanelIds.current[panelId] = isExpanded;
     }
   }
 
   useEffect(() => {
-    if (Object.keys(expandedPanelStates).length !== 0) {
-      // For each page panel ID that doesn't already have a state, set it to collapsed. Then save
-      // the new state to session storage.
-      const newPagePanelStates = { ...expandedPanelStates };
-      pagePanelIds.current.forEach((panelId) => {
-        if (!newPagePanelStates[panelId]) {
-          newPagePanelStates[panelId] = false;
-        }
-      });
-      setStoredPanelStates(JSON.stringify(newPagePanelStates));
-    }
-  }, [storedPanelStates]);
+    // Set the expanded panels states based on `pagePanelIds` when the page first gets rendered.
+    const newPagePanelStates = { ...panelStates };
+    Object.entries(pagePanelIds.current).forEach(([panelId, isExpanded]) => {
+      if (!newPagePanelStates[panelId]) {
+        newPagePanelStates[panelId] = isExpanded;
+      }
+    });
+    pagePanelIds.current = {};
+    setPanelStates(newPagePanelStates);
+  }, []);
 
   return {
-    expandedPanels: expandedPanelStates,
+    expandedPanels: panelStates,
     setExpanded,
     setAllExpanded,
     isExpanded,
@@ -110,24 +102,27 @@ export function usePagePanels(pageId: string) {
  * @param {PagePanelStates} pagePanels The page panels controller
  * @param {string} pagePanelId The ID of the panel unique on the page
  * @param {string} label The accessible label for the button used by screen readers
+ * @param {boolean} [isDefaultExpanded] Whether the panel is expanded by default
  * @param {ReactNode} children The title of the panel
  */
 export function PagePanelButton({
   pagePanels,
   pagePanelId,
   label,
+  isDefaultExpanded = false,
   children,
 }: {
   pagePanels: PagePanelStates;
   pagePanelId: string;
   label: string;
+  isDefaultExpanded?: boolean;
   children?: ReactNode;
 }) {
   const isExpanded = pagePanels.isExpanded(pagePanelId);
 
   // Register the panel when the page gets rendered on page load so that the expanded panel states
   // exist for every collapsible panel on the page.
-  pagePanels.registerExpanded(pagePanelId);
+  pagePanels.registerExpanded(pagePanelId, isDefaultExpanded);
 
   // Handle a click in the button to expand/collapse the panel. If the user was holding down the
   // control or alt key, expand/collapse all panels on the page.

--- a/components/phenotypic-feature-table.js
+++ b/components/phenotypic-feature-table.js
@@ -1,7 +1,12 @@
 // node_modules
+import { AnimatePresence, motion } from "framer-motion";
 import Link from "next/link";
 import PropTypes from "prop-types";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import { DataAreaTitle } from "./data-area";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
@@ -154,16 +159,39 @@ function quantitySortingCode(quantity, quantityUnits) {
 export default function PhenotypicFeatureTable({
   phenotypicFeatures,
   title = "Phenotypic Features",
+  pagePanels,
+  pagePanelId,
 }) {
   return (
     <>
-      <DataAreaTitle>{title}</DataAreaTitle>
-      <SortableGrid
-        data={phenotypicFeatures}
-        columns={phenotypicFeaturesColumns}
-        pager={{}}
-        keyProp="@id"
-      />
+      <DataAreaTitle>
+        <DataAreaTitle.Expander
+          pagePanels={pagePanels}
+          pagePanelId={pagePanelId}
+          label={`${title} table`}
+        >
+          {title}
+        </DataAreaTitle.Expander>
+      </DataAreaTitle>
+      <AnimatePresence>
+        {pagePanels.isExpanded(pagePanelId) && (
+          <motion.div
+            className="overflow-hidden"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            transition={standardAnimationTransition}
+            variants={standardAnimationVariants}
+          >
+            <SortableGrid
+              data={phenotypicFeatures}
+              columns={phenotypicFeaturesColumns}
+              pager={{}}
+              keyProp="@id"
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -173,4 +201,8 @@ PhenotypicFeatureTable.propTypes = {
   phenotypicFeatures: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Title of the table if not "Phenotypic Features"
   title: PropTypes.string,
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this table, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
 };

--- a/components/related-donors-table.js
+++ b/components/related-donors-table.js
@@ -1,6 +1,11 @@
 // node_modules
+import { AnimatePresence, motion } from "framer-motion";
 import PropTypes from "prop-types";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import { DataAreaTitle } from "./data-area";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
@@ -57,16 +62,39 @@ export default function RelatedDonorsTable({
   relatedDonors,
   embeddedDonors,
   title = "Related Donors",
+  pagePanels,
+  pagePanelId,
 }) {
   return (
     <>
-      <DataAreaTitle>{title}</DataAreaTitle>
-      <SortableGrid
-        data={relatedDonors}
-        columns={relatedDonorsColumns}
-        meta={{ embeddedDonors }}
-        pager={{}}
-      />
+      <DataAreaTitle>
+        <DataAreaTitle.Expander
+          pagePanels={pagePanels}
+          pagePanelId={pagePanelId}
+          label={`${title} table`}
+        >
+          {title}
+        </DataAreaTitle.Expander>
+      </DataAreaTitle>
+      <AnimatePresence>
+        {pagePanels.isExpanded(pagePanelId) && (
+          <motion.div
+            className="overflow-hidden"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            transition={standardAnimationTransition}
+            variants={standardAnimationVariants}
+          >
+            <SortableGrid
+              data={relatedDonors}
+              columns={relatedDonorsColumns}
+              meta={{ embeddedDonors }}
+              pager={{}}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -78,4 +106,8 @@ RelatedDonorsTable.propTypes = {
   embeddedDonors: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Title of the table if not "Related Donors"
   title: PropTypes.string,
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this table, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
 };

--- a/components/sample-table.js
+++ b/components/sample-table.js
@@ -1,10 +1,15 @@
 // node_modules
+import { AnimatePresence, motion } from "framer-motion";
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import _ from "lodash";
 import Link from "next/link";
 import PropTypes from "prop-types";
 import { useContext } from "react";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import SeparatedList from "./separated-list";
@@ -96,26 +101,48 @@ export default function SampleTable({
   reportLink = null,
   reportLabel = null,
   title = "Samples",
+  pagePanels,
+  pagePanelId,
 }) {
+  const isExpanded = pagePanels.isExpanded(pagePanelId);
   const { collectionTitles } = useContext(SessionContext);
 
   return (
     <>
       <DataAreaTitle>
-        {title}
-        {reportLink && reportLabel && (
+        <DataAreaTitle.Expander
+          pagePanels={pagePanels}
+          pagePanelId={pagePanelId}
+          label={`${title} table`}
+        >
+          {title}
+        </DataAreaTitle.Expander>
+        {reportLink && reportLabel && isExpanded && (
           <DataAreaTitleLink href={reportLink} label={reportLabel}>
             <TableCellsIcon className="h-4 w-4" />
           </DataAreaTitleLink>
         )}
       </DataAreaTitle>
-      <SortableGrid
-        data={samples}
-        columns={sampleColumns}
-        keyProp="@id"
-        meta={{ collectionTitles }}
-        pager={{}}
-      />
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            className="overflow-hidden"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            transition={standardAnimationTransition}
+            variants={standardAnimationVariants}
+          >
+            <SortableGrid
+              data={samples}
+              columns={sampleColumns}
+              keyProp="@id"
+              meta={{ collectionTitles }}
+              pager={{}}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -129,4 +156,8 @@ SampleTable.propTypes = {
   reportLabel: PropTypes.string,
   // Title of the table if not "Samples"
   title: PropTypes.string,
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this table, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
 };

--- a/components/sequencing-file-table.js
+++ b/components/sequencing-file-table.js
@@ -1,9 +1,14 @@
 // node_modules
+import { AnimatePresence, motion } from "framer-motion";
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import _ from "lodash";
 import Link from "next/link";
 import PropTypes from "prop-types";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import { FileAccessionAndDownload } from "./file-download";
 import SortableGrid from "./sortable-grid";
@@ -125,7 +130,11 @@ export default function SequencingFileTable({
   seqspecFiles = [],
   hasReadType = false,
   isSeqspecHidden = false,
+  pagePanels,
+  pagePanelId,
 }) {
+  const isExpanded = pagePanels.isExpanded(pagePanelId);
+
   // True or false isIlluminaReadType adds a positive or negative `illumina_read_type` selector to
   // the report link. Undefined generates no `illumina_read_type` selector in the file query string.
   let illuminaSelector = "";
@@ -144,8 +153,14 @@ export default function SequencingFileTable({
   return (
     <>
       <DataAreaTitle>
-        {title}
-        {reportLink && (
+        <DataAreaTitle.Expander
+          pagePanels={pagePanels}
+          pagePanelId={pagePanelId}
+          label={`${title} table`}
+        >
+          {title}
+        </DataAreaTitle.Expander>
+        {reportLink && isExpanded && (
           <DataAreaTitleLink
             href={reportLink}
             label="Report of files that have this item as their file set"
@@ -154,17 +169,30 @@ export default function SequencingFileTable({
           </DataAreaTitleLink>
         )}
       </DataAreaTitle>
-      <SortableGrid
-        data={files}
-        columns={filesColumns}
-        pager={{}}
-        meta={{
-          seqspecFiles,
-          hasReadType,
-          isSeqspecHidden,
-        }}
-        keyProp="@id"
-      />
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            className="overflow-hidden"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            transition={standardAnimationTransition}
+            variants={standardAnimationVariants}
+          >
+            <SortableGrid
+              data={files}
+              columns={filesColumns}
+              pager={{}}
+              meta={{
+                seqspecFiles,
+                hasReadType,
+                isSeqspecHidden,
+              }}
+              keyProp="@id"
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -186,4 +214,8 @@ SequencingFileTable.propTypes = {
   hasReadType: PropTypes.bool,
   // True to hide the seqspec column
   isSeqspecHidden: PropTypes.bool,
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this table, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
 };

--- a/components/sequencing-file-table.js
+++ b/components/sequencing-file-table.js
@@ -132,6 +132,7 @@ export default function SequencingFileTable({
   isSeqspecHidden = false,
   pagePanels,
   pagePanelId,
+  isDefaultExpanded = false,
 }) {
   const isExpanded = pagePanels.isExpanded(pagePanelId);
 
@@ -157,6 +158,7 @@ export default function SequencingFileTable({
           pagePanels={pagePanels}
           pagePanelId={pagePanelId}
           label={`${title} table`}
+          isDefaultExpanded={isDefaultExpanded}
         >
           {title}
         </DataAreaTitle.Expander>
@@ -218,4 +220,6 @@ SequencingFileTable.propTypes = {
   pagePanels: PropTypes.object.isRequired,
   // ID of the panel that contains this table, unique on the page
   pagePanelId: PropTypes.string.isRequired,
+  // True if the table should be expanded by default
+  isDefaultExpanded: PropTypes.bool,
 };

--- a/components/sequencing-file-table.js
+++ b/components/sequencing-file-table.js
@@ -132,7 +132,6 @@ export default function SequencingFileTable({
   isSeqspecHidden = false,
   pagePanels,
   pagePanelId,
-  isDefaultExpanded = false,
 }) {
   const isExpanded = pagePanels.isExpanded(pagePanelId);
 
@@ -158,7 +157,6 @@ export default function SequencingFileTable({
           pagePanels={pagePanels}
           pagePanelId={pagePanelId}
           label={`${title} table`}
-          isDefaultExpanded={isDefaultExpanded}
         >
           {title}
         </DataAreaTitle.Expander>
@@ -220,6 +218,4 @@ SequencingFileTable.propTypes = {
   pagePanels: PropTypes.object.isRequired,
   // ID of the panel that contains this table, unique on the page
   pagePanelId: PropTypes.string.isRequired,
-  // True if the table should be expanded by default
-  isDefaultExpanded: PropTypes.bool,
 };

--- a/components/sequencing-file-table.js
+++ b/components/sequencing-file-table.js
@@ -133,7 +133,7 @@ export default function SequencingFileTable({
   pagePanels,
   pagePanelId,
 }) {
-  const isExpanded = pagePanels.isExpanded(pagePanelId);
+  const isExpanded = pagePanels?.isExpanded(pagePanelId) ?? true;
 
   // True or false isIlluminaReadType adds a positive or negative `illumina_read_type` selector to
   // the report link. Undefined generates no `illumina_read_type` selector in the file query string.
@@ -150,16 +150,34 @@ export default function SequencingFileTable({
       )}${illuminaSelector}`
     : "";
 
+  const sortableGrid = (
+    <SortableGrid
+      data={files}
+      columns={filesColumns}
+      pager={{}}
+      meta={{
+        seqspecFiles,
+        hasReadType,
+        isSeqspecHidden,
+      }}
+      keyProp="@id"
+    />
+  );
+
   return (
     <>
       <DataAreaTitle>
-        <DataAreaTitle.Expander
-          pagePanels={pagePanels}
-          pagePanelId={pagePanelId}
-          label={`${title} table`}
-        >
-          {title}
-        </DataAreaTitle.Expander>
+        {pagePanels ? (
+          <DataAreaTitle.Expander
+            pagePanels={pagePanels}
+            pagePanelId={pagePanelId}
+            label={`${title} table`}
+          >
+            {title}
+          </DataAreaTitle.Expander>
+        ) : (
+          title
+        )}
         {reportLink && isExpanded && (
           <DataAreaTitleLink
             href={reportLink}
@@ -169,30 +187,24 @@ export default function SequencingFileTable({
           </DataAreaTitleLink>
         )}
       </DataAreaTitle>
-      <AnimatePresence>
-        {isExpanded && (
-          <motion.div
-            className="overflow-hidden"
-            initial="collapsed"
-            animate="open"
-            exit="collapsed"
-            transition={standardAnimationTransition}
-            variants={standardAnimationVariants}
-          >
-            <SortableGrid
-              data={files}
-              columns={filesColumns}
-              pager={{}}
-              meta={{
-                seqspecFiles,
-                hasReadType,
-                isSeqspecHidden,
-              }}
-              keyProp="@id"
-            />
-          </motion.div>
-        )}
-      </AnimatePresence>
+      {pagePanels ? (
+        <AnimatePresence>
+          {isExpanded && (
+            <motion.div
+              className="overflow-hidden"
+              initial="collapsed"
+              animate="open"
+              exit="collapsed"
+              transition={standardAnimationTransition}
+              variants={standardAnimationVariants}
+            >
+              {sortableGrid}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      ) : (
+        <>{sortableGrid}</>
+      )}
     </>
   );
 }

--- a/components/software-table.js
+++ b/components/software-table.js
@@ -1,7 +1,12 @@
 // node_modules
+import { AnimatePresence, motion } from "framer-motion";
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import PropTypes from "prop-types";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
@@ -55,23 +60,46 @@ export default function SoftwareTable({
   reportLink = null,
   reportLabel = null,
   title = "Software",
+  pagePanels,
+  pagePanelId,
 }) {
+  const isExpanded = pagePanels.isExpanded(pagePanelId);
+
   return (
     <>
       <DataAreaTitle>
-        {title}
-        {reportLink && reportLabel && (
+        <DataAreaTitle.Expander
+          pagePanels={pagePanels}
+          pagePanelId={pagePanelId}
+          label={`${title} table`}
+        >
+          {title}
+        </DataAreaTitle.Expander>
+        {reportLink && reportLabel && isExpanded && (
           <DataAreaTitleLink href={reportLink} label={reportLabel}>
             <TableCellsIcon className="h-4 w-4" />
           </DataAreaTitleLink>
         )}
       </DataAreaTitle>
-      <SortableGrid
-        data={software}
-        columns={columns}
-        pager={{}}
-        keyProp="@id"
-      />
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            className="overflow-hidden"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            transition={standardAnimationTransition}
+            variants={standardAnimationVariants}
+          >
+            <SortableGrid
+              data={software}
+              columns={columns}
+              pager={{}}
+              keyProp="@id"
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -85,4 +113,8 @@ SoftwareTable.propTypes = {
   reportLabel: PropTypes.string,
   // Optional title to display if not "Software"
   title: PropTypes.string,
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this table, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
 };

--- a/components/software-version-table.js
+++ b/components/software-version-table.js
@@ -1,7 +1,12 @@
 // node_modules
+import { AnimatePresence, motion } from "framer-motion";
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import PropTypes from "prop-types";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
@@ -47,18 +52,41 @@ export default function SoftwareVersionTable({
   reportLink = null,
   reportLabel = null,
   title = "Software Versions",
+  pagePanels,
+  pagePanelId,
 }) {
+  const isExpanded = pagePanels.isExpanded(pagePanelId);
+
   return (
     <>
       <DataAreaTitle>
-        {title}
-        {reportLink && reportLabel && (
+        <DataAreaTitle.Expander
+          pagePanels={pagePanels}
+          pagePanelId={pagePanelId}
+          label={`${title} table`}
+        >
+          {title}
+        </DataAreaTitle.Expander>
+        {reportLink && reportLabel && isExpanded && (
           <DataAreaTitleLink href={reportLink} label={reportLabel}>
             <TableCellsIcon className="h-4 w-4" />
           </DataAreaTitleLink>
         )}
       </DataAreaTitle>
-      <SortableGrid data={versions} columns={columns} pager={{}} />
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            className="overflow-hidden"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            transition={standardAnimationTransition}
+            variants={standardAnimationVariants}
+          >
+            <SortableGrid data={versions} columns={columns} pager={{}} />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -72,4 +100,8 @@ SoftwareVersionTable.propTypes = {
   reportLabel: PropTypes.string,
   // Title for the table if not "Software Versions"
   title: PropTypes.string,
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this table, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
 };

--- a/components/treatment-table.js
+++ b/components/treatment-table.js
@@ -1,7 +1,12 @@
 // node_modules
+import { AnimatePresence, motion } from "framer-motion";
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import PropTypes from "prop-types";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
@@ -42,23 +47,46 @@ export default function TreatmentTable({
   reportLink = null,
   reportLabel = null,
   title = "Treatments",
+  pagePanels,
+  pagePanelId,
 }) {
+  const isExpanded = pagePanels.isExpanded(pagePanelId);
+
   return (
     <>
       <DataAreaTitle>
-        {title}
-        {reportLink && reportLabel && (
+        <DataAreaTitle.Expander
+          pagePanels={pagePanels}
+          pagePanelId={pagePanelId}
+          label={`${title} table`}
+        >
+          {title}
+        </DataAreaTitle.Expander>
+        {reportLink && reportLabel && isExpanded && (
           <DataAreaTitleLink href={reportLink} label={reportLabel}>
             <TableCellsIcon className="h-4 w-4" />
           </DataAreaTitleLink>
         )}
       </DataAreaTitle>
-      <SortableGrid
-        data={treatments}
-        columns={treatmentColumns}
-        pager={{}}
-        keyProp="@id"
-      />
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            className="overflow-hidden"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            transition={standardAnimationTransition}
+            variants={standardAnimationVariants}
+          >
+            <SortableGrid
+              data={treatments}
+              columns={treatmentColumns}
+              pager={{}}
+              keyProp="@id"
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -72,4 +100,8 @@ TreatmentTable.propTypes = {
   reportLabel: PropTypes.string,
   // Optional title to display if not "Treatments"
   title: PropTypes.string,
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this table, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
 };

--- a/components/workflow-table.js
+++ b/components/workflow-table.js
@@ -1,7 +1,12 @@
 // node_modules
+import { AnimatePresence, motion } from "framer-motion";
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import PropTypes from "prop-types";
 // components
+import {
+  standardAnimationTransition,
+  standardAnimationVariants,
+} from "./animation";
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
@@ -51,23 +56,46 @@ export default function WorkflowTable({
   reportLink = null,
   reportLabel = null,
   title = "Workflows",
+  pagePanels,
+  pagePanelId,
 }) {
+  const isExpanded = pagePanels.isExpanded(pagePanelId);
+
   return (
     <>
       <DataAreaTitle>
-        {title}
-        {reportLink && reportLabel && (
+        <DataAreaTitle.Expander
+          pagePanels={pagePanels}
+          pagePanelId={pagePanelId}
+          label={`${title} table`}
+        >
+          {title}
+        </DataAreaTitle.Expander>
+        {reportLink && reportLabel && isExpanded && (
           <DataAreaTitleLink href={reportLink} label={reportLabel}>
             <TableCellsIcon className="h-4 w-4" />
           </DataAreaTitleLink>
         )}
       </DataAreaTitle>
-      <SortableGrid
-        data={workflows}
-        columns={columns}
-        pager={{}}
-        keyProp="@id"
-      />
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            className="overflow-hidden"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            transition={standardAnimationTransition}
+            variants={standardAnimationVariants}
+          >
+            <SortableGrid
+              data={workflows}
+              columns={columns}
+              pager={{}}
+              keyProp="@id"
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -81,4 +109,8 @@ WorkflowTable.propTypes = {
   reportLabel: PropTypes.string,
   // Optional title to display if not "Workflows"
   title: PropTypes.string,
+  // Expandable panels to determine if this table should appear collapsed or expanded
+  pagePanels: PropTypes.object.isRequired,
+  // ID of the panel that contains this table, unique on the page
+  pagePanelId: PropTypes.string.isRequired,
 };

--- a/cypress/e2e/documents.cy.js
+++ b/cypress/e2e/documents.cy.js
@@ -30,6 +30,7 @@ describe("Must sign in to see current document objects", () => {
       "http://localhost:3000/treatments/10c05ac0-52a2-11e6-bdf4-0800200c9a66/"
     );
     cy.contains("Cypress Testing");
+    cy.get(`[aria-label="Documents table"]`).click();
     cy.get("[role=table]").find("[aria-label^=Download]");
   });
 });

--- a/pages/alignment-files/[...id].js
+++ b/pages/alignment-files/[...id].js
@@ -20,6 +20,7 @@ import { FileHeaderDownload } from "../../components/file-download";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SeparatedList from "../../components/separated-list";
 // lib
@@ -48,6 +49,8 @@ export default function AlignmentFile({
   referenceFiles,
   isJson,
 }) {
+  const pagePanels = usePagePanels(alignmentFile["@id"]);
+
   return (
     <>
       <Breadcrumbs item={alignmentFile} />
@@ -110,8 +113,10 @@ export default function AlignmentFile({
               derivedFrom={derivedFrom}
               derivedFromFileSets={derivedFromFileSets}
               reportLink={`/multireport/?type=File&input_file_for=${alignmentFile["@id"]}`}
-              reportLabel={`Report of files ${alignmentFile.accession} derives from`}
+              reportLabel="Report of files that this file derives from"
               title="Files This File Derives From"
+              pagePanels={pagePanels}
+              pagePanelId="derived-from"
             />
           )}
           {inputFileFor.length > 0 && (
@@ -120,15 +125,25 @@ export default function AlignmentFile({
               reportLink={`/multireport/?type=File&derived_from=${alignmentFile["@id"]}`}
               reportLabel="Report of files derived from this file"
               title="Files Derived From This File"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-for"
             />
           )}
           {fileFormatSpecifications.length > 0 && (
             <DocumentTable
               documents={fileFormatSpecifications}
               title="File Format Specifications"
+              pagePanels={pagePanels}
+              pagePanelId="file-format-docs"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/alignment-files/[...id].js
+++ b/pages/alignment-files/[...id].js
@@ -49,7 +49,7 @@ export default function AlignmentFile({
   referenceFiles,
   isJson,
 }) {
-  const pagePanels = usePagePanels(alignmentFile["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/alignment-files/[...id].js
+++ b/pages/alignment-files/[...id].js
@@ -49,7 +49,7 @@ export default function AlignmentFile({
   referenceFiles,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(alignmentFile["@id"]);
 
   return (
     <>

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -57,7 +57,7 @@ export default function AnalysisSet({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(analysisSet["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>
@@ -164,6 +164,7 @@ export default function AnalysisSet({
               isDownloadable
               pagePanels={pagePanels}
               pagePanelId="file-table"
+              isDefaultExpanded
             />
           )}
 

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -158,13 +158,7 @@ export default function AnalysisSet({
           </DataPanel>
 
           {files.length > 0 && (
-            <FileTable
-              files={files}
-              fileSet={analysisSet}
-              isDownloadable
-              pagePanels={pagePanels}
-              pagePanelId="file-table"
-            />
+            <FileTable files={files} fileSet={analysisSet} isDownloadable />
           )}
 
           {analysisSet.samples?.length > 0 && (

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -24,6 +24,7 @@ import FileTable from "../../components/file-table";
 import InputFileSets from "../../components/input-file-sets";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -56,6 +57,8 @@ export default function AnalysisSet({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(analysisSet["@id"]);
+
   return (
     <>
       <Breadcrumbs item={analysisSet} />
@@ -155,7 +158,13 @@ export default function AnalysisSet({
           </DataPanel>
 
           {files.length > 0 && (
-            <FileTable files={files} fileSet={analysisSet} isDownloadable />
+            <FileTable
+              files={files}
+              fileSet={analysisSet}
+              isDownloadable
+              pagePanels={pagePanels}
+              pagePanelId="file-table"
+            />
           )}
 
           {analysisSet.samples?.length > 0 && (
@@ -163,11 +172,17 @@ export default function AnalysisSet({
               samples={analysisSet.samples}
               reportLink={`/multireport/?type=Sample&file_sets.@id=${analysisSet["@id"]}`}
               reportLabel="Report of samples in this analysis set"
+              pagePanels={pagePanels}
+              pagePanelId="sample-table"
             />
           )}
 
           {analysisSet.donors?.length > 0 && (
-            <DonorTable donors={analysisSet.donors} />
+            <DonorTable
+              donors={analysisSet.donors}
+              pagePanels={pagePanels}
+              pagePanelId="donors"
+            />
           )}
 
           {inputFileSets.length > 0 && (
@@ -180,6 +195,8 @@ export default function AnalysisSet({
               auxiliarySets={auxiliarySets}
               measurementSets={measurementSets}
               constructLibrarySets={constructLibrarySets}
+              pagePanels={pagePanels}
+              pagePanelId="analysis-set-input-file-sets"
             />
           )}
 
@@ -189,6 +206,8 @@ export default function AnalysisSet({
               reportLink={`/multireport/?type=FileSet&input_file_sets.@id=${analysisSet["@id"]}`}
               reportLabel="Report of file sets that this analysis set is an input for"
               title="File Sets Using This Analysis Set as an Input"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-set-for"
             />
           )}
 
@@ -198,10 +217,19 @@ export default function AnalysisSet({
               reportLink={`/multireport/?type=FileSet&control_file_sets.@id=${analysisSet["@id"]}`}
               reportLabel="Report of file sets that this analysis set serves as a control for"
               title="File Sets Controlled by This Analysis Set"
+              pagePanels={pagePanels}
+              pagePanelId="control-for"
             />
           )}
 
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
+
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -57,7 +57,7 @@ export default function AnalysisSet({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(analysisSet["@id"]);
 
   return (
     <>
@@ -164,7 +164,6 @@ export default function AnalysisSet({
               isDownloadable
               pagePanels={pagePanels}
               pagePanelId="file-table"
-              isDefaultExpanded
             />
           )}
 

--- a/pages/auxiliary-sets/[id].js
+++ b/pages/auxiliary-sets/[id].js
@@ -43,7 +43,7 @@ export default function AuxiliarySet({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(auxiliarySet["@id"]);
 
   // Split the files into those with an @type of TabularFile and all others.
   const groupedFiles = _.groupBy(files, (file) =>
@@ -74,7 +74,6 @@ export default function AuxiliarySet({
             fileSet={auxiliarySet}
             seqspecFiles={seqspecFiles}
             pagePanels={pagePanels}
-            isDefaultExpanded
           >
             {groupedFiles.tabular?.length > 0 && (
               <FileTable

--- a/pages/auxiliary-sets/[id].js
+++ b/pages/auxiliary-sets/[id].js
@@ -73,15 +73,12 @@ export default function AuxiliarySet({
             files={groupedFiles.other}
             fileSet={auxiliarySet}
             seqspecFiles={seqspecFiles}
-            pagePanels={pagePanels}
           >
             {groupedFiles.tabular?.length > 0 && (
               <FileTable
                 files={groupedFiles.tabular}
                 fileSet={auxiliarySet}
                 title="Tabular Files"
-                pagePanels={pagePanels}
-                pagePanelId="tabular-files"
               />
             )}
           </FileSetFilesTables>

--- a/pages/auxiliary-sets/[id].js
+++ b/pages/auxiliary-sets/[id].js
@@ -15,6 +15,7 @@ import FileSetTable from "../../components/file-set-table";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";
 // lib
@@ -42,6 +43,8 @@ export default function AuxiliarySet({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(auxiliarySet["@id"]);
+
   // Split the files into those with an @type of TabularFile and all others.
   const groupedFiles = _.groupBy(files, (file) =>
     file["@type"].includes("TabularFile") ? "tabular" : "other"
@@ -70,12 +73,15 @@ export default function AuxiliarySet({
             files={groupedFiles.other}
             fileSet={auxiliarySet}
             seqspecFiles={seqspecFiles}
+            pagePanels={pagePanels}
           >
             {groupedFiles.tabular?.length > 0 && (
               <FileTable
                 files={groupedFiles.tabular}
                 fileSet={auxiliarySet}
                 title="Tabular Files"
+                pagePanels={pagePanels}
+                pagePanelId="tabular-files"
               />
             )}
           </FileSetFilesTables>
@@ -84,10 +90,16 @@ export default function AuxiliarySet({
               samples={auxiliarySet.samples}
               reportLink={`/multireport/?type=Sample&file_sets.@id=${auxiliarySet["@id"]}`}
               reportLabel="Report of samples in this auxiliary set"
+              pagePanels={pagePanels}
+              pagePanelId="samples"
             />
           )}
           {auxiliarySet.donors?.length > 0 && (
-            <DonorTable donors={auxiliarySet.donors} />
+            <DonorTable
+              donors={auxiliarySet.donors}
+              pagePanels={pagePanels}
+              pagePanelId="donors"
+            />
           )}
           {relatedDatasets.length > 0 && (
             <FileSetTable
@@ -95,6 +107,8 @@ export default function AuxiliarySet({
               title="Related Measurement Sets"
               reportLink={`/multireport/?type=MeasurementSet&auxiliary_sets.@id=${auxiliarySet["@id"]}`}
               reportLabel="Report of measurement sets related to this auxiliary set"
+              pagePanels={pagePanels}
+              pagePanelId="related-datasets"
             />
           )}
           {inputFileSetFor.length > 0 && (
@@ -103,6 +117,8 @@ export default function AuxiliarySet({
               reportLink={`/multireport/?type=FileSet&input_file_sets.@id=${auxiliarySet["@id"]}`}
               reportLabel="Report of file sets that this auxiliary set is an input for"
               title="File Sets Using This Auxiliary Set as an Input"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-sets"
             />
           )}
           {controlFor.length > 0 && (
@@ -113,7 +129,13 @@ export default function AuxiliarySet({
               title="File Sets Controlled by This Auxiliary Set"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
 
           <Attribution attribution={attribution} />
         </JsonDisplay>

--- a/pages/auxiliary-sets/[id].js
+++ b/pages/auxiliary-sets/[id].js
@@ -43,7 +43,7 @@ export default function AuxiliarySet({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(auxiliarySet["@id"]);
+  const pagePanels = usePagePanels();
 
   // Split the files into those with an @type of TabularFile and all others.
   const groupedFiles = _.groupBy(files, (file) =>
@@ -74,6 +74,7 @@ export default function AuxiliarySet({
             fileSet={auxiliarySet}
             seqspecFiles={seqspecFiles}
             pagePanels={pagePanels}
+            isDefaultExpanded
           >
             {groupedFiles.tabular?.length > 0 && (
               <FileTable

--- a/pages/configuration-files/[...id].js
+++ b/pages/configuration-files/[...id].js
@@ -42,7 +42,7 @@ export default function ConfigurationFile({
   fileFormatSpecifications,
   isJson,
 }) {
-  const pagePanels = usePagePanels(configurationFile["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/configuration-files/[...id].js
+++ b/pages/configuration-files/[...id].js
@@ -13,6 +13,7 @@ import { FileHeaderDownload } from "../../components/file-download";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SequencingFileTable from "../../components/sequencing-file-table";
 // lib
@@ -41,6 +42,8 @@ export default function ConfigurationFile({
   fileFormatSpecifications,
   isJson,
 }) {
+  const pagePanels = usePagePanels(configurationFile["@id"]);
+
   return (
     <>
       <Breadcrumbs item={configurationFile} />
@@ -66,6 +69,8 @@ export default function ConfigurationFile({
               itemPath={configurationFile["@id"]}
               itemPathProp="seqspecs"
               isSeqspecHidden
+              pagePanels={pagePanels}
+              pagePanelId="seqspec-file-of"
             />
           )}
           {derivedFrom.length > 0 && (
@@ -73,8 +78,10 @@ export default function ConfigurationFile({
               derivedFrom={derivedFrom}
               derivedFromFileSets={derivedFromFileSets}
               reportLink={`/multireport/?type=File&input_file_for=${configurationFile["@id"]}`}
-              reportLabel={`Report of files ${configurationFile.accession} derives from`}
+              reportLabel="Report of files that this file derives from"
               title="Files This File Derives From"
+              pagePanels={pagePanels}
+              pagePanelId="derived-from"
             />
           )}
           {inputFileFor.length > 0 && (
@@ -83,15 +90,25 @@ export default function ConfigurationFile({
               reportLink={`/multireport/?type=File&derived_from=${configurationFile["@id"]}`}
               reportLabel="Report of files derived from this file"
               title="Files Derived From This File"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-for"
             />
           )}
           {fileFormatSpecifications.length > 0 && (
             <DocumentTable
               documents={fileFormatSpecifications}
               title="File Format Specifications"
+              pagePanels={pagePanels}
+              pagePanelId="file-format-specifications"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/configuration-files/[...id].js
+++ b/pages/configuration-files/[...id].js
@@ -42,7 +42,7 @@ export default function ConfigurationFile({
   fileFormatSpecifications,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(configurationFile["@id"]);
 
   return (
     <>

--- a/pages/construct-library-sets/[id].js
+++ b/pages/construct-library-sets/[id].js
@@ -258,7 +258,7 @@ export default function ConstructLibrarySet({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(constructLibrarySet["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>
@@ -314,6 +314,7 @@ export default function ConstructLibrarySet({
             fileSet={constructLibrarySet}
             seqspecFiles={seqspecFiles}
             pagePanels={pagePanels}
+            isDefaultExpanded
           />
           {integratedContentFiles.length > 0 && (
             <FileTable

--- a/pages/construct-library-sets/[id].js
+++ b/pages/construct-library-sets/[id].js
@@ -313,7 +313,6 @@ export default function ConstructLibrarySet({
             files={files}
             fileSet={constructLibrarySet}
             seqspecFiles={seqspecFiles}
-            pagePanels={pagePanels}
           />
           {integratedContentFiles.length > 0 && (
             <FileTable

--- a/pages/construct-library-sets/[id].js
+++ b/pages/construct-library-sets/[id].js
@@ -21,6 +21,7 @@ import FileSetTable from "../../components/file-set-table";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";
 import SeparatedList from "../../components/separated-list";
@@ -257,6 +258,8 @@ export default function ConstructLibrarySet({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(constructLibrarySet["@id"]);
+
   return (
     <>
       <Breadcrumbs item={constructLibrarySet} />
@@ -310,6 +313,7 @@ export default function ConstructLibrarySet({
             files={files}
             fileSet={constructLibrarySet}
             seqspecFiles={seqspecFiles}
+            pagePanels={pagePanels}
           />
           {integratedContentFiles.length > 0 && (
             <FileTable
@@ -317,6 +321,8 @@ export default function ConstructLibrarySet({
               title="Integrated Content Files"
               reportLink={`/multireport/?type=File&integrated_in.@id=${constructLibrarySet["@id"]}`}
               reportLabel="Report of files that have integrated in this construct library set"
+              pagePanels={pagePanels}
+              pagePanelId="integrated-content-files"
             />
           )}
           {inputFileSetFor.length > 0 && (
@@ -325,6 +331,8 @@ export default function ConstructLibrarySet({
               reportLink={`/multireport/?type=FileSet&input_file_sets.@id=${constructLibrarySet["@id"]}`}
               reportLabel="Report of file sets that this construct library set is an input for"
               title="File Sets Using This Construct Library Set as an Input"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-set-for"
             />
           )}
           {controlFor.length > 0 && (
@@ -333,6 +341,8 @@ export default function ConstructLibrarySet({
               reportLink={`/multireport/?type=FileSet&control_file_sets.@id=${constructLibrarySet["@id"]}`}
               reportLabel="Report of file sets that have this construct library set as a control"
               title="File Sets Controlled by This Construct Library Set"
+              pagePanels={pagePanels}
+              pagePanelId="control-for"
             />
           )}
           {constructLibrarySet.applied_to_samples.length > 0 && (
@@ -341,9 +351,17 @@ export default function ConstructLibrarySet({
               reportLink={`/multireport/?type=Sample&construct_library_sets=${constructLibrarySet["@id"]}`}
               reportLabel="Report of samples that link to this construct library set"
               title="Applied to Samples"
+              pagePanels={pagePanels}
+              pagePanelId="applied-to-samples"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/construct-library-sets/[id].js
+++ b/pages/construct-library-sets/[id].js
@@ -258,7 +258,7 @@ export default function ConstructLibrarySet({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(constructLibrarySet["@id"]);
 
   return (
     <>
@@ -314,7 +314,6 @@ export default function ConstructLibrarySet({
             fileSet={constructLibrarySet}
             seqspecFiles={seqspecFiles}
             pagePanels={pagePanels}
-            isDefaultExpanded
           />
           {integratedContentFiles.length > 0 && (
             <FileTable

--- a/pages/crispr-modifications/[uuid].js
+++ b/pages/crispr-modifications/[uuid].js
@@ -36,7 +36,7 @@ export default function CrisprModification({
   isJson,
   attribution = null,
 }) {
-  const pagePanels = usePagePanels(modification["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/crispr-modifications/[uuid].js
+++ b/pages/crispr-modifications/[uuid].js
@@ -36,7 +36,7 @@ export default function CrisprModification({
   isJson,
   attribution = null,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(modification["@id"]);
 
   return (
     <>

--- a/pages/crispr-modifications/[uuid].js
+++ b/pages/crispr-modifications/[uuid].js
@@ -16,6 +16,7 @@ import { EditableItem } from "../../components/edit";
 import ProductInfo from "../../components/product-info";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";
 // lib
@@ -35,6 +36,8 @@ export default function CrisprModification({
   isJson,
   attribution = null,
 }) {
+  const pagePanels = usePagePanels(modification["@id"]);
+
   return (
     <>
       <Breadcrumbs item={modification} />
@@ -103,10 +106,18 @@ export default function CrisprModification({
               samples={biosamplesModified}
               reportLink={`/multireport/?type=Biosample&modifications.@id=${modification["@id"]}`}
               reportLabel="Report of biosamples that have this modification"
-              title="Biosamples modified by this Modification"
+              title="Biosamples Modified by this Modification"
+              pagePanels={pagePanels}
+              pagePanelId="biosamples-modified"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/curated-sets/[id].js
+++ b/pages/curated-sets/[id].js
@@ -44,7 +44,7 @@ export default function CuratedSet({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(curatedSet["@id"]);
 
   return (
     <>
@@ -119,7 +119,6 @@ export default function CuratedSet({
               isDownloadable
               pagePanels={pagePanels}
               pagePanelId="files"
-              isDefaultExpanded
             />
           )}
           {inputFileSetFor.length > 0 && (

--- a/pages/curated-sets/[id].js
+++ b/pages/curated-sets/[id].js
@@ -44,7 +44,7 @@ export default function CuratedSet({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(curatedSet["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>
@@ -119,6 +119,7 @@ export default function CuratedSet({
               isDownloadable
               pagePanels={pagePanels}
               pagePanelId="files"
+              isDefaultExpanded
             />
           )}
           {inputFileSetFor.length > 0 && (

--- a/pages/curated-sets/[id].js
+++ b/pages/curated-sets/[id].js
@@ -19,6 +19,7 @@ import FileTable from "../../components/file-table";
 import FileSetTable from "../../components/file-set-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";
 // lib
@@ -43,6 +44,8 @@ export default function CuratedSet({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(curatedSet["@id"]);
+
   return (
     <>
       <Breadcrumbs item={curatedSet} />
@@ -98,13 +101,25 @@ export default function CuratedSet({
               samples={curatedSet.samples}
               reportLink={`/multireport/?type=Sample&file_sets.@id=${curatedSet["@id"]}`}
               reportLabel="Report of samples in this curated set"
+              pagePanels={pagePanels}
+              pagePanelId="samples"
             />
           )}
           {curatedSet.donors?.length > 0 && (
-            <DonorTable donors={curatedSet.donors} />
+            <DonorTable
+              donors={curatedSet.donors}
+              pagePanels={pagePanels}
+              pagePanelId="donors"
+            />
           )}
           {files.length > 0 && (
-            <FileTable files={files} fileSet={curatedSet} isDownloadable />
+            <FileTable
+              files={files}
+              fileSet={curatedSet}
+              isDownloadable
+              pagePanels={pagePanels}
+              pagePanelId="files"
+            />
           )}
           {inputFileSetFor.length > 0 && (
             <FileSetTable
@@ -112,6 +127,8 @@ export default function CuratedSet({
               reportLink={`/multireport/?type=FileSet&input_file_sets.@id=${curatedSet["@id"]}`}
               reportLabel="Report of file sets that this curated set is an input for"
               title="File Sets Using This Curated Set as an Input"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-set-for"
             />
           )}
           {controlFor.length > 0 && (
@@ -120,9 +137,17 @@ export default function CuratedSet({
               reportLink={`/multireport/?type=FileSet&control_file_sets.@id=${curatedSet["@id"]}`}
               reportLabel="Report of file sets that have this curated set as a control"
               title="File Sets Controlled by This Curated Set"
+              pagePanels={pagePanels}
+              pagePanelId="control-for"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/curated-sets/[id].js
+++ b/pages/curated-sets/[id].js
@@ -113,13 +113,7 @@ export default function CuratedSet({
             />
           )}
           {files.length > 0 && (
-            <FileTable
-              files={files}
-              fileSet={curatedSet}
-              isDownloadable
-              pagePanels={pagePanels}
-              pagePanelId="files"
-            />
+            <FileTable files={files} fileSet={curatedSet} isDownloadable />
           )}
           {inputFileSetFor.length > 0 && (
             <FileSetTable

--- a/pages/degron-modifications/[uuid].js
+++ b/pages/degron-modifications/[uuid].js
@@ -41,7 +41,7 @@ export default function DegronModification({
   isJson,
   attribution = null,
 }) {
-  const pagePanels = usePagePanels(modification["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/degron-modifications/[uuid].js
+++ b/pages/degron-modifications/[uuid].js
@@ -41,7 +41,7 @@ export default function DegronModification({
   isJson,
   attribution = null,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(modification["@id"]);
 
   return (
     <>

--- a/pages/degron-modifications/[uuid].js
+++ b/pages/degron-modifications/[uuid].js
@@ -16,6 +16,7 @@ import { EditableItem } from "../../components/edit";
 import ProductInfo from "../../components/product-info";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";
 import SeparatedList from "../../components/separated-list";
@@ -40,6 +41,8 @@ export default function DegronModification({
   isJson,
   attribution = null,
 }) {
+  const pagePanels = usePagePanels(modification["@id"]);
+
   return (
     <>
       <Breadcrumbs item={modification} />
@@ -103,9 +106,17 @@ export default function DegronModification({
               reportLink={`/multireport/?type=Biosample&modifications.@id=${modification["@id"]}`}
               reportLabel="Report of biosamples that have this item as their modification"
               title="Biosamples Modified by this Modification"
+              pagePanels={pagePanels}
+              pagePanelId="biosamples-modified"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/human-donors/[uuid].js
+++ b/pages/human-donors/[uuid].js
@@ -43,7 +43,7 @@ export default function HumanDonor({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(donor["@id"]);
 
   return (
     <>

--- a/pages/human-donors/[uuid].js
+++ b/pages/human-donors/[uuid].js
@@ -17,6 +17,7 @@ import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import PhenotypicFeatureTable from "../../components/phenotypic-feature-table";
 import RelatedDonorsTable from "../../components/related-donors-table";
@@ -42,6 +43,8 @@ export default function HumanDonor({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(donor["@id"]);
+
   return (
     <>
       <Breadcrumbs item={donor} />
@@ -79,15 +82,27 @@ export default function HumanDonor({
             </DataArea>
           </DataPanel>
           {phenotypicFeatures.length > 0 && (
-            <PhenotypicFeatureTable phenotypicFeatures={phenotypicFeatures} />
+            <PhenotypicFeatureTable
+              phenotypicFeatures={phenotypicFeatures}
+              pagePanels={pagePanels}
+              pagePanelId="phenotypic-features"
+            />
           )}
           {relatedDonors.length > 0 && (
             <RelatedDonorsTable
               relatedDonors={relatedDonors}
               embeddedDonors={donor.related_donors}
+              pagePanels={pagePanels}
+              pagePanelId="related-donors"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/human-donors/[uuid].js
+++ b/pages/human-donors/[uuid].js
@@ -43,7 +43,7 @@ export default function HumanDonor({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(donor["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/image-files/[...id].js
+++ b/pages/image-files/[...id].js
@@ -13,6 +13,7 @@ import { FileHeaderDownload } from "../../components/file-download";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -39,6 +40,8 @@ export default function ImageFile({
   fileFormatSpecifications,
   isJson,
 }) {
+  const pagePanels = usePagePanels(imageFile["@id"]);
+
   return (
     <>
       <Breadcrumbs item={imageFile} />
@@ -62,8 +65,10 @@ export default function ImageFile({
               derivedFrom={derivedFrom}
               derivedFromFileSets={derivedFromFileSets}
               reportLink={`/multireport/?type=File&input_file_for=${imageFile["@id"]}`}
-              reportLabel={`Report of files ${imageFile.accession} derives from`}
-              title={`Files ${imageFile.accession} Derives From`}
+              reportLabel="Report of files that this file derives from"
+              title="Files This File Derives From"
+              pagePanels={pagePanels}
+              pagePanelId="derived-from"
             />
           )}
           {inputFileFor.length > 0 && (
@@ -72,15 +77,25 @@ export default function ImageFile({
               reportLink={`/multireport/?type=File&derived_from=${imageFile["@id"]}`}
               reportLabel="Report of files derived from this file"
               title="Files Derived From This File"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-for"
             />
           )}
           {fileFormatSpecifications.length > 0 && (
             <DocumentTable
               documents={fileFormatSpecifications}
               title="File Format Specifications"
+              pagePanels={pagePanels}
+              pagePanelId="file-format-specifications"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="document"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/image-files/[...id].js
+++ b/pages/image-files/[...id].js
@@ -40,7 +40,7 @@ export default function ImageFile({
   fileFormatSpecifications,
   isJson,
 }) {
-  const pagePanels = usePagePanels(imageFile["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/image-files/[...id].js
+++ b/pages/image-files/[...id].js
@@ -40,7 +40,7 @@ export default function ImageFile({
   fileFormatSpecifications,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(imageFile["@id"]);
 
   return (
     <>

--- a/pages/in-vitro-systems/[id].js
+++ b/pages/in-vitro-systems/[id].js
@@ -20,6 +20,7 @@ import FileSetTable from "../../components/file-set-table";
 import JsonDisplay from "../../components/json-display";
 import ModificationTable from "../../components/modification-table";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";
 import TreatmentTable from "../../components/treatment-table";
@@ -66,6 +67,8 @@ export default function InVitroSystem({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(inVitroSystem["@id"]);
+
   return (
     <>
       <Breadcrumbs item={inVitroSystem} />
@@ -156,12 +159,20 @@ export default function InVitroSystem({
               </BiosampleDataItems>
             </DataArea>
           </DataPanel>
-          {donors.length > 0 && <DonorTable donors={donors} />}
+          {donors.length > 0 && (
+            <DonorTable
+              donors={donors}
+              pagePanels={pagePanels}
+              pagePanelId="donors"
+            />
+          )}
           {inVitroSystem.file_sets.length > 0 && (
             <FileSetTable
               fileSets={inVitroSystem.file_sets}
               reportLink={`/multireport/?type=FileSet&samples.@id=${inVitroSystem["@id"]}`}
               reportLabel="Report of file sets associated with this sample"
+              pagePanels={pagePanels}
+              pagePanelId="file-sets"
             />
           )}
           {multiplexedInSamples.length > 0 && (
@@ -170,6 +181,8 @@ export default function InVitroSystem({
               reportLink={`/multireport/?type=MultiplexedSample&multiplexed_samples.@id=${inVitroSystem["@id"]}`}
               reportLabel="Report of multiplexed samples in which this sample is included"
               title="Multiplexed In Samples"
+              pagePanels={pagePanels}
+              pagePanelId="multiplexed-in-samples"
             />
           )}
           {pooledFrom.length > 0 && (
@@ -178,6 +191,8 @@ export default function InVitroSystem({
               reportLink={`/multireport/?type=Sample&pooled_in=${inVitroSystem["@id"]}`}
               reportLabel="Report of samples this biosample is pooled from"
               title="Biosamples Pooled From"
+              pagePanels={pagePanels}
+              pagePanelId="biosamples-pooled-from"
             />
           )}
           {pooledIn.length > 0 && (
@@ -186,6 +201,8 @@ export default function InVitroSystem({
               reportLink={`/multireport/?type=Biosample&pooled_from=${inVitroSystem["@id"]}`}
               reportLabel="Report of pooled biosamples in which this sample is included"
               title="Pooled In"
+              pagePanels={pagePanels}
+              pagePanelId="pooled-in"
             />
           )}
           {demultiplexedTo.length > 0 && (
@@ -194,6 +211,8 @@ export default function InVitroSystem({
               reportLink={`/multireport/?type=Biosample&demultiplexed_from=${inVitroSystem["@id"]}`}
               reportLabel="Report of parts into which this sample has been demultiplexed"
               title="Demultiplexed To Sample"
+              pagePanels={pagePanels}
+              pagePanelId="demultiplexed-to-sample"
             />
           )}
           {parts.length > 0 && (
@@ -202,6 +221,8 @@ export default function InVitroSystem({
               reportLink={`/multireport/?type=Biosample&part_of=${inVitroSystem["@id"]}`}
               reportLabel="Report of parts into which this sample has been divided"
               title="Sample Parts"
+              pagePanels={pagePanels}
+              pagePanelId="sample-parts"
             />
           )}
           {originOf.length > 0 && (
@@ -210,6 +231,8 @@ export default function InVitroSystem({
               reportLink={`/multireport/?type=Biosample&originated_from.@id=${inVitroSystem["@id"]}`}
               reportLabel="Report of samples which originate from this sample"
               title="Origin Sample Of"
+              pagePanels={pagePanels}
+              pagePanelId="origin-sample-of"
             />
           )}
           {inVitroSystem.modifications?.length > 0 && (
@@ -217,6 +240,8 @@ export default function InVitroSystem({
               modifications={inVitroSystem.modifications}
               reportLink={`/multireport/?type=Modification&biosamples_modified=${inVitroSystem["@id"]}`}
               reportLabel={`Report of genetic modifications for ${inVitroSystem.accession}`}
+              pagePanels={pagePanels}
+              pagePanelId="modifications"
             />
           )}
           {sortedFractions.length > 0 && (
@@ -225,6 +250,8 @@ export default function InVitroSystem({
               reportLink={`/multireport/?type=Sample&sorted_from.@id=${inVitroSystem["@id"]}`}
               reportLabel="Report of fractions into which this sample has been sorted"
               title="Sorted Fractions of Sample"
+              pagePanels={pagePanels}
+              pagePanelId="sorted-fractions-of-sample"
             />
           )}
           {biomarkers.length > 0 && (
@@ -232,6 +259,8 @@ export default function InVitroSystem({
               biomarkers={biomarkers}
               reportLink={`/multireport/?type=Biomarker&biomarker_for=${inVitroSystem["@id"]}`}
               reportLabel={`Report of biological markers that are associated with biosample ${inVitroSystem.accession}`}
+              pagePanels={pagePanels}
+              pagePanelId="biomarkers"
             />
           )}
           {treatments.length > 0 && (
@@ -239,15 +268,25 @@ export default function InVitroSystem({
               treatments={treatments}
               reportLink={`/multireport/?type=Treatment&biosamples_treated=${inVitroSystem["@id"]}`}
               reportLabel={`Report of treatments applied to the biosample ${inVitroSystem.accession}`}
+              pagePanels={pagePanels}
+              pagePanelId="treatments"
             />
           )}
           {cellFateChangeTreatments.length > 0 && (
             <TreatmentTable
               treatments={cellFateChangeTreatments}
               title="Cell Fate Change Treatments"
+              pagePanels={pagePanels}
+              pagePanelId="cell-fate-change-treatments"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/in-vitro-systems/[id].js
+++ b/pages/in-vitro-systems/[id].js
@@ -67,7 +67,7 @@ export default function InVitroSystem({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(inVitroSystem["@id"]);
 
   return (
     <>

--- a/pages/in-vitro-systems/[id].js
+++ b/pages/in-vitro-systems/[id].js
@@ -67,7 +67,7 @@ export default function InVitroSystem({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(inVitroSystem["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/matrix-files/[...id].js
+++ b/pages/matrix-files/[...id].js
@@ -47,7 +47,7 @@ export default function MatrixFile({
   referenceFiles,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(matrixFile["@id"]);
 
   return (
     <>

--- a/pages/matrix-files/[...id].js
+++ b/pages/matrix-files/[...id].js
@@ -47,7 +47,7 @@ export default function MatrixFile({
   referenceFiles,
   isJson,
 }) {
-  const pagePanels = usePagePanels(matrixFile["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/matrix-files/[...id].js
+++ b/pages/matrix-files/[...id].js
@@ -19,6 +19,7 @@ import { FileHeaderDownload } from "../../components/file-download";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -46,6 +47,8 @@ export default function MatrixFile({
   referenceFiles,
   isJson,
 }) {
+  const pagePanels = usePagePanels(matrixFile["@id"]);
+
   return (
     <>
       <Breadcrumbs item={matrixFile} />
@@ -76,15 +79,22 @@ export default function MatrixFile({
             </DataArea>
           </DataPanel>
           {referenceFiles.length > 0 && (
-            <FileTable files={referenceFiles} title="Reference Files" />
+            <FileTable
+              files={referenceFiles}
+              title="Reference Files"
+              pagePanels={pagePanels}
+              pagePanelId="reference-files"
+            />
           )}
           {derivedFrom.length > 0 && (
             <DerivedFromTable
               derivedFrom={derivedFrom}
               derivedFromFileSets={derivedFromFileSets}
               reportLink={`/multireport/?type=File&input_file_for=${matrixFile["@id"]}`}
-              reportLabel={`Report of files ${matrixFile.accession} derives from`}
-              title={`Files ${matrixFile.accession} Derives From`}
+              reportLabel="Report of files that this file derives from"
+              title="Files This File Derives From"
+              pagePanels={pagePanels}
+              pagePanelId="derived-from"
             />
           )}
           {inputFileFor.length > 0 && (
@@ -93,15 +103,25 @@ export default function MatrixFile({
               reportLink={`/multireport/?type=File&derived_from=${matrixFile["@id"]}`}
               reportLabel="Report of files derived from this file"
               title="Files Derived From This File"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-for"
             />
           )}
           {fileFormatSpecifications.length > 0 && (
             <DocumentTable
               documents={fileFormatSpecifications}
               title="File Format Specifications"
+              pagePanels={pagePanels}
+              pagePanelId="file-format-specifications"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/measurement-sets/[id].js
+++ b/pages/measurement-sets/[id].js
@@ -25,6 +25,7 @@ import FileSetFilesTables from "../../components/file-set-files-tables";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";
 import SeparatedList from "../../components/separated-list";
@@ -115,6 +116,8 @@ export default function MeasurementSet({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(measurementSet["@id"]);
+
   // Split the files into those with an @type of ImageFile and all others.
   const groupedFiles = _.groupBy(files, (file) =>
     file["@type"].includes("ImageFile") ? "image" : "other"
@@ -263,12 +266,15 @@ export default function MeasurementSet({
             files={groupedFiles.other}
             fileSet={measurementSet}
             seqspecFiles={seqspecFiles}
+            pagePanels={pagePanels}
           >
             {groupedFiles.image?.length > 0 && (
               <FileTable
                 files={groupedFiles.image}
                 fileSet={measurementSet}
                 title="Imaging Results"
+                pagePanels={pagePanels}
+                pagePanelId="imaging-results"
               />
             )}
           </FileSetFilesTables>
@@ -276,11 +282,17 @@ export default function MeasurementSet({
             <SampleTable
               samples={measurementSet.samples}
               reportLink={`/multireport/?type=Sample&file_sets.@id=${measurementSet["@id"]}`}
-              reportLabel="Report of samples in this file set"
+              reportLabel="Report of Samples in This File Set"
+              pagePanels={pagePanels}
+              pagePanelId="samples"
             />
           )}
           {measurementSet.donors?.length > 0 && (
-            <DonorTable donors={measurementSet.donors} />
+            <DonorTable
+              donors={measurementSet.donors}
+              pagePanels={pagePanels}
+              pagePanelId="donors"
+            />
           )}
           <AssayDetails measurementSet={measurementSet} />
           {controlFileSets.length > 0 && (
@@ -288,7 +300,9 @@ export default function MeasurementSet({
               fileSets={controlFileSets}
               title="Control File Sets"
               reportLink={`/multireport/?type=FileSet&control_for.@id=${measurementSet["@id"]}`}
-              reportLabel="Report of control file sets in this file set"
+              reportLabel="Report of Control File Sets in This File Set"
+              pagePanels={pagePanels}
+              pagePanelId="control-file-sets"
             />
           )}
           {inputFileSetFor.length > 0 && (
@@ -297,6 +311,8 @@ export default function MeasurementSet({
               reportLink={`/multireport/?type=FileSet&input_file_sets.@id=${measurementSet["@id"]}`}
               reportLabel="Report of file sets that this measurement set is an input for"
               title="File Sets Using This Measurement Set as an Input"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-set-for"
             />
           )}
           {controlFor.length > 0 && (
@@ -305,6 +321,8 @@ export default function MeasurementSet({
               reportLink={`/multireport/?type=FileSet&control_file_sets.@id=${measurementSet["@id"]}`}
               reportLabel="Report of file sets that have this measurement set as a control"
               title="File Sets Controlled by This Measurement Set"
+              pagePanels={pagePanels}
+              pagePanelId="control-for"
             />
           )}
           {relatedMultiomeSets.length > 0 && (
@@ -312,7 +330,9 @@ export default function MeasurementSet({
               fileSets={relatedMultiomeSets}
               title="Related Multiome Datasets"
               reportLink={composeRelatedDatasetReportLink(measurementSet)}
-              reportLabel="Report of related multiome datasets"
+              reportLabel="Report of Related Multiome Datasets"
+              pagePanels={pagePanels}
+              pagePanelId="related-multiome-datasets"
             />
           )}
           {auxiliarySets.length > 0 && (
@@ -329,9 +349,17 @@ export default function MeasurementSet({
                   );
                 },
               }}
+              pagePanels={pagePanels}
+              pagePanelId="auxiliary-datasets"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/measurement-sets/[id].js
+++ b/pages/measurement-sets/[id].js
@@ -266,15 +266,12 @@ export default function MeasurementSet({
             files={groupedFiles.other}
             fileSet={measurementSet}
             seqspecFiles={seqspecFiles}
-            pagePanels={pagePanels}
           >
             {groupedFiles.image?.length > 0 && (
               <FileTable
                 files={groupedFiles.image}
                 fileSet={measurementSet}
                 title="Imaging Results"
-                pagePanels={pagePanels}
-                pagePanelId="imaging-results"
               />
             )}
           </FileSetFilesTables>

--- a/pages/measurement-sets/[id].js
+++ b/pages/measurement-sets/[id].js
@@ -116,7 +116,7 @@ export default function MeasurementSet({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(measurementSet["@id"]);
 
   // Split the files into those with an @type of ImageFile and all others.
   const groupedFiles = _.groupBy(files, (file) =>
@@ -267,7 +267,6 @@ export default function MeasurementSet({
             fileSet={measurementSet}
             seqspecFiles={seqspecFiles}
             pagePanels={pagePanels}
-            isDefaultExpanded
           >
             {groupedFiles.image?.length > 0 && (
               <FileTable

--- a/pages/measurement-sets/[id].js
+++ b/pages/measurement-sets/[id].js
@@ -116,7 +116,7 @@ export default function MeasurementSet({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(measurementSet["@id"]);
+  const pagePanels = usePagePanels();
 
   // Split the files into those with an @type of ImageFile and all others.
   const groupedFiles = _.groupBy(files, (file) =>
@@ -267,6 +267,7 @@ export default function MeasurementSet({
             fileSet={measurementSet}
             seqspecFiles={seqspecFiles}
             pagePanels={pagePanels}
+            isDefaultExpanded
           >
             {groupedFiles.image?.length > 0 && (
               <FileTable

--- a/pages/model-files/[...id].js
+++ b/pages/model-files/[...id].js
@@ -40,7 +40,7 @@ export default function ModelFile({
   fileFormatSpecifications,
   isJson,
 }) {
-  const pagePanels = usePagePanels(modelFile["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/model-files/[...id].js
+++ b/pages/model-files/[...id].js
@@ -40,7 +40,7 @@ export default function ModelFile({
   fileFormatSpecifications,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(modelFile["@id"]);
 
   return (
     <>

--- a/pages/model-files/[...id].js
+++ b/pages/model-files/[...id].js
@@ -13,6 +13,7 @@ import { FileHeaderDownload } from "../../components/file-download";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -39,6 +40,8 @@ export default function ModelFile({
   fileFormatSpecifications,
   isJson,
 }) {
+  const pagePanels = usePagePanels(modelFile["@id"]);
+
   return (
     <>
       <Breadcrumbs item={modelFile} />
@@ -62,8 +65,10 @@ export default function ModelFile({
               derivedFrom={derivedFrom}
               derivedFromFileSets={derivedFromFileSets}
               reportLink={`/multireport/?type=File&input_file_for=${modelFile["@id"]}`}
-              reportLabel={`Report of files ${modelFile.accession} derives from`}
+              reportLabel="Report of files that this file derives from"
               title="Files This File Derives From"
+              pagePanels={pagePanels}
+              pagePanelId="derived-from"
             />
           )}
           {inputFileFor.length > 0 && (
@@ -72,15 +77,25 @@ export default function ModelFile({
               reportLink={`/multireport/?type=File&derived_from=${modelFile["@id"]}`}
               reportLabel="Report of files derived from this file"
               title="Files Derived From This File"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-for"
             />
           )}
           {fileFormatSpecifications.length > 0 && (
             <DocumentTable
               documents={fileFormatSpecifications}
               title="File Format Specifications"
+              pagePanels={pagePanels}
+              pagePanelId="file-format-specifications"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/model-sets/[id].js
+++ b/pages/model-sets/[id].js
@@ -45,7 +45,7 @@ export default function ModelSet({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(modelSet["@id"]);
 
   return (
     <>
@@ -152,7 +152,6 @@ export default function ModelSet({
               isDownloadable
               pagePanels={pagePanels}
               pagePanelId="files"
-              isDefaultExpanded
             />
           )}
 

--- a/pages/model-sets/[id].js
+++ b/pages/model-sets/[id].js
@@ -19,6 +19,7 @@ import FileSetTable from "../../components/file-set-table";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -44,6 +45,8 @@ export default function ModelSet({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(modelSet["@id"]);
+
   return (
     <>
       <Breadcrumbs item={modelSet} />
@@ -115,6 +118,8 @@ export default function ModelSet({
               title="Input File Sets"
               reportLink={`/multireport/?type=FileSet&input_file_set_for=${modelSet["@id"]}`}
               reportLabel={`View file sets used as input file sets for ${modelSet.accession}`}
+              pagePanels={pagePanels}
+              pagePanelId="input-file-sets"
             />
           )}
 
@@ -124,6 +129,8 @@ export default function ModelSet({
               reportLink={`/multireport/?type=FileSet&input_file_sets.@id=${modelSet["@id"]}`}
               reportLabel="Report of file sets that this model set is an input for"
               title="File Sets Using This Model Set as an Input"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-set-for"
             />
           )}
 
@@ -133,13 +140,29 @@ export default function ModelSet({
               reportLink={`/multireport/?type=FileSet&control_file_sets.@id=${modelSet["@id"]}`}
               reportLabel="Report of file sets that have this model set as a control"
               title="File Sets Controlled by This Model Set"
+              pagePanels={pagePanels}
+              pagePanelId="control-for"
             />
           )}
 
           {files.length > 0 && (
-            <FileTable files={files} fileSet={modelSet} isDownloadable />
+            <FileTable
+              files={files}
+              fileSet={modelSet}
+              isDownloadable
+              pagePanels={pagePanels}
+              pagePanelId="files"
+            />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
+
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/model-sets/[id].js
+++ b/pages/model-sets/[id].js
@@ -45,7 +45,7 @@ export default function ModelSet({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(modelSet["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>
@@ -152,6 +152,7 @@ export default function ModelSet({
               isDownloadable
               pagePanels={pagePanels}
               pagePanelId="files"
+              isDefaultExpanded
             />
           )}
 

--- a/pages/model-sets/[id].js
+++ b/pages/model-sets/[id].js
@@ -146,13 +146,7 @@ export default function ModelSet({
           )}
 
           {files.length > 0 && (
-            <FileTable
-              files={files}
-              fileSet={modelSet}
-              isDownloadable
-              pagePanels={pagePanels}
-              pagePanelId="files"
-            />
+            <FileTable files={files} fileSet={modelSet} isDownloadable />
           )}
 
           {documents.length > 0 && (

--- a/pages/multiplexed-samples/[uuid].js
+++ b/pages/multiplexed-samples/[uuid].js
@@ -56,7 +56,7 @@ export default function MultiplexedSample({
   barcodeSampleMap,
   isJson,
 }) {
-  const pagePanels = usePagePanels(multiplexedSample["@id"]);
+  const pagePanels = usePagePanels();
   const reportLink = `/multireport/?type=Sample&field=%40id&field=multiplexed_in&field=taxa&field=sample_terms.term_name&field=donors&field=disease_terms&field=status&field=summary&field=%40type&multiplexed_in.accession=${multiplexedSample.accession}&field=construct_library_sets`;
 
   return (

--- a/pages/multiplexed-samples/[uuid].js
+++ b/pages/multiplexed-samples/[uuid].js
@@ -20,6 +20,7 @@ import FileSetTable from "../../components/file-set-table";
 import JsonDisplay from "../../components/json-display";
 import ModificationTable from "../../components/modification-table";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";
 import SeparatedList from "../../components/separated-list";
@@ -55,6 +56,7 @@ export default function MultiplexedSample({
   barcodeSampleMap,
   isJson,
 }) {
+  const pagePanels = usePagePanels(multiplexedSample["@id"]);
   const reportLink = `/multireport/?type=Sample&field=%40id&field=multiplexed_in&field=taxa&field=sample_terms.term_name&field=donors&field=disease_terms&field=status&field=summary&field=%40type&multiplexed_in.accession=${multiplexedSample.accession}&field=construct_library_sets`;
 
   return (
@@ -116,6 +118,8 @@ export default function MultiplexedSample({
               fileSets={multiplexedSample.file_sets}
               reportLink={`/multireport/?type=FileSet&samples.@id=${multiplexedSample["@id"]}`}
               reportLabel="Report of file sets associated with this sample"
+              pagePanels={pagePanels}
+              pagePanelId="file-sets"
             />
           )}
           {multiplexedSample.multiplexed_samples.length > 0 && (
@@ -124,6 +128,8 @@ export default function MultiplexedSample({
               reportLink={reportLink}
               reportLabel="Report of samples multiplexed together to produce this sample"
               title="Multiplexed Samples"
+              pagePanels={pagePanels}
+              pagePanelId="multiplexed-samples"
             />
           )}
           {multiplexedInSamples.length > 0 && (
@@ -132,11 +138,15 @@ export default function MultiplexedSample({
               reportLink={`/multireport/?type=MultiplexedSample&multiplexed_samples.@id=${multiplexedSample["@id"]}`}
               reportLabel="Report of multiplexed samples in which this sample is included"
               title="Multiplexed In Samples"
+              pagePanels={pagePanels}
+              pagePanelId="multiplexed-in-samples"
             />
           )}
           {multiplexedSample.modifications?.length > 0 && (
             <ModificationTable
               modifications={multiplexedSample.modifications}
+              pagePanels={pagePanels}
+              pagePanelId="modifications"
             />
           )}
           {sortedFractions.length > 0 && (
@@ -145,11 +155,31 @@ export default function MultiplexedSample({
               reportLink={`/multireport/?type=Sample&sorted_from.@id=${multiplexedSample["@id"]}`}
               reportLabel="Report of fractions into which this sample has been sorted"
               title="Sorted Fractions of Sample"
+              pagePanels={pagePanels}
+              pagePanelId="sorted-fractions"
             />
           )}
-          {biomarkers.length > 0 && <BiomarkerTable biomarkers={biomarkers} />}
-          {treatments.length > 0 && <TreatmentTable treatments={treatments} />}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {biomarkers.length > 0 && (
+            <BiomarkerTable
+              biomarkers={biomarkers}
+              pagePanels={pagePanels}
+              pagePanelId="biomarkers"
+            />
+          )}
+          {treatments.length > 0 && (
+            <TreatmentTable
+              treatments={treatments}
+              pagePanels={pagePanels}
+              pagePanelId="treatments"
+            />
+          )}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/multiplexed-samples/[uuid].js
+++ b/pages/multiplexed-samples/[uuid].js
@@ -56,7 +56,7 @@ export default function MultiplexedSample({
   barcodeSampleMap,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(multiplexedSample["@id"]);
   const reportLink = `/multireport/?type=Sample&field=%40id&field=multiplexed_in&field=taxa&field=sample_terms.term_name&field=donors&field=disease_terms&field=status&field=summary&field=%40type&multiplexed_in.accession=${multiplexedSample.accession}&field=construct_library_sets`;
 
   return (

--- a/pages/prediction-sets/[id].js
+++ b/pages/prediction-sets/[id].js
@@ -21,6 +21,7 @@ import FileSetTable from "../../components/file-set-table";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";
 import SeparatedList from "../../components/separated-list";
@@ -50,6 +51,7 @@ export default function PredictionSet({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(predictionSet["@id"]);
   const constructLibrarySets =
     predictionSet.samples?.length > 0
       ? predictionSet.samples.reduce(
@@ -177,10 +179,16 @@ export default function PredictionSet({
               samples={predictionSet.samples}
               reportLink={`/multireport/?type=Sample&file_sets.@id=${predictionSet["@id"]}`}
               reportLabel="Report of samples in this prediction set"
+              pagePanels={pagePanels}
+              pagePanelId="samples"
             />
           )}
           {predictionSet.donors?.length > 0 && (
-            <DonorTable donors={predictionSet.donors} />
+            <DonorTable
+              donors={predictionSet.donors}
+              pagePanels={pagePanels}
+              pagePanelId="donors"
+            />
           )}
           {inputFileSets.length > 0 && (
             <FileSetTable
@@ -188,6 +196,8 @@ export default function PredictionSet({
               reportLink={`/multireport/?type=FileSet&input_file_set_for=${predictionSet["@id"]}`}
               reportLabel="Report of file sets that are inputs for this prediction set"
               title="Input File Sets"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-sets"
             />
           )}
           {inputFileSetFor.length > 0 && (
@@ -196,6 +206,8 @@ export default function PredictionSet({
               reportLink={`/multireport/?type=FileSet&input_file_sets.@id=${predictionSet["@id"]}`}
               reportLabel="Report of file sets that this prediction set is an input for"
               title="File Sets Using This Prediction Set as an Input"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-set-for"
             />
           )}
           {controlFor.length > 0 && (
@@ -204,12 +216,26 @@ export default function PredictionSet({
               reportLink={`/multireport/?type=FileSet&control_file_sets.@id=${predictionSet["@id"]}`}
               reportLabel="Report of file sets that have this prediction set as a control"
               title="File Sets Controlled by This Prediction Set"
+              pagePanels={pagePanels}
+              pagePanelId="control-for"
             />
           )}
           {files.length > 0 && (
-            <FileTable files={files} fileSet={predictionSet} isDownloadable />
+            <FileTable
+              files={files}
+              fileSet={predictionSet}
+              isDownloadable
+              pagePanels={pagePanels}
+              pagePanelId="files"
+            />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/prediction-sets/[id].js
+++ b/pages/prediction-sets/[id].js
@@ -51,7 +51,7 @@ export default function PredictionSet({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(predictionSet["@id"]);
   const constructLibrarySets =
     predictionSet.samples?.length > 0
       ? predictionSet.samples.reduce(
@@ -227,7 +227,6 @@ export default function PredictionSet({
               isDownloadable
               pagePanels={pagePanels}
               pagePanelId="files"
-              isDefaultExpanded
             />
           )}
           {documents.length > 0 && (

--- a/pages/prediction-sets/[id].js
+++ b/pages/prediction-sets/[id].js
@@ -221,13 +221,7 @@ export default function PredictionSet({
             />
           )}
           {files.length > 0 && (
-            <FileTable
-              files={files}
-              fileSet={predictionSet}
-              isDownloadable
-              pagePanels={pagePanels}
-              pagePanelId="files"
-            />
+            <FileTable files={files} fileSet={predictionSet} isDownloadable />
           )}
           {documents.length > 0 && (
             <DocumentTable

--- a/pages/prediction-sets/[id].js
+++ b/pages/prediction-sets/[id].js
@@ -51,7 +51,7 @@ export default function PredictionSet({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(predictionSet["@id"]);
+  const pagePanels = usePagePanels();
   const constructLibrarySets =
     predictionSet.samples?.length > 0
       ? predictionSet.samples.reduce(
@@ -227,6 +227,7 @@ export default function PredictionSet({
               isDownloadable
               pagePanels={pagePanels}
               pagePanelId="files"
+              isDefaultExpanded
             />
           )}
           {documents.length > 0 && (

--- a/pages/primary-cells/[uuid].js
+++ b/pages/primary-cells/[uuid].js
@@ -19,6 +19,7 @@ import FileSetTable from "../../components/file-set-table";
 import JsonDisplay from "../../components/json-display";
 import ModificationTable from "../../components/modification-table";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";
 import TreatmentTable from "../../components/treatment-table";
@@ -59,6 +60,8 @@ export default function PrimaryCell({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(primaryCell["@id"]);
+
   return (
     <>
       <Breadcrumbs item={primaryCell} />
@@ -96,12 +99,20 @@ export default function PrimaryCell({
               </BiosampleDataItems>
             </DataArea>
           </DataPanel>
-          {donors.length > 0 && <DonorTable donors={donors} />}
+          {donors.length > 0 && (
+            <DonorTable
+              donors={donors}
+              pagePanels={pagePanels}
+              pagePanelId="donors"
+            />
+          )}
           {primaryCell.file_sets.length > 0 && (
             <FileSetTable
               fileSets={primaryCell.file_sets}
               reportLink={`/multireport/?type=FileSet&samples.@id=${primaryCell["@id"]}`}
               reportLabel="Report of file sets associated with this sample"
+              pagePanels={pagePanels}
+              pagePanelId="file-sets"
             />
           )}
           {multiplexedInSamples.length > 0 && (
@@ -110,6 +121,8 @@ export default function PrimaryCell({
               reportLink={`/multireport/?type=MultiplexedSample&multiplexed_samples.@id=${primaryCell["@id"]}`}
               reportLabel="Report of multiplexed samples in which this sample is included"
               title="Multiplexed In Samples"
+              pagePanels={pagePanels}
+              pagePanelId="multiplexed-in-samples"
             />
           )}
           {pooledFrom.length > 0 && (
@@ -118,6 +131,8 @@ export default function PrimaryCell({
               reportLink={`/multireport/?type=Sample&pooled_in=${primaryCell["@id"]}`}
               reportLabel="Report of biosamples this sample is pooled from"
               title="Biosamples Pooled From"
+              pagePanels={pagePanels}
+              pagePanelId="pooled-from"
             />
           )}
           {pooledIn.length > 0 && (
@@ -126,6 +141,8 @@ export default function PrimaryCell({
               reportLink={`/multireport/?type=Biosample&pooled_from=${primaryCell["@id"]}`}
               reportLabel="Report of pooled samples in which this sample is included"
               title="Pooled In"
+              pagePanels={pagePanels}
+              pagePanelId="pooled-in"
             />
           )}
           {parts.length > 0 && (
@@ -134,6 +151,8 @@ export default function PrimaryCell({
               reportLink={`/multireport/?type=Biosample&part_of=${primaryCell["@id"]}`}
               reportLabel="Report of parts into which this sample has been divided"
               title="Sample Parts"
+              pagePanels={pagePanels}
+              pagePanelId="parts"
             />
           )}
           {primaryCell.modifications?.length > 0 && (
@@ -141,6 +160,8 @@ export default function PrimaryCell({
               modifications={primaryCell.modifications}
               reportLink={`/multireport/?type=Modification&biosamples_modified=${primaryCell["@id"]}`}
               reportLabel={`Report of genetic modifications for ${primaryCell.accession}`}
+              pagePanels={pagePanels}
+              pagePanelId="modifications"
             />
           )}
           {sortedFractions.length > 0 && (
@@ -149,6 +170,8 @@ export default function PrimaryCell({
               reportLink={`/multireport/?type=Sample&sorted_from.@id=${primaryCell["@id"]}`}
               reportLabel="Report of fractions into which this sample has been sorted"
               title="Sorted Fractions of Sample"
+              pagePanels={pagePanels}
+              pagePanelId="sorted-fractions"
             />
           )}
           {biomarkers.length > 0 && (
@@ -156,6 +179,8 @@ export default function PrimaryCell({
               biomarkers={biomarkers}
               reportLink={`/multireport/?type=Biomarker&biomarker_for=${primaryCell["@id"]}`}
               reportLabel={`Report of biological markers that are associated with biosample ${primaryCell.accession}`}
+              pagePanels={pagePanels}
+              pagePanelId="biomarkers"
             />
           )}
           {treatments.length > 0 && (
@@ -163,9 +188,17 @@ export default function PrimaryCell({
               treatments={treatments}
               reportLink={`/multireport/?type=Treatment&biosamples_treated=${primaryCell["@id"]}`}
               reportLabel={`Report of treatments applied to the biosample ${primaryCell.accession}`}
+              pagePanels={pagePanels}
+              pagePanelId="treatments"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/primary-cells/[uuid].js
+++ b/pages/primary-cells/[uuid].js
@@ -60,7 +60,7 @@ export default function PrimaryCell({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(primaryCell["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/primary-cells/[uuid].js
+++ b/pages/primary-cells/[uuid].js
@@ -60,7 +60,7 @@ export default function PrimaryCell({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(primaryCell["@id"]);
 
   return (
     <>

--- a/pages/publications/[id].js
+++ b/pages/publications/[id].js
@@ -51,7 +51,7 @@ export default function Publication({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(publication["@id"]);
 
   return (
     <>

--- a/pages/publications/[id].js
+++ b/pages/publications/[id].js
@@ -51,7 +51,7 @@ export default function Publication({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(publication["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/publications/[id].js
+++ b/pages/publications/[id].js
@@ -17,6 +17,7 @@ import { EditableItem } from "../../components/edit";
 import FileSetTable from "../../components/file-set-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import { PublicationCitation } from "../../components/publication";
 import SampleTable from "../../components/sample-table";
@@ -50,6 +51,8 @@ export default function Publication({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(publication["@id"]);
+
   return (
     <>
       <Breadcrumbs
@@ -113,6 +116,8 @@ export default function Publication({
               samples={samples}
               reportLink={`/multireport/?type=Sample&publications.@id=${publication["@id"]}`}
               reportLabel="Report of samples in this publication"
+              pagePanels={pagePanels}
+              pagePanelId="samples"
             />
           )}
           {donors.length > 0 && (
@@ -120,6 +125,8 @@ export default function Publication({
               reportLink={`/multireport/?type=Donor&publications.@id=${publication["@id"]}`}
               reportLabel="Report of donors with this publication"
               donors={donors}
+              pagePanels={pagePanels}
+              pagePanelId="donors"
             />
           )}
           {fileSets.length > 0 && (
@@ -127,6 +134,8 @@ export default function Publication({
               fileSets={fileSets}
               reportLink={`/multireport/?type=FileSet&publications.@id=${publication["@id"]}`}
               reportLabel="Report of file sets with this publication"
+              pagePanels={pagePanels}
+              pagePanelId="file-sets"
             />
           )}
           {workflows.length > 0 && (
@@ -134,6 +143,8 @@ export default function Publication({
               workflows={workflows}
               reportLink={`/multireport/?type=Workflow&publications.@id=${publication["@id"]}`}
               reportLabel="Report of workflows with this publication"
+              pagePanels={pagePanels}
+              pagePanelId="workflows"
             />
           )}
           {software.length > 0 && (
@@ -141,6 +152,8 @@ export default function Publication({
               software={software}
               reportLink={`/multireport/?type=Software&publications.@id=${publication["@id"]}`}
               reportLabel="Report of software with this publication"
+              pagePanels={pagePanels}
+              pagePanelId="software"
             />
           )}
           {softwareVersions.length > 0 && (
@@ -148,6 +161,8 @@ export default function Publication({
               versions={softwareVersions}
               reportLink={`/multireport/?type=SoftwareVersion&publications.@id=${publication["@id"]}`}
               reportLabel="Report of software versions with this publication"
+              pagePanels={pagePanels}
+              pagePanelId="software-versions"
             />
           )}
           <Attribution attribution={attribution} />

--- a/pages/reference-files/[...id].js
+++ b/pages/reference-files/[...id].js
@@ -49,7 +49,7 @@ export default function ReferenceFile({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(referenceFile["@id"]);
   console.log("REFERENCE FILE", referenceFile["@id"]);
 
   return (

--- a/pages/reference-files/[...id].js
+++ b/pages/reference-files/[...id].js
@@ -49,7 +49,7 @@ export default function ReferenceFile({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(referenceFile["@id"]);
+  const pagePanels = usePagePanels();
   console.log("REFERENCE FILE", referenceFile["@id"]);
 
   return (

--- a/pages/reference-files/[...id].js
+++ b/pages/reference-files/[...id].js
@@ -21,6 +21,7 @@ import FileSetTable from "../../components/file-set-table";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -48,6 +49,9 @@ export default function ReferenceFile({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(referenceFile["@id"]);
+  console.log("REFERENCE FILE", referenceFile["@id"]);
+
   return (
     <>
       <Breadcrumbs item={referenceFile} />
@@ -110,8 +114,10 @@ export default function ReferenceFile({
               derivedFrom={derivedFrom}
               derivedFromFileSets={derivedFromFileSets}
               reportLink={`/multireport/?type=File&input_file_for=${referenceFile["@id"]}`}
-              reportLabel={`Report of files ${referenceFile.accession} derives from`}
-              title={`Files ${referenceFile.accession} Derives From`}
+              reportLabel="Report of files that this file derives from"
+              title="Files This File Derives From"
+              pagePanels={pagePanels}
+              pagePanelId="derived-from"
             />
           )}
           {inputFileFor.length > 0 && (
@@ -120,12 +126,16 @@ export default function ReferenceFile({
               reportLink={`/multireport/?type=File&derived_from=${referenceFile["@id"]}`}
               reportLabel="Report of files derived from this file"
               title="Files Derived From This File"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-for"
             />
           )}
           {fileFormatSpecifications.length > 0 && (
             <DocumentTable
               documents={fileFormatSpecifications}
               title="File Format Specifications"
+              pagePanels={pagePanels}
+              pagePanelId="file-format-specifications"
             />
           )}
           {integratedIn.length > 0 && (
@@ -134,9 +144,17 @@ export default function ReferenceFile({
               title="Integrated In"
               reportLink={`/multireport/?type=ConstructLibrarySet&integrated_content_files.@id=${referenceFile["@id"]}`}
               reportLabel={`View ConstructLibrarySets integrated with ${referenceFile.accession}`}
+              pagePanels={pagePanels}
+              pagePanelId="integrated-in"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/rodent-donors/[uuid].js
+++ b/pages/rodent-donors/[uuid].js
@@ -16,6 +16,7 @@ import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import {
@@ -40,6 +41,8 @@ export default function RodentDonor({
   sources = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(donor["@id"]);
+
   return (
     <>
       <Breadcrumbs item={donor} />
@@ -92,9 +95,19 @@ export default function RodentDonor({
             </DataArea>
           </DataPanel>
           {phenotypicFeatures.length > 0 && (
-            <PhenotypicFeatureTable phenotypicFeatures={phenotypicFeatures} />
+            <PhenotypicFeatureTable
+              phenotypicFeatures={phenotypicFeatures}
+              pagePanels={pagePanels}
+              pagePanelId="phenotypic-features"
+            />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/rodent-donors/[uuid].js
+++ b/pages/rodent-donors/[uuid].js
@@ -41,7 +41,7 @@ export default function RodentDonor({
   sources = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(donor["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/rodent-donors/[uuid].js
+++ b/pages/rodent-donors/[uuid].js
@@ -41,7 +41,7 @@ export default function RodentDonor({
   sources = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(donor["@id"]);
 
   return (
     <>

--- a/pages/sequence-files/[...id].js
+++ b/pages/sequence-files/[...id].js
@@ -50,7 +50,7 @@ export default function SequenceFile({
   isJson,
   seqspecs,
 }) {
-  const pagePanels = usePagePanels(sequenceFile["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/sequence-files/[...id].js
+++ b/pages/sequence-files/[...id].js
@@ -50,7 +50,7 @@ export default function SequenceFile({
   isJson,
   seqspecs,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(sequenceFile["@id"]);
 
   return (
     <>

--- a/pages/sequence-files/[...id].js
+++ b/pages/sequence-files/[...id].js
@@ -20,6 +20,7 @@ import { FileHeaderDownload } from "../../components/file-download";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -49,6 +50,8 @@ export default function SequenceFile({
   isJson,
   seqspecs,
 }) {
+  const pagePanels = usePagePanels(sequenceFile["@id"]);
+
   return (
     <>
       <Breadcrumbs item={sequenceFile} />
@@ -141,8 +144,10 @@ export default function SequenceFile({
               derivedFrom={derivedFrom}
               derivedFromFileSets={derivedFromFileSets}
               reportLink={`/multireport/?type=File&input_file_for=${sequenceFile["@id"]}`}
-              reportLabel={`Report of files ${sequenceFile.accession} derives from`}
-              title={`Files ${sequenceFile.accession} Derives From`}
+              reportLabel="Report of files that this file derives from"
+              title="Files This File Derives From"
+              pagePanels={pagePanels}
+              pagePanelId="derived-from"
             />
           )}
           {inputFileFor.length > 0 && (
@@ -151,6 +156,8 @@ export default function SequenceFile({
               reportLink={`/multireport/?type=File&derived_from=${sequenceFile["@id"]}`}
               reportLabel="Report of files derived from this file"
               title="Files Derived From This File"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-for"
             />
           )}
           {seqspecs.length > 0 && (
@@ -158,15 +165,25 @@ export default function SequenceFile({
               files={seqspecs}
               title="Associated seqspec Files"
               reportLink={`/multireport/?type=ConfigurationFile&seqspec_of=${sequenceFile["@id"]}`}
+              pagePanels={pagePanels}
+              pagePanelId="associated-seqspec-files"
             />
           )}
           {fileFormatSpecifications.length > 0 && (
             <DocumentTable
               documents={fileFormatSpecifications}
               title="File Format Specifications"
+              pagePanels={pagePanels}
+              pagePanelId="file-format-specifications"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/signal-files/[...id].js
+++ b/pages/signal-files/[...id].js
@@ -47,7 +47,7 @@ export default function SignalFile({
   referenceFiles,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(signalFile["@id"]);
 
   return (
     <>

--- a/pages/signal-files/[...id].js
+++ b/pages/signal-files/[...id].js
@@ -47,7 +47,7 @@ export default function SignalFile({
   referenceFiles,
   isJson,
 }) {
-  const pagePanels = usePagePanels(signalFile["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/signal-files/[...id].js
+++ b/pages/signal-files/[...id].js
@@ -19,6 +19,7 @@ import { FileHeaderDownload } from "../../components/file-download";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -46,6 +47,8 @@ export default function SignalFile({
   referenceFiles,
   isJson,
 }) {
+  const pagePanels = usePagePanels(signalFile["@id"]);
+
   return (
     <>
       <Breadcrumbs item={signalFile} />
@@ -98,8 +101,10 @@ export default function SignalFile({
               derivedFrom={derivedFrom}
               derivedFromFileSets={derivedFromFileSets}
               reportLink={`/multireport/?type=File&input_file_for=${signalFile["@id"]}`}
-              reportLabel={`Report of files ${signalFile.accession} derives from`}
-              title={`Files ${signalFile.accession} Derives From`}
+              reportLabel="Report of files that this file derives from"
+              title="Files This File Derives From"
+              pagePanels={pagePanels}
+              pagePanelId="derived-from"
             />
           )}
           {inputFileFor.length > 0 && (
@@ -108,18 +113,33 @@ export default function SignalFile({
               reportLink={`/multireport/?type=File&derived_from=${signalFile["@id"]}`}
               reportLabel="Report of files derived from this file"
               title="Files Derived From This File"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-for"
             />
           )}
           {referenceFiles.length > 0 && (
-            <FileTable files={referenceFiles} title="Reference Files" />
+            <FileTable
+              files={referenceFiles}
+              title="Reference Files"
+              pagePanels={pagePanels}
+              pagePanelId="reference-files"
+            />
           )}
           {fileFormatSpecifications.length > 0 && (
             <DocumentTable
               documents={fileFormatSpecifications}
               title="File Format Specifications"
+              pagePanels={pagePanels}
+              pagePanelId="file-format-specifications"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/software/[id].js
+++ b/pages/software/[id].js
@@ -36,7 +36,7 @@ export default function Software({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(software["@id"]);
 
   return (
     <>

--- a/pages/software/[id].js
+++ b/pages/software/[id].js
@@ -36,7 +36,7 @@ export default function Software({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(software["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/software/[id].js
+++ b/pages/software/[id].js
@@ -15,6 +15,7 @@ import {
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SoftwareVersionTable from "../../components/software-version-table";
 // lib
@@ -35,6 +36,8 @@ export default function Software({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(software["@id"]);
+
   return (
     <>
       <Breadcrumbs item={software} />
@@ -81,7 +84,13 @@ export default function Software({
             </DataArea>
           </DataPanel>
 
-          {versions?.length > 0 && <SoftwareVersionTable versions={versions} />}
+          {versions?.length > 0 && (
+            <SoftwareVersionTable
+              versions={versions}
+              pagePanels={pagePanels}
+              pagePanelId="software-versions"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/tabular-files/[...id].js
+++ b/pages/tabular-files/[...id].js
@@ -48,7 +48,7 @@ export default function TabularFile({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(tabularFile["@id"]);
 
   return (
     <>

--- a/pages/tabular-files/[...id].js
+++ b/pages/tabular-files/[...id].js
@@ -48,7 +48,7 @@ export default function TabularFile({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(tabularFile["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/tabular-files/[...id].js
+++ b/pages/tabular-files/[...id].js
@@ -20,6 +20,7 @@ import FileSetTable from "../../components/file-set-table";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import buildAttribution from "../../lib/attribution";
@@ -47,6 +48,8 @@ export default function TabularFile({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(tabularFile["@id"]);
+
   return (
     <>
       <Breadcrumbs item={tabularFile} />
@@ -94,7 +97,9 @@ export default function TabularFile({
               derivedFromFileSets={derivedFromFileSets}
               reportLink={`/multireport/?type=File&input_file_for=${tabularFile["@id"]}`}
               reportLabel="Report of files that this file derives from"
-              title={`Files ${tabularFile.accession} Derives From`}
+              title="Files This File Derives From"
+              pagePanels={pagePanels}
+              pagePanelId="derived-from"
             />
           )}
           {inputFileFor.length > 0 && (
@@ -103,6 +108,8 @@ export default function TabularFile({
               reportLink={`/multireport/?type=File&derived_from=${tabularFile["@id"]}`}
               reportLabel="Report of files derived from this file"
               title="Files Derived From This File"
+              pagePanels={pagePanels}
+              pagePanelId="input-file-for"
             />
           )}
           {integratedIn.length > 0 && (
@@ -111,15 +118,25 @@ export default function TabularFile({
               title="Integrated In"
               reportLink={`/multireport/?type=ConstructLibrarySet&integrated_content_files.@id=${tabularFile["@id"]}`}
               reportLabel={`Report of ConstructLibrarySets that integrate ${tabularFile.accession}`}
+              pagePanels={pagePanels}
+              pagePanelId="integrated-in"
             />
           )}
           {fileFormatSpecifications.length > 0 && (
             <DocumentTable
               documents={fileFormatSpecifications}
               title="File Format Specifications"
+              pagePanels={pagePanels}
+              pagePanelId="file-format-specifications"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/technical-samples/[uuid].js
+++ b/pages/technical-samples/[uuid].js
@@ -17,6 +17,7 @@ import { EditableItem } from "../../components/edit";
 import FileSetTable from "../../components/file-set-table";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";
 // lib
@@ -45,6 +46,8 @@ export default function TechnicalSample({
   multiplexedInSamples,
   isJson,
 }) {
+  const pagePanels = usePagePanels(sample["@id"]);
+
   return (
     <>
       <Breadcrumbs item={sample} />
@@ -81,6 +84,8 @@ export default function TechnicalSample({
               fileSets={sample.file_sets}
               reportLink={`/multireport/?type=FileSet&samples.@id=${sample["@id"]}`}
               reportLabel="Report of file sets containing this sample"
+              pagePanels={pagePanels}
+              pagePanelId="file-sets"
             />
           )}
           {multiplexedInSamples.length > 0 && (
@@ -89,6 +94,8 @@ export default function TechnicalSample({
               reportLink={`/multireport/?type=MultiplexedSample&multiplexed_samples.@id=${sample["@id"]}`}
               reportLabel="Report of multiplexed samples in which this sample is included"
               title="Multiplexed In Samples"
+              pagePanels={pagePanels}
+              pagePanelId="multiplexed-in-samples"
             />
           )}
           {sortedFractions.length > 0 && (
@@ -97,9 +104,17 @@ export default function TechnicalSample({
               reportLink={`/multireport/?type=Sample&sorted_from.@id=${sample["@id"]}`}
               reportLabel="Report of fractions into which this sample has been sorted"
               title="Sorted Fractions of Sample"
+              pagePanels={pagePanels}
+              pagePanelId="sorted-fractions"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/technical-samples/[uuid].js
+++ b/pages/technical-samples/[uuid].js
@@ -46,7 +46,7 @@ export default function TechnicalSample({
   multiplexedInSamples,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(sample["@id"]);
 
   return (
     <>

--- a/pages/technical-samples/[uuid].js
+++ b/pages/technical-samples/[uuid].js
@@ -46,7 +46,7 @@ export default function TechnicalSample({
   multiplexedInSamples,
   isJson,
 }) {
-  const pagePanels = usePagePanels(sample["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/tissues/[uuid].js
+++ b/pages/tissues/[uuid].js
@@ -60,7 +60,7 @@ export default function Tissue({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(tissue["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/tissues/[uuid].js
+++ b/pages/tissues/[uuid].js
@@ -20,6 +20,7 @@ import FileSetTable from "../../components/file-set-table";
 import JsonDisplay from "../../components/json-display";
 import ModificationTable from "../../components/modification-table";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";
 import TreatmentTable from "../../components/treatment-table";
@@ -59,6 +60,8 @@ export default function Tissue({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(tissue["@id"]);
+
   return (
     <>
       <Breadcrumbs item={tissue} />
@@ -123,12 +126,20 @@ export default function Tissue({
               </BiosampleDataItems>
             </DataArea>
           </DataPanel>
-          {donors.length > 0 && <DonorTable donors={donors} />}
+          {donors.length > 0 && (
+            <DonorTable
+              donors={donors}
+              pagePanels={pagePanels}
+              pagePanelId="donors"
+            />
+          )}
           {tissue.file_sets.length > 0 && (
             <FileSetTable
               fileSets={tissue.file_sets}
               reportLink={`/multireport/?type=FileSet&samples.@id=${tissue["@id"]}`}
               reportLabel="Report of file sets containing this sample"
+              pagePanels={pagePanels}
+              pagePanelId="file-sets"
             />
           )}
           {multiplexedInSamples.length > 0 && (
@@ -137,6 +148,8 @@ export default function Tissue({
               reportLink={`/multireport/?type=MultiplexedSample&multiplexed_samples.@id=${tissue["@id"]}`}
               reportLabel="Report of multiplexed samples in which this sample is included"
               title="Multiplexed In Samples"
+              pagePanels={pagePanels}
+              pagePanelId="multiplexed-in-samples"
             />
           )}
           {pooledFrom.length > 0 && (
@@ -145,6 +158,8 @@ export default function Tissue({
               reportLink={`/multireport/?type=Sample&pooled_in=${tissue["@id"]}`}
               reportLabel="Report of biosamples this biosample is pooled from"
               title="Biosamples Pooled From"
+              pagePanels={pagePanels}
+              pagePanelId="pooled-from"
             />
           )}
           {pooledIn.length > 0 && (
@@ -153,6 +168,8 @@ export default function Tissue({
               reportLink={`/multireport/?type=Biosample&pooled_from=${tissue["@id"]}`}
               reportLabel="Report of pooled samples in which this sample is included"
               title="Pooled In"
+              pagePanels={pagePanels}
+              pagePanelId="pooled-in"
             />
           )}
           {parts.length > 0 && (
@@ -161,6 +178,8 @@ export default function Tissue({
               reportLink={`/multireport/?type=Biosample&part_of=${tissue["@id"]}`}
               reportLabel="Report of parts into which this sample has been divided"
               title="Sample Parts"
+              pagePanels={pagePanels}
+              pagePanelId="parts"
             />
           )}
           {tissue.modifications?.length > 0 && (
@@ -168,6 +187,8 @@ export default function Tissue({
               modifications={tissue.modifications}
               reportLink={`/multireport/?type=Modification&biosamples_modified=${tissue["@id"]}`}
               reportLabel={`Report of genetic modifications for ${tissue.accession}`}
+              pagePanels={pagePanels}
+              pagePanelId="modifications"
             />
           )}
           {sortedFractions.length > 0 && (
@@ -176,6 +197,8 @@ export default function Tissue({
               reportLink={`/multireport/?type=Sample&sorted_from.@id=${tissue["@id"]}`}
               reportLabel="Report of fractions into which this sample has been sorted"
               title="Sorted Fractions of Sample"
+              pagePanels={pagePanels}
+              pagePanelId="sorted-fractions"
             />
           )}
           {biomarkers.length > 0 && (
@@ -183,6 +206,8 @@ export default function Tissue({
               biomarkers={biomarkers}
               reportLink={`/multireport/?type=Biomarker&biomarker_for=${tissue["@id"]}`}
               reportLabel={`Report of biological markers that are associated with biosample ${tissue.accession}`}
+              pagePanels={pagePanels}
+              pagePanelId="biomarkers"
             />
           )}
           {treatments.length > 0 && (
@@ -190,9 +215,17 @@ export default function Tissue({
               treatments={treatments}
               reportLink={`/multireport/?type=Treatment&biosamples_treated=${tissue["@id"]}`}
               reportLabel={`Report of treatments applied to the biosample ${tissue.accession}`}
+              pagePanels={pagePanels}
+              pagePanelId="treatments"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/tissues/[uuid].js
+++ b/pages/tissues/[uuid].js
@@ -60,7 +60,7 @@ export default function Tissue({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(tissue["@id"]);
 
   return (
     <>

--- a/pages/treatments/[uuid].js
+++ b/pages/treatments/[uuid].js
@@ -15,6 +15,7 @@ import ProductInfo from "../../components/product-info";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";
 // lib
@@ -35,6 +36,8 @@ export default function Treatment({
   sources,
   isJson,
 }) {
+  const pagePanels = usePagePanels(treatment["@id"]);
+
   return (
     <>
       <Breadcrumbs item={treatment} />
@@ -141,9 +144,17 @@ export default function Treatment({
             <SampleTable
               samples={biosamplesTreated}
               title="Treated Biosamples"
+              pagePanels={pagePanels}
+              pagePanelId="biosamples-treated"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/treatments/[uuid].js
+++ b/pages/treatments/[uuid].js
@@ -36,7 +36,7 @@ export default function Treatment({
   sources,
   isJson,
 }) {
-  const pagePanels = usePagePanels(treatment["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/treatments/[uuid].js
+++ b/pages/treatments/[uuid].js
@@ -36,7 +36,7 @@ export default function Treatment({
   sources,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(treatment["@id"]);
 
   return (
     <>

--- a/pages/whole-organisms/[id].js
+++ b/pages/whole-organisms/[id].js
@@ -14,6 +14,7 @@ import FileSetTable from "../../components/file-set-table";
 import JsonDisplay from "../../components/json-display";
 import ModificationTable from "../../components/modification-table";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";
 import TreatmentTable from "../../components/treatment-table";
@@ -51,6 +52,8 @@ export default function WholeOrganism({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(sample["@id"]);
+
   return (
     <>
       <Breadcrumbs item={sample} />
@@ -79,12 +82,20 @@ export default function WholeOrganism({
               />
             </DataArea>
           </DataPanel>
-          {donors.length > 0 && <DonorTable donors={donors} />}
+          {donors.length > 0 && (
+            <DonorTable
+              donors={donors}
+              pagePanels={pagePanels}
+              pagePanelId="donors"
+            />
+          )}
           {sample.file_sets.length > 0 && (
             <FileSetTable
               fileSets={sample.file_sets}
               reportLink={`/multireport/?type=FileSet&samples.@id=${sample["@id"]}`}
               reportLabel="Report of file sets containing this sample"
+              pagePanels={pagePanels}
+              pagePanelId="file-sets"
             />
           )}
           {multiplexedInSamples.length > 0 && (
@@ -93,6 +104,8 @@ export default function WholeOrganism({
               reportLink={`/multireport/?type=MultiplexedSample&multiplexed_samples.@id=${sample["@id"]}`}
               reportLabel="Report of multiplexed samples in which this sample is included"
               title="Multiplexed In Samples"
+              pagePanels={pagePanels}
+              pagePanelId="multiplexed-in-samples"
             />
           )}
           {pooledIn.length > 0 && (
@@ -101,6 +114,8 @@ export default function WholeOrganism({
               reportLink={`/multireport/?type=Biosample&pooled_from=${sample["@id"]}`}
               reportLabel="Report of pooled samples in which this sample is included"
               title="Pooled In"
+              pagePanels={pagePanels}
+              pagePanelId="pooled-in"
             />
           )}
           {parts.length > 0 && (
@@ -109,6 +124,8 @@ export default function WholeOrganism({
               reportLink={`/multireport/?type=Biosample&part_of=${sample["@id"]}`}
               reportLabel="Report of parts into which this sample has been divided"
               title="Sample Parts"
+              pagePanels={pagePanels}
+              pagePanelId="parts"
             />
           )}
           {sample.modifications?.length > 0 && (
@@ -116,6 +133,8 @@ export default function WholeOrganism({
               modifications={sample.modifications}
               reportLink={`/multireport/?type=Modification&biosamples_modified=${sample["@id"]}`}
               reportLabel={`Report of genetic modifications for ${sample.accession}`}
+              pagePanels={pagePanels}
+              pagePanelId="modifications"
             />
           )}
           {sortedFractions.length > 0 && (
@@ -124,6 +143,8 @@ export default function WholeOrganism({
               reportLink={`/multireport/?type=Sample&sorted_from.@id=${sample["@id"]}`}
               reportLabel="Report of fractions into which this sample has been sorted"
               title="Sorted Fractions of Sample"
+              pagePanels={pagePanels}
+              pagePanelId="sorted-fractions"
             />
           )}
           {biomarkers.length > 0 && (
@@ -131,6 +152,8 @@ export default function WholeOrganism({
               biomarkers={biomarkers}
               reportLink={`/multireport/?type=Biomarker&biomarker_for=${sample["@id"]}`}
               reportLabel={`Report of biological markers that are associated with biosample ${sample.accession}`}
+              pagePanels={pagePanels}
+              pagePanelId="biomarkers"
             />
           )}
           {treatments.length > 0 && (
@@ -138,9 +161,17 @@ export default function WholeOrganism({
               treatments={treatments}
               reportLink={`/multireport/?type=Treatment&biosamples_treated=${sample["@id"]}`}
               reportLabel={`Report of treatments applied to the biosample ${sample.accession}`}
+              pagePanels={pagePanels}
+              pagePanelId="treatments"
             />
           )}
-          {documents.length > 0 && <DocumentTable documents={documents} />}
+          {documents.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>

--- a/pages/whole-organisms/[id].js
+++ b/pages/whole-organisms/[id].js
@@ -52,7 +52,7 @@ export default function WholeOrganism({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(sample["@id"]);
 
   return (
     <>

--- a/pages/whole-organisms/[id].js
+++ b/pages/whole-organisms/[id].js
@@ -52,7 +52,7 @@ export default function WholeOrganism({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(sample["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/workflows/[id].js
+++ b/pages/workflows/[id].js
@@ -40,7 +40,7 @@ export default function Workflow({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels(workflow["@id"]);
+  const pagePanels = usePagePanels();
 
   return (
     <>

--- a/pages/workflows/[id].js
+++ b/pages/workflows/[id].js
@@ -40,7 +40,7 @@ export default function Workflow({
   attribution = null,
   isJson,
 }) {
-  const pagePanels = usePagePanels();
+  const pagePanels = usePagePanels(workflow["@id"]);
 
   return (
     <>

--- a/pages/workflows/[id].js
+++ b/pages/workflows/[id].js
@@ -18,6 +18,7 @@ import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";
+import { usePagePanels } from "../../components/page-panels";
 import PagePreamble from "../../components/page-preamble";
 // lib
 import {
@@ -39,6 +40,8 @@ export default function Workflow({
   attribution = null,
   isJson,
 }) {
+  const pagePanels = usePagePanels(workflow["@id"]);
+
   return (
     <>
       <Breadcrumbs item={workflow} />
@@ -136,9 +139,17 @@ export default function Workflow({
               analysisSteps={analysisSteps}
               reportLink={`/multireport/?type=AnalysisStep&workflow.@id=${workflow["@id"]}`}
               reportLabel="Analysis Steps that link to this workflow"
+              pagePanels={pagePanels}
+              pagePanelId="analysis-steps"
             />
           )}
-          {documents?.length > 0 && <DocumentTable documents={documents} />}
+          {documents?.length > 0 && (
+            <DocumentTable
+              documents={documents}
+              pagePanels={pagePanels}
+              pagePanelId="documents"
+            />
+          )}
           <Attribution attribution={attribution} />
         </JsonDisplay>
       </EditableItem>


### PR DESCRIPTION
Yeah, this is a lot of changed files. But all the ones in the `pages` directory have virtually the same changes for each table they display. They call `usePagePanels()` with the path of the page, then pass the resulting `pagePanels` as well as an ID to each table. Also, all components that display tables (the files ending in `-table.js`)  have pretty much the same changes as well. They accept `pagePanels` and `pagePanelId`, then use a new `DataAreaTitle.Expander` component to display the expand/collapse button, and use `pagePanel.isExpanded` to determine whether to render the table or not.

Focus most on the new code, which is in `page-panels.tsx`. I wrote it in Typescript, but the Typescript is all pretty basic. I also rewrote browser-storage.js in Typescript as it helps for `page-panels` quite a bit. Again, the Typescript conversion is pretty basic. The `T` type just says whatever type I pass in the parameter becomes the type of the first array element the hook returns.

Pretty much all other changes are the same changes over and over, as I described, plus additions to Jest tests and an adjustment to a Cypress test to expand a table.