### PR TITLE
IGVF-2439 Multiplexed samples check construct library sets before using them

### DIFF
--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -66,6 +66,7 @@ config: Dict[str, Any] = {
                 'max_capacity': 4,
                 'use_redis_named': 'Redis71',
             },
+            'backend_url': 'https://igvfd-igvf-2401-fix-audit-nucleic.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/cdk/infrastructure/config.py
+++ b/cdk/infrastructure/config.py
@@ -66,7 +66,6 @@ config: Dict[str, Any] = {
                 'max_capacity': 4,
                 'use_redis_named': 'Redis71',
             },
-            'backend_url': 'https://igvfd-igvf-2401-fix-audit-nucleic.demo.igvf.org',
             'tags': [
                 ('time-to-live-hours', '60'),
                 ('turn-off-on-friday-night', 'yes'),

--- a/pages/multiplexed-samples/[uuid].js
+++ b/pages/multiplexed-samples/[uuid].js
@@ -215,7 +215,7 @@ export async function getServerSideProps({ params, req, query }) {
   ).union();
   if (FetchRequest.isResponseSuccess(multiplexedSample)) {
     let constructLibrarySets = [];
-    if (multiplexedSample.construct_library_sets.length > 0) {
+    if (multiplexedSample.construct_library_sets?.length > 0) {
       const constructLibrarySetPaths =
         multiplexedSample.construct_library_sets.map(
           (constructLibrarySet) => constructLibrarySet["@id"]


### PR DESCRIPTION
Calculated properties will disappear from some objects when empty instead of having an empty array. This change is needed to prevent a crash in tomorrow’s release. More changes like this will follow in future releases.