### PR TITLE
IGVF-2578 Barcode map fixes

### DIFF
--- a/lib/facets.ts
+++ b/lib/facets.ts
@@ -234,7 +234,7 @@ export async function getFacetConfig(
   request: FetchRequest
 ): Promise<FacetOpenState> {
   const apiPath = generateFacetConfigApiPath(userUuid, selectedType);
-  return (await request.getObject(apiPath)).unwrap_or({}) as FacetOpenState;
+  return (await request.getObject(apiPath)).optional() as FacetOpenState;
 }
 
 /**

--- a/pages/multiplexed-samples/[uuid].js
+++ b/pages/multiplexed-samples/[uuid].js
@@ -299,7 +299,7 @@ export async function getServerSideProps({ params, req, query }) {
       );
     }
     const barcodeMap = multiplexedSample.barcode_map
-      ? (await request.getObject(multiplexedSample.barcode_map)).unwrap_or({})
+      ? (await request.getObject(multiplexedSample.barcode_map)).optional()
       : null;
     const attribution = await buildAttribution(
       multiplexedSample,

--- a/pages/tabular-files/[...id].js
+++ b/pages/tabular-files/[...id].js
@@ -216,7 +216,7 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         : [];
     const barcodeMapFor =
       tabularFile.barcode_map_for.length > 0
-        ? await requestFiles(tabularFile.barcode_map_for, request)
+        ? await requestSamples(tabularFile.barcode_map_for, request)
         : [];
     const inputFileFor =
       tabularFile.input_file_for.length > 0


### PR DESCRIPTION
`.unwrap_or({})` returns the requested object if successful, or an empty object if not. The React code was expecting a null instead of an empty object. This replaces that with `.optional()` so failure returns a null.