### PR TITLE
IGVF-2150 Remove link prefetching on schemas page

### DIFF
--- a/components/add.js
+++ b/components/add.js
@@ -87,7 +87,7 @@ function schemaToName(schema) {
  * Generates a button link to the #!add url for the given collection.
  * A custom label can be suplied with the `label` prop.
  */
-export function AddLink({ schema, label = null }) {
+export function AddLink({ schema, label = null, prefetch = true }) {
   const { isAuthenticated } = useAuth0();
   if (isAuthenticated && canEdit(schema)) {
     const schemaName = schemaToName(schema);
@@ -104,6 +104,7 @@ export function AddLink({ schema, label = null }) {
           size="sm"
           type="secondary"
           hasIconOnly
+          prefetch={prefetch}
         >
           <PlusIcon />
         </ButtonLink>
@@ -118,6 +119,8 @@ AddLink.propTypes = {
   schema: PropTypes.object.isRequired,
   // Label for the Add button
   label: PropTypes.string,
+  // False to disable link prefetching
+  prefetch: PropTypes.bool,
 };
 
 export function AddInstancePage({ collection }) {

--- a/components/chart-file-set-lab.js
+++ b/components/chart-file-set-lab.js
@@ -109,7 +109,11 @@ CustomXTick.propTypes = {
  * `shouldIncludeLinks` is true.
  */
 function BarLink({ path, children }) {
-  return <Link href={path}>{children}</Link>;
+  return (
+    <Link href={path} prefetch={false}>
+      {children}
+    </Link>
+  );
 }
 
 BarLink.propTypes = {

--- a/components/form-elements/__tests__/button.test.js
+++ b/components/form-elements/__tests__/button.test.js
@@ -120,6 +120,36 @@ describe("ButtonLink component", () => {
     );
     expect(container.firstChild.tagName).toBe("A");
   });
+
+  it("renders an `<A>` tag normally when `prefetch` is set to false", () => {
+    const { container } = render(
+      <ButtonLink href="/" prefetch={false}>
+        No prefetch
+      </ButtonLink>
+    );
+
+    expect(container.firstChild.tagName).toBe("A");
+  });
+
+  it("renders an `<A>` tag normally when `prefetch` is set to true", () => {
+    const { container } = render(
+      <ButtonLink href="/" prefetch={true}>
+        No prefetch
+      </ButtonLink>
+    );
+
+    expect(container.firstChild.tagName).toBe("A");
+  });
+
+  it("renders an `<A>` tag normally when `prefetch` is set to null", () => {
+    const { container } = render(
+      <ButtonLink href="/" prefetch={null}>
+        No prefetch
+      </ButtonLink>
+    );
+
+    expect(container.firstChild.tagName).toBe("A");
+  });
 });
 
 describe("Test the Tailwind CSS classes resulting from using the `hasIconOnly` flag", () => {

--- a/components/form-elements/button.js
+++ b/components/form-elements/button.js
@@ -198,26 +198,28 @@ Button.displayName = "Button";
  */
 function LinkElement(props) {
   const { isExternal } = props;
+  const prefetch = props.prefetch ?? true;
 
-  // Make a copy of `props` but without `isExternal` in case it was included.
-  const { isExternal: _, ...propsWithoutIsExternal } = props;
+  // Make a copy of `props` but without `isExternal` nor `prefetch` in case it was included.
+  const { isExternal: _, prefetch: __, ...propsWithoutExceptions } = props;
 
   if (isExternal) {
-    const { isExternal: _, ...propsWithoutIsExternal } = props;
     return (
       <a
-        {...propsWithoutIsExternal}
+        {...propsWithoutExceptions}
         target="_blank"
         rel="noopener noreferrer"
       />
     );
   }
-  return <Link {...propsWithoutIsExternal} />;
+  return <Link {...propsWithoutExceptions} prefetch={prefetch} />;
 }
 
 LinkElement.propTypes = {
   // True for external links
   isExternal: PropTypes.bool,
+  // True to prefetch the link
+  prefetch: PropTypes.bool,
 };
 
 /**
@@ -239,6 +241,7 @@ export function ButtonLink({
   isInline = false,
   isDisabled = false,
   isExternal = false,
+  prefetch = true,
   className = "",
   children,
 }) {
@@ -265,6 +268,7 @@ export function ButtonLink({
   ) : (
     <LinkElement
       isExternal={isExternal}
+      prefetch={prefetch}
       href={href}
       aria-label={label}
       id={id}
@@ -300,6 +304,8 @@ ButtonLink.propTypes = {
   isDisabled: PropTypes.bool,
   // True if the link is external
   isExternal: PropTypes.bool,
+  // True to prefetch the link
+  prefetch: PropTypes.bool,
   // Additional Tailwind CSS classes to apply to the <button> element
   className: PropTypes.string,
 };

--- a/components/hosted-file-preview.tsx
+++ b/components/hosted-file-preview.tsx
@@ -42,7 +42,6 @@ const typePreviewMap: TypePreviewMap = {
   tsv: PreviewTsv,
   vcf: PreviewText,
   yaml: PreviewText,
-  gtf: PreviewText,
 };
 
 /**

--- a/components/hosted-file-preview.tsx
+++ b/components/hosted-file-preview.tsx
@@ -42,6 +42,7 @@ const typePreviewMap: TypePreviewMap = {
   tsv: PreviewTsv,
   vcf: PreviewText,
   yaml: PreviewText,
+  gtf: PreviewText,
 };
 
 /**

--- a/components/profiles.js
+++ b/components/profiles.js
@@ -67,7 +67,7 @@ SchemaSearchField.propTypes = {
 /**
  * Displays links to the search-list and report pages for the given schema object type.
  */
-export function SearchAndReportType({ type, title }) {
+export function SearchAndReportType({ type, title, prefetch = true }) {
   // Extra query-string parameters for list/report pages
   let extraQueries = useBrowserStateQuery();
   if (typesWithoutExtraQueries.includes(type)) {
@@ -82,6 +82,7 @@ export function SearchAndReportType({ type, title }) {
         type="secondary"
         size="sm"
         hasIconOnly
+        prefetch={prefetch}
       >
         <Bars4Icon />
       </ButtonLink>
@@ -91,6 +92,7 @@ export function SearchAndReportType({ type, title }) {
         type="secondary"
         size="sm"
         hasIconOnly
+        prefetch={prefetch}
       >
         <TableCellsIcon />
       </ButtonLink>
@@ -103,12 +105,14 @@ SearchAndReportType.propTypes = {
   type: PropTypes.string.isRequired,
   // Human-readable title for the schema
   title: PropTypes.string.isRequired,
+  // False to disable link prefetching
+  prefetch: PropTypes.bool,
 };
 
 /**
  * Display a schema's version number.
  */
-export function SchemaVersion({ schema, isLinked = false }) {
+export function SchemaVersion({ schema, isLinked = false, prefetch = true }) {
   const version = schema.properties.schema_version.default;
   const path = schemaToPath(schema);
   const className =
@@ -118,6 +122,7 @@ export function SchemaVersion({ schema, isLinked = false }) {
       <Link
         href={`${path}/changelog`}
         className={`${className} rounded-sm`}
+        prefetch={prefetch}
       >{`v${version}`}</Link>
     );
   }
@@ -129,4 +134,6 @@ SchemaVersion.propTypes = {
   schema: PropTypes.object.isRequired,
   // True to link to the changelog page, false to just display the version number
   isLinked: PropTypes.bool,
+  // False to disable link prefetching
+  prefetch: PropTypes.bool,
 };

--- a/lib/__tests__/general.test.js
+++ b/lib/__tests__/general.test.js
@@ -5,7 +5,6 @@ import {
   isValidPath,
   isValidUrl,
   itemId,
-  nullOnError,
   pathToId,
   pathToType,
   removeTrailingSlash,
@@ -91,17 +90,6 @@ describe("Test the removeTrailingSlash utility function", () => {
   it("Should remove a trailing slash from a string", () => {
     expect(removeTrailingSlash("/path/object/")).toBe("/path/object");
     expect(removeTrailingSlash("/path/object")).toBe("/path/object");
-  });
-});
-
-describe("Test nullOnError utility", () => {
-  it("should return null on error", () => {
-    expect(nullOnError({ isError: true })).toBe(null);
-  });
-  it("should return the parameter when null or not an error", () => {
-    expect(nullOnError(null)).toBe(null);
-    expect(nullOnError("hello")).toStrictEqual("hello");
-    expect(nullOnError({ hello: "world" })).toStrictEqual({ hello: "world" });
   });
 });
 

--- a/lib/general.ts
+++ b/lib/general.ts
@@ -91,22 +91,6 @@ export interface IsError {
 }
 
 /**
- * Takes a value which could be an error, and if so, returns
- * a default of null. If not an error, the value is merely returned.
- * This is used to sort of flatten the Error possibility into just
- * T or null.
- * @param {T | E extends IsError | null} x The value to be defaulted
- * @returns null if x is null or extends IsError, returns the parameter
- * x otherwise
- */
-export function nullOnError<T, E extends IsError>(x: T | E | null): T | null {
-  if (x && typeof x === "object" && "isError" in x) {
-    return null;
-  }
-  return x as T;
-}
-
-/**
  * Copy the given object but with its properties sorted alphabetically. Properties that are
  * themselves objects get sorted recursively. Properties that are arrays of objects have their
  * objects sorted. This does not handle arrays of arrays of objects, so hopefully we don't have to

--- a/pages/cell-models/[view].tsx
+++ b/pages/cell-models/[view].tsx
@@ -160,6 +160,7 @@ function RowHeaderCell({
     <Link
       href={source.href}
       className={`flex h-full items-center px-2 py-0.5 font-semibold no-underline ${bgClass}`}
+      prefetch={false}
     >
       {source.key}
     </Link>
@@ -186,6 +187,7 @@ function RowSubheaderCell({
       <Link
         href={source.href}
         className={`flex h-full items-center px-2 py-0.5 text-gray-800 no-underline dark:text-gray-200 ${bgClass} ${hoverClass}`}
+        prefetch={false}
       >
         {source.key}
       </Link>
@@ -211,6 +213,7 @@ function ColumnHeaderCell({
     <Link
       href={source.href}
       className={`grid h-full w-full place-items-end no-underline ${bgClass}`}
+      prefetch={false}
     >
       <div className="flex rotate-180 items-end whitespace-nowrap px-1 py-2 font-semibold [writing-mode:vertical-lr]">
         {source.key}
@@ -237,7 +240,11 @@ function DataCell({
   if (source.href) {
     return (
       <div className="relative h-full w-full">
-        <Link href={source.href} className={`block h-full w-full ${bgClass}`} />
+        <Link
+          href={source.href}
+          className={`block h-full w-full ${bgClass}`}
+          prefetch={false}
+        />
         <div
           className={`pointer-events-none absolute inset-0 group-hover:opacity-40 dark:group-hover:bg-opacity-30 ${hoverClass}`}
         />

--- a/pages/index.js
+++ b/pages/index.js
@@ -103,6 +103,7 @@ function Statistic({ graphic, label, value, query, colorClass }) {
       <Link
         href={`/search/?${query}`}
         className={`flex h-full items-center gap-4 p-2 no-underline`}
+        prefetch={false}
       >
         <div className="h-10 w-10 min-w-10 basis-10 rounded-full border border-gray-400 p-2 dark:border-gray-500">
           {graphic}

--- a/pages/profiles/index.js
+++ b/pages/profiles/index.js
@@ -249,10 +249,11 @@ function SubTree({
               className={`block scroll-mt-28 @xl:scroll-mt-24 ${
                 isTitleHighlighted ? "bg-schema-name-highlight" : ""
               }`}
+              prefetch={false}
             >
               {title}
             </Link>
-            <SchemaVersion schema={schema} isLinked />
+            <SchemaVersion schema={schema} prefetch={false} isLinked />
             <TooltipRef tooltipAttr={tooltipAttr}>
               <button>
                 <QuestionMarkCircleIcon className="h-4 w-4 cursor-pointer" />
@@ -261,13 +262,25 @@ function SubTree({
             <Tooltip tooltipAttr={tooltipAttr}>
               {schema.description || "No description available"}
             </Tooltip>
-            <SearchAndReportType type={objectType} title={title} />
-            <AddLink schema={schema} label={`Add ${schema.title}`} />
+            <SearchAndReportType
+              type={objectType}
+              title={title}
+              prefetch={false}
+            />
+            <AddLink
+              schema={schema}
+              label={`Add ${schema.title}`}
+              prefetch={false}
+            />
           </>
         ) : (
           <>
             {title}
-            <SearchAndReportType type={objectType} title={title} />
+            <SearchAndReportType
+              type={objectType}
+              title={title}
+              prefetch={false}
+            />
           </>
         )}
       </div>

--- a/pages/tissue-summary/[taxa].tsx
+++ b/pages/tissue-summary/[taxa].tsx
@@ -99,6 +99,7 @@ function RowHeaderCell({
     <Link
       href={source.href}
       className={`flex h-full items-center px-2 py-0.5 font-semibold no-underline ${bgClass}`}
+      prefetch={false}
     >
       {source.key}
     </Link>
@@ -125,6 +126,7 @@ function RowSubheaderCell({
       <Link
         href={source.href}
         className={`flex h-full items-center px-2 py-0.5 text-gray-800 no-underline dark:text-gray-200 ${bgClass} ${hoverClass}`}
+        prefetch={false}
       >
         {source.key}
       </Link>
@@ -150,6 +152,7 @@ function ColumnHeaderCell({
     <Link
       href={source.href}
       className={`grid h-full w-full place-items-end no-underline ${bgClass}`}
+      prefetch={false}
     >
       <div className="flex rotate-180 items-end whitespace-nowrap px-1 py-2 font-semibold [writing-mode:vertical-lr]">
         {source.key}
@@ -176,7 +179,11 @@ function DataCell({
   if (source.href) {
     return (
       <div className="relative h-full w-full">
-        <Link href={source.href} className={`block h-full w-full ${bgClass}`} />
+        <Link
+          href={source.href}
+          className={`block h-full w-full ${bgClass}`}
+          prefetch={false}
+        />
         <div
           className={`pointer-events-none absolute inset-0 group-hover:opacity-40 dark:group-hover:bg-opacity-30 ${hoverClass}`}
         />


### PR DESCRIPTION
I visited report pages but didn’t find very much prefetch load so I left those alone. The Impersonate User page has lots of buttons, but not links.

I deleted the `nullOnError` function because it has never been used, and it has Typescript issues when doing production builds locally. Not sure why I don’t see those on demos. The error stops the build.