### PR TITLE
IGVF-2453 Fix applied-to samples report link.

### DIFF
--- a/pages/construct-library-sets/[id].js
+++ b/pages/construct-library-sets/[id].js
@@ -346,7 +346,7 @@ export default function ConstructLibrarySet({
           {constructLibrarySet.applied_to_samples.length > 0 && (
             <SampleTable
               samples={constructLibrarySet.applied_to_samples}
-              reportLink={`/multireport/?type=Sample&construct_library_sets=${constructLibrarySet["@id"]}`}
+              reportLink={`/multireport/?type=Sample&construct_library_sets.@id=${constructLibrarySet["@id"]}`}
               reportLabel="Report of samples that link to this construct library set"
               title="Applied to Samples"
             />


### PR DESCRIPTION
This looks to have been caused by an embedding change in search results.