### PR TITLE
IGVF-2277 Add file size facet

### DIFF
--- a/components/__tests__/range-selector.test.tsx
+++ b/components/__tests__/range-selector.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { RangeSelector } from "../range-selector";
+
+describe("Test RangeSelector", () => {
+  it("should render the range selector with default values", () => {
+    const onChange = jest.fn();
+
+    render(
+      <RangeSelector
+        id="test-range-selector"
+        minValue={0}
+        maxValue={100}
+        onChange={onChange}
+      />
+    );
+
+    // Make sure two inputs with type="range" are rendered.
+    const inputs = screen.getAllByRole("slider");
+    expect(inputs).toHaveLength(2);
+
+    // Change the value of the first input and make sure onChange is called with the
+    // correct values.
+    const minInput = inputs[0];
+    const maxInput = inputs[1];
+    fireEvent.input(minInput, { target: { value: 10 } });
+    expect(onChange).toHaveBeenCalledWith(10, 100);
+    fireEvent.input(maxInput, { target: { value: 90 } });
+    expect(onChange).toHaveBeenCalledWith(0, 90);
+  });
+});

--- a/components/facets/__tests__/facet-tags.test.js
+++ b/components/facets/__tests__/facet-tags.test.js
@@ -557,3 +557,84 @@ describe("Test the <FacetTags> component", () => {
     expect(tags[0]).toHaveTextContent(/Homo sapiens$/);
   });
 });
+
+describe("Test the file-size facet tags", () => {
+  it("renders file-size facet tags", () => {
+    const searchResults = {
+      "@context": "/terms/",
+      "@graph": [
+        {
+          "@id": "/sequence-files/IGVFFI1165AJSO/",
+          "@type": ["SequenceFile", "File", "Item"],
+          accession: "IGVFFI1165AJSO",
+          content_type: "Nanopore reads",
+          file_format: "pod5",
+          lab: {
+            "@id": "/labs/j-michael-cherry/",
+            title: "J. Michael Cherry, Stanford",
+          },
+          status: "released",
+          summary: "Nanopore reads from sequencing run 1",
+          upload_status: "validated",
+          uuid: "fffcd64e-af02-4675-8953-7352459ee06a",
+        },
+      ],
+      "@id": "/search/?type=File&file_size=gte:5&file_size=lte:10",
+      "@type": ["Search"],
+      all: "/search/?type=File&file_size=gte:5&file_size=lte:10&limit=all",
+      clear_filters: "/search/?type=File",
+      columns: {
+        "@id": {
+          title: "ID",
+        },
+      },
+      facet_groups: [],
+      facets: [
+        {
+          field: "file_size",
+          title: "File Size",
+          terms: {
+            count: 69,
+            min: 43,
+            max: 1453609183,
+            avg: 76413286.1884058,
+            sum: 5272516747,
+          },
+          total: 1,
+          type: "stats",
+          appended: false,
+          open_on_load: false,
+        },
+      ],
+      filters: [
+        {
+          field: "file_size",
+          term: "gte:5000",
+          remove: "/search/?type=File&file_size=lte%3A10",
+        },
+        {
+          field: "file_size",
+          term: "lte:10000000",
+          remove: "/search/?type=File&file_size=gte%3A5",
+        },
+        {
+          field: "type",
+          term: "File",
+          remove: "/search/?file_size=gte%3A5&file_size=lte%3A10",
+        },
+      ],
+      notification: "Success",
+      title: "Search",
+      total: 1,
+    };
+
+    render(<FacetTags searchResults={searchResults} />);
+    const tagSection = screen.getByTestId("facettags");
+    const tags = within(tagSection).getAllByRole("link");
+    expect(tags.length).toBe(2);
+    expect(tags[0]).toHaveTextContent(/^File Size/);
+    expect(tags[0]).toHaveTextContent("> 5.0 KB");
+    expect(tags[1]).toHaveTextContent(/^File Size/);
+    expect(tags[1]).toHaveTextContent("< 10 MB");
+  });
+});

--- a/components/facets/__tests__/file-size-terms.test.tsx
+++ b/components/facets/__tests__/file-size-terms.test.tsx
@@ -1,0 +1,478 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { jest } from "@jest/globals";
+import FileSizeTerms from "../custom-facets/file-size-terms";
+import type { SearchResults } from "../../../globals";
+
+type ResizeObserverCallback = (entries: ResizeObserverEntry[]) => void;
+
+class ResizeObserverMock {
+  callback: ResizeObserverCallback;
+  observe = jest.fn();
+  unobserve = jest.fn();
+  disconnect = jest.fn();
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+
+  // Custom method you can call in your test
+  trigger(entries: ResizeObserverEntry[]) {
+    this.callback(entries);
+  }
+}
+
+// Mock the ResizeObserver class globally
+function resizeObserverMock(resizeObserverInstance: ResizeObserverMock) {
+  resizeObserverInstance.trigger([
+    {
+      target: document.createElement("div"),
+      contentRect: {
+        width: 500,
+        height: 300,
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      },
+    } as unknown as ResizeObserverEntry,
+  ]);
+}
+
+describe("Test FileSizeTerms component", () => {
+  let resizeObserverInstance: ResizeObserverMock;
+
+  beforeAll(() => {
+    // Override the global ResizeObserver
+    global.ResizeObserver = jest.fn(
+      (...args: ConstructorParameters<typeof ResizeObserverMock>) => {
+        resizeObserverInstance = new ResizeObserverMock(...args);
+        return resizeObserverInstance;
+      }
+    ) as unknown as typeof ResizeObserver;
+  });
+
+  it("renders a file-size terms facet with limits in the query string", () => {
+    jest.useFakeTimers();
+
+    const searchResults: SearchResults = {
+      "@context": "/terms/",
+      "@graph": [
+        {
+          "@id": "/sequence-files/IGVFFI1165AJSO/",
+          "@type": ["SequenceFile", "File", "Item"],
+          accession: "IGVFFI1165AJSO",
+          content_type: "Nanopore reads",
+          file_format: "pod5",
+          lab: {
+            "@id": "/labs/j-michael-cherry/",
+            title: "J. Michael Cherry, Stanford",
+          },
+          status: "released",
+          summary: "Nanopore reads from sequencing run 1",
+          upload_status: "validated",
+          uuid: "fffcd64e-af02-4675-8953-7352459ee06a",
+        },
+      ],
+      "@id": "/search/?type=File&file_size=gte:5000&file_size=lte:10000000",
+      "@type": ["Search"],
+      clear_filters: "/search/?type=File",
+      columns: {
+        "@id": {
+          title: "ID",
+        },
+      },
+      facets: [
+        {
+          field: "file_size",
+          title: "File Size",
+          terms: {
+            count: 69,
+            min: 5000,
+            max: 10000000,
+            avg: 5002500,
+            sum: 5272516747,
+          },
+          total: 1,
+          type: "stats",
+          appended: false,
+        },
+      ],
+      filters: [
+        {
+          field: "file_size",
+          term: "gte:5000",
+          remove: "/search/?type=File&file_size=lte%3A10000000",
+        },
+        {
+          field: "file_size",
+          term: "lte:10000000",
+          remove: "/search/?type=File&file_size=gte%3A5000",
+        },
+        {
+          field: "type",
+          term: "File",
+          remove: "/search/?file_size=gte%3A5000&file_size=lte%3A1000000",
+        },
+      ],
+      notification: "Success",
+      title: "Search",
+      total: 1,
+    };
+
+    // Mock the updateQuery function so that it receives the URL
+    const updateQuery = jest.fn();
+
+    render(
+      <FileSizeTerms
+        searchResults={searchResults}
+        facet={searchResults.facets[0]}
+        updateQuery={updateQuery}
+      />
+    );
+
+    act(resizeObserverMock.bind(null, resizeObserverInstance));
+
+    // Check the basic output of the component.
+    const legend = screen.getByTestId("file-size-terms-legend");
+    expect(legend).toBeInTheDocument();
+    expect(legend).toHaveTextContent("5.0 KB–10 MB");
+    const range = screen.getByTestId("file-size-terms-range");
+    expect(range).toBeInTheDocument();
+
+    // Check the range input elements comprising the range component.
+    const sliders = range.querySelectorAll("input[type='range']");
+    expect(sliders[0]).toBeInTheDocument();
+    expect(sliders[1]).toBeInTheDocument();
+
+    // Set the minimum and maximum sliders and make sure this applies the new range after a delay.
+    // fireEvent.change(sliders[0], { target: { value: "75" } });
+    fireEvent.input(sliders[0], { target: { value: "75" } });
+
+    jest.advanceTimersByTime(1000);
+    expect((sliders[0] as HTMLInputElement).value).toBe("75");
+    expect(updateQuery).toHaveBeenCalledWith("type=File&file_size=gte:5293");
+    fireEvent.input(sliders[1], { target: { value: "100" } });
+    jest.advanceTimersByTime(1000);
+    expect((sliders[1] as HTMLInputElement).value).toBe("5037");
+    expect(updateQuery).toHaveBeenCalledWith(
+      "type=File&file_size=gte:5293&file_size=lte:229985"
+    );
+
+    // Click the reset button and check it calls updateQuery with the correct URL.
+    const resetButton = screen.getByTestId("reset-range-file_size");
+    expect(resetButton).toBeInTheDocument();
+    fireEvent.click(resetButton);
+    expect(updateQuery).toHaveBeenCalledWith("type=File");
+  });
+
+  it("renders a file-size terms facet with no limits in the query string", () => {
+    const searchResults: SearchResults = {
+      "@context": "/terms/",
+      "@graph": [
+        {
+          "@id": "/sequence-files/IGVFFI1165AJSO/",
+          "@type": ["SequenceFile", "File", "Item"],
+          accession: "IGVFFI1165AJSO",
+          content_type: "Nanopore reads",
+          file_format: "pod5",
+          lab: {
+            "@id": "/labs/j-michael-cherry/",
+            title: "J. Michael Cherry, Stanford",
+          },
+          status: "released",
+          summary: "Nanopore reads from sequencing run 1",
+          upload_status: "validated",
+          uuid: "fffcd64e-af02-4675-8953-7352459ee06a",
+        },
+      ],
+      "@id": "/search/?type=File",
+      "@type": ["Search"],
+      clear_filters: "/search/?type=File",
+      columns: {
+        "@id": {
+          title: "ID",
+        },
+      },
+      facets: [
+        {
+          field: "file_size",
+          title: "File Size",
+          terms: {
+            count: 69,
+            min: 5000,
+            max: 10000000,
+            avg: 5002500,
+            sum: 5272516747,
+          },
+          total: 1,
+          type: "stats",
+          appended: false,
+        },
+      ],
+      filters: [
+        {
+          field: "type",
+          term: "File",
+          remove: "/search/?file_size=gte%3A5000&file_size=lte%3A1000000",
+        },
+      ],
+      notification: "Success",
+      title: "Search",
+      total: 1,
+    };
+
+    // Mock the updateQuery function so that it receives the URL
+    const updateQuery = jest.fn();
+
+    render(
+      <FileSizeTerms
+        searchResults={searchResults}
+        facet={searchResults.facets[0]}
+        updateQuery={updateQuery}
+      />
+    );
+
+    act(resizeObserverMock.bind(null, resizeObserverInstance));
+
+    // Check the basic output of the component.
+    const legend = screen.getByTestId("file-size-terms-legend");
+    expect(legend).toBeInTheDocument();
+    expect(legend).toHaveTextContent("5.0 KB–10 MB");
+    const range = screen.getByTestId("file-size-terms-range");
+    expect(range).toBeInTheDocument();
+
+    // Check the range input elements comprising the range component.
+    const sliders = range.querySelectorAll("input[type='range']");
+    expect(sliders[0]).toBeInTheDocument();
+    expect(sliders[1]).toBeInTheDocument();
+  });
+
+  it("renders a file-size terms facet with query-string limits outside the facet range", () => {
+    const searchResults: SearchResults = {
+      "@context": "/terms/",
+      "@graph": [
+        {
+          "@id": "/sequence-files/IGVFFI1165AJSO/",
+          "@type": ["SequenceFile", "File", "Item"],
+          accession: "IGVFFI1165AJSO",
+          content_type: "Nanopore reads",
+          file_format: "pod5",
+          lab: {
+            "@id": "/labs/j-michael-cherry/",
+            title: "J. Michael Cherry, Stanford",
+          },
+          status: "released",
+          summary: "Nanopore reads from sequencing run 1",
+          upload_status: "validated",
+          uuid: "fffcd64e-af02-4675-8953-7352459ee06a",
+        },
+      ],
+      "@id": "/search/?type=File&file_size=gte:50&file_size=lte:20000000",
+      "@type": ["Search"],
+      clear_filters: "/search/?type=File",
+      columns: {
+        "@id": {
+          title: "ID",
+        },
+      },
+      facets: [
+        {
+          field: "file_size",
+          title: "File Size",
+          terms: {
+            count: 69,
+            min: 5000,
+            max: 10000000,
+            avg: 5002500,
+            sum: 5272516747,
+          },
+          total: 1,
+          type: "stats",
+          appended: false,
+        },
+      ],
+      filters: [
+        {
+          field: "type",
+          term: "File",
+          remove: "/search/",
+        },
+      ],
+      notification: "Success",
+      title: "Search",
+      total: 1,
+    };
+
+    // Mock the updateQuery function so that it receives the URL
+    const updateQuery = jest.fn();
+
+    render(
+      <FileSizeTerms
+        searchResults={searchResults}
+        facet={searchResults.facets[0]}
+        updateQuery={updateQuery}
+      />
+    );
+
+    act(resizeObserverMock.bind(null, resizeObserverInstance));
+
+    // Check the basic output of the component.
+    const legend = screen.getByTestId("file-size-terms-legend");
+    expect(legend).toBeInTheDocument();
+    expect(legend).toHaveTextContent("5.0 KB–10 MB");
+    const range = screen.getByTestId("file-size-terms-range");
+    expect(range).toBeInTheDocument();
+
+    // Check the range input elements comprising the range component.
+    const sliders = range.querySelectorAll("input[type='range']");
+    expect(sliders[0]).toBeInTheDocument();
+    expect(sliders[1]).toBeInTheDocument();
+  });
+
+  it("renders nothing and displays a message to console.error if the facet type isn't stats", () => {
+    const searchResults: SearchResults = {
+      "@context": "/terms/",
+      "@graph": [
+        {
+          "@id": "/sequence-files/IGVFFI1165AJSO/",
+          "@type": ["SequenceFile", "File", "Item"],
+          accession: "IGVFFI1165AJSO",
+          content_type: "Nanopore reads",
+          file_format: "pod5",
+          lab: {
+            "@id": "/labs/j-michael-cherry/",
+            title: "J. Michael Cherry, Stanford",
+          },
+          status: "released",
+          summary: "Nanopore reads from sequencing run 1",
+          upload_status: "validated",
+          uuid: "fffcd64e-af02-4675-8953-7352459ee06a",
+        },
+      ],
+      "@id": "/search/?type=File&file_size=gte:5000&file_size=lte:10000000",
+      "@type": ["Search"],
+      clear_filters: "/search/?type=File",
+      columns: {
+        "@id": {
+          title: "ID",
+        },
+      },
+      facets: [
+        {
+          field: "file_format_type",
+          title: "File Format Type",
+          terms: [
+            {
+              key: "bed3",
+              doc_count: 2,
+            },
+          ],
+          total: 2,
+          type: "terms",
+        },
+      ],
+      filters: [
+        {
+          field: "type",
+          term: "File",
+          remove: "/search/?file_size=gte%3A5000&file_size=lte%3A1000000",
+        },
+      ],
+      notification: "Success",
+      title: "Search",
+      total: 1,
+    };
+
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    render(
+      <FileSizeTerms
+        searchResults={searchResults}
+        facet={searchResults.facets[0]}
+        updateQuery={jest.fn()}
+      />
+    );
+
+    // Check that the component renders nothing and displays a console error.
+    const legend = screen.queryByTestId("file-size-terms-legend");
+    expect(legend).not.toBeInTheDocument();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "FileSizeTerms: Expected a stats facet but got a terms facet for file_format_type."
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("displays a message if the minimum and maximum stats are equal", () => {
+    const searchResults: SearchResults = {
+      "@context": "/terms/",
+      "@graph": [
+        {
+          "@id": "/sequence-files/IGVFFI1165AJSO/",
+          "@type": ["SequenceFile", "File", "Item"],
+          accession: "IGVFFI1165AJSO",
+          content_type: "Nanopore reads",
+          file_format: "pod5",
+          lab: {
+            "@id": "/labs/j-michael-cherry/",
+            title: "J. Michael Cherry, Stanford",
+          },
+          status: "released",
+          summary: "Nanopore reads from sequencing run 1",
+          upload_status: "validated",
+          uuid: "fffcd64e-af02-4675-8953-7352459ee06a",
+        },
+      ],
+      "@id": "/search/?type=File&file_size=gte:5000&file_size=lte:10000000",
+      "@type": ["Search"],
+      clear_filters: "/search/?type=File",
+      columns: {
+        "@id": {
+          title: "ID",
+        },
+      },
+      facets: [
+        {
+          field: "file_size",
+          title: "File Size",
+          terms: {
+            count: 69,
+            min: 5000,
+            max: 5000,
+            avg: 5000,
+            sum: 5000,
+          },
+          total: 1,
+          type: "stats",
+          appended: false,
+        },
+      ],
+      filters: [
+        {
+          field: "type",
+          term: "File",
+          remove: "/search/?file_size=gte%3A5000&file_size=lte%3A1000000",
+        },
+      ],
+      notification: "Success",
+      title: "Search",
+      total: 1,
+    };
+
+    render(
+      <FileSizeTerms
+        searchResults={searchResults}
+        facet={searchResults.facets[0]}
+        updateQuery={jest.fn()}
+      />
+    );
+
+    // Check that the component renders nothing and displays a console error.
+    const legend = screen.queryByTestId("file-size-terms-legend");
+    expect(legend).toHaveTextContent("No selectable range");
+  });
+});

--- a/components/facets/__tests__/stats-lib.test.ts
+++ b/components/facets/__tests__/stats-lib.test.ts
@@ -1,0 +1,77 @@
+import {
+  getRangeQueryValues,
+  scaleToInteger,
+  scaleToOriginal,
+} from "../custom-facets/stats-lib";
+import QueryString from "../../../lib/query-string";
+
+describe("Test the scaleToInteger function", () => {
+  it("should return the original value if valueMode is 'integer'", () => {
+    const originalValue = 5;
+    const valueMode = "integer";
+    const result = scaleToInteger(originalValue, valueMode);
+    expect(result).toBe(originalValue);
+  });
+
+  it("should return the scaled value if valueMode is 'float'", () => {
+    const originalValue = 5.1234;
+    const valueMode = "float";
+    const result = scaleToInteger(originalValue, valueMode);
+    expect(result).toBe(512);
+  });
+});
+
+describe("Test the scaleToOriginal function", () => {
+  it("should return the original value if valueMode is 'integer'", () => {
+    const scaledValue = 5;
+    const valueMode = "integer";
+    const result = scaleToOriginal(scaledValue, valueMode);
+    expect(result).toBe(scaledValue);
+  });
+
+  it("should return the scaled value if valueMode is 'float'", () => {
+    const scaledValue = 512;
+    const valueMode = "float";
+    const result = scaleToOriginal(scaledValue, valueMode);
+    expect(result).toBe(5.12);
+  });
+});
+
+describe("Test the getRangeQueryValues function", () => {
+  it("should return the correct min and max values for integer value mode", () => {
+    const query = new QueryString("type=File&file_size=gte:5&file_size=lte:10");
+    const field = "file_size";
+    const result = getRangeQueryValues(query, field);
+    expect(result.minRangeQueryValue).toBe(5);
+    expect(result.maxRangeQueryValue).toBe(10);
+  });
+
+  it("should return the correct min and max values for float value mode", () => {
+    const query = new QueryString(
+      "type=File&qc_metric=gte:5.1234&qc_metric=lte:10.5678"
+    );
+    const field = "qc_metric";
+    const valueMode = "float";
+    const result = getRangeQueryValues(query, field, valueMode);
+    expect(result.minRangeQueryValue).toBe(512);
+    expect(result.maxRangeQueryValue).toBe(1057);
+  });
+
+  it("should return null min value for missing min value", () => {
+    const query = new QueryString("type=File&qc_metric=lte:10.5678");
+    const field = "qc_metric";
+    const valueMode = "float";
+    const result = getRangeQueryValues(query, field, valueMode);
+    expect(result.minRangeQueryValue).toBeNull();
+    expect(result.maxRangeQueryValue).toBe(1057);
+  });
+
+  it("should return null max value for missing max value", () => {
+    const query = new QueryString("type=File&qc_metric=gte:5");
+    const field = "qc_metric";
+    const valueMode = "integer";
+    const result = getRangeQueryValues(query, field, valueMode);
+    expect(result.minRangeQueryValue).toBe(5);
+    expect(result.maxRangeQueryValue).toBeNull();
+  });
+});

--- a/components/facets/custom-facets/file-size-tag-label.tsx
+++ b/components/facets/custom-facets/file-size-tag-label.tsx
@@ -1,0 +1,29 @@
+// lib
+import { dataSize } from "../../../lib/general";
+// root
+import { SearchResultsFilter } from "../../../globals";
+
+/**
+ * Display the facet tag label for file-size range terms with magnitudes (e.g. KB, GB). This
+ * converts the term from `gte:0` to `> 0B` and `lte:100000` to `< 100KB`. Don't have to worry too
+ * much about bad formatting because the server should have already validated the query.
+ * @param filter Filter object for the facet
+ */
+export default function FileSizeTagLabel({
+  filter,
+}: {
+  filter: SearchResultsFilter;
+}) {
+  // Extract the file size value in bytes from the filter as well as the gte or lte operator.
+  const value = filter.term.replace(/(gte:|lte:)/, "");
+  const operator = filter.term.startsWith("gte:") ? ">" : "<";
+
+  // Convert the value to a size with the appropriate magnitude
+  const sizeLabel = dataSize(parseInt(value));
+
+  return (
+    <span>
+      {operator} {sizeLabel}
+    </span>
+  );
+}

--- a/components/facets/custom-facets/file-size-terms.tsx
+++ b/components/facets/custom-facets/file-size-terms.tsx
@@ -1,0 +1,282 @@
+// node_modules
+import { useEffect, useRef, useState } from "react";
+// components
+import { Button } from "../../form-elements";
+import Icon from "../../icon";
+import { RangeSelector } from "../../range-selector";
+import { Tooltip, TooltipRef, useTooltip } from "../../tooltip";
+// lib
+import { SearchResultsFacetStats } from "../../../lib/facets";
+import { dataSize } from "../../../lib/general";
+import QueryString from "../../../lib/query-string";
+import { splitPathAndQueryString } from "../../../lib/query-utils";
+// components/facets/custom-facets
+import { getRangeQueryValues, RANGE_APPLY_DELAY } from "./stats-lib";
+// root
+import type { SearchResults, SearchResultsFacet } from "../../../globals";
+
+/**
+ * Maximum value the slider can be set to. The maximum possible file size from the stats facet gets
+ * mapped to this value while the minimum file size gets mapped to 0. Generally large values cause
+ * fewer conversion errors between slider and file-size values.
+ */
+const SLIDER_MAX_VALUE = 10_000;
+
+/**
+ * Converts from slider position to a file size in bytes. Allow more fine-grained values for
+ * smaller file sizes and coarser values for larger file sizes.
+ * @param sliderValue - Value of the slider
+ * @param sizeMin - Minimum possible file size from the stats facet
+ * @param sizeMax - Maximum possible file size from the stats facet
+ * @returns The actual file size in bytes
+ */
+function sliderToSize(
+  sliderValue: number,
+  sizeMin: number,
+  sizeMax: number
+): number {
+  const minLog = Math.log10(sizeMin);
+  const maxLog = Math.log10(sizeMax);
+  const logValue =
+    minLog + (sliderValue / SLIDER_MAX_VALUE) * (maxLog - minLog);
+  return Math.round(Math.pow(10, logValue));
+}
+
+/**
+ * Converts from file size in bytes to slider position.
+ * @param sizeValue - File size in bytes
+ * @param sizeMin - Minimum possible file size from the stats facet
+ * @param sizeMax - Maximum possible file size from the stats facet
+ * @returns Value for the slider
+ */
+function sizeToSlider(
+  sizeValue: number,
+  sizeMin: number,
+  sizeMax: number
+): number {
+  const minLog = Math.log10(sizeMin);
+  const maxLog = Math.log10(sizeMax);
+  const sizeValueLog = Math.log10(sizeValue);
+  return Math.round(
+    ((sizeValueLog - minLog) / (maxLog - minLog)) * SLIDER_MAX_VALUE
+  );
+}
+
+/**
+ * Custom terms facet for allowing the user to select a range of file sizes.
+ *
+ * This component uses a range selector to allow the user to select a range of file sizes to pass
+ * the filter. It uses a logarithmic scale so that the user can select a finer range of values
+ * towards the left end, and a coarser range of values towards the right end.
+ *
+ * The range selector always uses values of 0 to SLIDER_MAX_VALUE, and the actual file sizes are
+ * calculated from the slider position.
+ *
+ * In general, variables with names including "sizeMin" or "sizeMax" are the actual file sizes,
+ * while variables with names including "sliderMin" or "sliderMax" are the range slider values.
+ * @param searchResults - Current list or report search results from the data provider
+ * @param facet - Facet to display from `searchResults`
+ * @param updateQuery - Function to call when the user selects a new range of values
+ */
+function FileSizeTermsCore({
+  searchResults,
+  facet,
+  updateQuery,
+}: {
+  searchResults: SearchResults;
+  facet: SearchResultsFacet;
+  updateQuery: (queryString: string) => void;
+}) {
+  const resetTooltipAttr = useTooltip("reset-range");
+  const stats = facet.terms as SearchResultsFacetStats;
+  const { min: sizeMin, max: sizeMax } = stats;
+  const ref = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { queryString } = splitPathAndQueryString(searchResults["@id"]);
+  const query = new QueryString(queryString);
+
+  // Get the minimum and maximum values from the query string for this facet.
+  const { minRangeQueryValue, maxRangeQueryValue } = getRangeQueryValues(
+    query,
+    facet.field
+  );
+
+  // Minimum range value the user has set
+  const [sliderMinValue, setSliderMinValue] = useState<number>(0);
+  // Maximum range value the user has set
+  const [sliderMaxValue, setSliderMaxValue] =
+    useState<number>(SLIDER_MAX_VALUE);
+  // True once range selector container is visible, preventing rendering while collapsed
+  const [isContainerVisible, setIsContainerVisible] = useState(false);
+
+  // Called when the user changes the range selector values. Applies the new range values to the
+  // query string if the user makes no new changes during a short delay.
+  function onChange(changedSliderMin: number, changedSliderMax: number) {
+    setSliderMinValue(changedSliderMin);
+    setSliderMaxValue(changedSliderMax);
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    // Apply the new range settings if the user doesn't change the setting for a short while.
+    timerRef.current = setTimeout(() => {
+      applyRange(changedSliderMin, changedSliderMax);
+    }, RANGE_APPLY_DELAY);
+  }
+
+  // Called to apply the selected range, normally a short time after the user stops making changes
+  // to the range. Create a new query string with the selected range values and update the URL.
+  function applyRange(changedSliderMin: number, changedSliderMax: number) {
+    const changedSizeMin = sliderToSize(changedSliderMin, sizeMin, sizeMax);
+    const changedSizeMax = sliderToSize(changedSliderMax, sizeMin, sizeMax);
+    query.deleteKeyValue(facet.field);
+    if (changedSizeMin > sizeMin) {
+      query.addKeyValue(facet.field, `gte:${changedSizeMin}`);
+    }
+    if (changedSizeMax < sizeMax) {
+      query.addKeyValue(facet.field, `lte:${changedSizeMax}`);
+    }
+    query.deleteKeyValue("from");
+    updateQuery(query.format());
+  }
+
+  // Called when the user resets the range selector values. It clears the range values from the
+  // query string and resets the range selector values to the min and max values from the stats.
+  function resetRange() {
+    query.deleteKeyValue(facet.field);
+    query.deleteKeyValue("from");
+    updateQuery(query.format());
+    setSliderMinValue(0);
+    setSliderMaxValue(SLIDER_MAX_VALUE);
+  }
+
+  // If the minimum or maximum possible values for the facet have changed, update the range
+  // selector values. This usually happens because the user has changed another facet's selections.
+  useEffect(() => {
+    let pinnedSizeMin = sizeMin;
+    let pinnedSizeMax = sizeMax;
+    if (minRangeQueryValue || maxRangeQueryValue) {
+      // At least one range query exists for this facet, so use the values from the query string
+      // as the facet's value.
+      if (minRangeQueryValue) {
+        pinnedSizeMin =
+          minRangeQueryValue < sizeMin ? sizeMin : minRangeQueryValue;
+      }
+      if (maxRangeQueryValue) {
+        pinnedSizeMax =
+          maxRangeQueryValue > sizeMax ? sizeMax : maxRangeQueryValue;
+      }
+    }
+    const pinnedSliderMin = sizeToSlider(pinnedSizeMin, sizeMin, sizeMax);
+    const pinnedSliderMax = sizeToSlider(pinnedSizeMax, sizeMin, sizeMax);
+    setSliderMinValue(pinnedSliderMin);
+    setSliderMaxValue(pinnedSliderMax);
+  }, [sizeMin, sizeMax, minRangeQueryValue, maxRangeQueryValue]);
+
+  // <RangeSelector> measures its dimensions, but the dimensions are all zero when the facet
+  // expansion animation begins. Only start rendering the range selector when the width is greater
+  // than 0.
+  useEffect(() => {
+    if (ref.current) {
+      const resizeObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          if (!isContainerVisible && entry.contentRect.width > 0) {
+            setIsContainerVisible(true);
+          }
+        }
+      });
+      resizeObserver.observe(ref.current);
+
+      return () => resizeObserver.disconnect();
+    }
+  }, []);
+
+  // Reset-range button is disabled if neither the minimum nor maximum values exist in the query
+  // string.
+  const resetButtonDisabled =
+    minRangeQueryValue === null && maxRangeQueryValue === null;
+
+  const currentSizeMin = sliderToSize(sliderMinValue, sizeMin, sizeMax);
+  const currentSizeMax = sliderToSize(sliderMaxValue, sizeMin, sizeMax);
+  return (
+    <div ref={ref} className="p-2">
+      <div
+        data-testid="file-size-terms-legend"
+        className="flex justify-center gap-2 text-sm font-semibold"
+      >
+        {sizeMin === sizeMax ? (
+          <div>No selectable range</div>
+        ) : (
+          <>
+            <div className="flex-1 text-right">{dataSize(currentSizeMin)}</div>
+            <div>&ndash;</div>
+            <div className="flex-1">{dataSize(currentSizeMax)}</div>
+          </>
+        )}
+      </div>
+      {isContainerVisible && (
+        <div
+          className="flex items-center gap-1"
+          data-testid="file-size-terms-range"
+        >
+          <RangeSelector
+            id={`${facet.field}-range`}
+            minValue={sliderMinValue}
+            maxValue={sliderMaxValue}
+            minRangeValue={0}
+            maxRangeValue={SLIDER_MAX_VALUE}
+            onChange={onChange}
+            isDisabled={sizeMin === sizeMax}
+          />
+          <TooltipRef tooltipAttr={resetTooltipAttr}>
+            <div>
+              <Button
+                onClick={resetRange}
+                size="sm"
+                isDisabled={resetButtonDisabled}
+                id={`reset-range-${facet.field}`}
+              >
+                <Icon.Reset className="h-4 w-4" />
+              </Button>
+            </div>
+          </TooltipRef>
+          <Tooltip tooltipAttr={resetTooltipAttr}>
+            Reset the range to the minimum and maximum values
+          </Tooltip>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Import this component into the facet registry. To reduce some misconfiguration crashes, it makes
+ * sure the facet is a stats facet and not a normal terms facet before rendering the component. If
+ * the facet isn't a stats facet, log an error to the console and render nothing -- someone needs to
+ * change the search config for this facet into a stats facet.
+ */
+export default function FileSizeTerms({
+  searchResults,
+  facet,
+  updateQuery,
+}: {
+  searchResults: SearchResults;
+  facet: SearchResultsFacet;
+  updateQuery: (queryString: string) => void;
+}) {
+  if (facet.type !== "stats") {
+    console.error(
+      `FileSizeTerms: Expected a stats facet but got a ${facet.type} facet for ${facet.field}.`
+    );
+    return null;
+  }
+
+  return (
+    <FileSizeTermsCore
+      searchResults={searchResults}
+      facet={facet}
+      updateQuery={updateQuery}
+    />
+  );
+}

--- a/components/facets/custom-facets/standard-title.js
+++ b/components/facets/custom-facets/standard-title.js
@@ -62,7 +62,10 @@ StandardTitle.propTypes = {
     // Facet title
     title: PropTypes.string.isRequired,
     // List of facet terms
-    terms: PropTypes.arrayOf(PropTypes.object).isRequired,
+    terms: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.object),
+      PropTypes.object,
+    ]),
   }).isRequired,
   // Entire search results object from the data provider
   searchResults: PropTypes.object.isRequired,

--- a/components/facets/custom-facets/stats-lib.ts
+++ b/components/facets/custom-facets/stats-lib.ts
@@ -1,0 +1,76 @@
+// lib
+import type QueryString from "../../../lib/query-string";
+
+/**
+ * Indicates whether the values in the stats facet are integers or floats. This determines how we
+ * handle the range selector values and the legend
+ */
+export type ValueMode = "integer" | "float";
+
+/**
+ * Delay in ms after the user stops changing the range selector values before the new range is
+ * applied.
+ */
+export const RANGE_APPLY_DELAY = 500;
+
+/**
+ * Scale the original value from the stats facet to an integer if the value mode is set to
+ * "float." If the value mode is set to "integer," the original value is returned. This lets
+ * fractional values work with the range selector, which only accepts integers.
+ * @param originalValue - The original value from the stats facet
+ * @param valueMode - Indicates whether the value is an integer or a float
+ * @returns Scaled value if the value mode is set to "float", otherwise the original value
+ */
+export function scaleToInteger(
+  originalValue: number,
+  valueMode: ValueMode
+): number {
+  return valueMode === "integer"
+    ? originalValue
+    : Math.round(originalValue * 100);
+}
+
+/**
+ * Scale the value back to the original value from the stats facet.
+ * @param scaledValue - The value scaled back to the original value
+ * @param valueMode - Indicates whether the value is an integer or a float
+ * @returns Original float value if the value mode is "float", otherwise the unscaled integer
+ */
+export function scaleToOriginal(
+  scaledValue: number,
+  valueMode: ValueMode
+): number {
+  return valueMode === "integer" ? scaledValue : scaledValue / 100;
+}
+
+/**
+ * Get the minimum and maximum values from the query string for the given field. The values are
+ * scaled to integers or floats based on the valueMode. If no value exist for either the minimum or
+ * maximum values, null is returned for that value.
+ * @param query - From the current query string
+ * @param field - Property the facet displays
+ * @param valueMode - Indicates whether the query-string values are integers or floats
+ * @returns The minimum and maximum values from the query string for the given field.
+ */
+export function getRangeQueryValues(
+  query: QueryString,
+  field: string,
+  valueMode: ValueMode = "integer"
+): {
+  minRangeQueryValue: number | null;
+  maxRangeQueryValue: number | null;
+} {
+  const rangeQueries = query.getKeyValues(field);
+  const minQuery = rangeQueries.find((query) => query.startsWith("gte:"));
+  const maxQuery = rangeQueries.find((query) => query.startsWith("lte:"));
+  const minQueryValue = minQuery ? parseFloat(minQuery.split(":")[1]) : null;
+  const maxQueryValue = maxQuery ? parseFloat(maxQuery.split(":")[1]) : null;
+  return {
+    minRangeQueryValue: minQueryValue
+      ? scaleToInteger(minQueryValue, valueMode)
+      : null,
+    maxRangeQueryValue: maxQueryValue
+      ? scaleToInteger(maxQueryValue, valueMode)
+      : null,
+  };
+}

--- a/components/facets/custom-facets/stats-tag-label.tsx
+++ b/components/facets/custom-facets/stats-tag-label.tsx
@@ -1,0 +1,24 @@
+// root
+import { SearchResultsFilter } from "../../../globals";
+
+/**
+ * Display the facet tag label for range terms. This converts the term from `gte:0` to `>0` and
+ * `lte:100` to `<100`.
+ * @param filter Filter object for the facet
+ */
+export default function StatsTagLabel({
+  filter,
+}: {
+  filter: SearchResultsFilter;
+}) {
+  const term = filter.term.replace(/^(gte:|lte:)/, (match) => {
+    if (match === "gte:") {
+      return ">";
+    }
+    if (match === "lte:") {
+      return "<";
+    }
+    return match;
+  });
+  return <>{term}</>;
+}

--- a/components/facets/custom-facets/stats-terms.tsx
+++ b/components/facets/custom-facets/stats-terms.tsx
@@ -1,0 +1,200 @@
+// node_modules
+import { useEffect, useRef, useState } from "react";
+// components
+import { Button } from "../../form-elements";
+import Icon from "../../icon";
+import { RangeSelector } from "../../range-selector";
+import { Tooltip, TooltipRef, useTooltip } from "../../tooltip";
+// lib
+import { SearchResultsFacetStats } from "../../../lib/facets";
+import QueryString from "../../../lib/query-string";
+import { splitPathAndQueryString } from "../../../lib/query-utils";
+// components/facets/custom-facets
+import {
+  getRangeQueryValues,
+  RANGE_APPLY_DELAY,
+  scaleToInteger,
+  scaleToOriginal,
+  type ValueMode,
+} from "./stats-lib";
+// root
+import type { SearchResults, SearchResultsFacet } from "../../../globals";
+
+/**
+ * Custom terms facet for allowing the user to select a range of values, as well as displaying a
+ * legend of the currently-selected range.
+ * @param searchResults - The current list or report search results from the data provider
+ * @param facet - The facet to display from `searchResults`
+ * @param updateQuery - Function to call when the user selects a new range of values
+ */
+export default function StatsTerms({
+  searchResults,
+  facet,
+  updateQuery,
+}: {
+  searchResults: SearchResults;
+  facet: SearchResultsFacet;
+  updateQuery: (queryString: string) => void;
+}) {
+  const resetTooltipAttr = useTooltip("reset-range");
+
+  const stats = facet.terms as SearchResultsFacetStats;
+  const ref = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { queryString } = splitPathAndQueryString(searchResults["@id"]);
+  const query = new QueryString(queryString);
+
+  // Determine the value mode based on the stats values. If the min and max values are integers,
+  // set the value mode to integer. Otherwise, set it to float.
+  const valueMode: ValueMode =
+    Number.isInteger(stats.min) && Number.isInteger(stats.max)
+      ? "integer"
+      : "float";
+
+  // Get the scaled minimum and maximum values from the query string if they exist.
+  const { minRangeQueryValue, maxRangeQueryValue } = getRangeQueryValues(
+    query,
+    facet.field,
+    valueMode
+  );
+
+  // Get the minimum and maximum possible values for the facet, scaled for the value mode.
+  const statsMin = scaleToInteger(stats.min, valueMode);
+  const statsMax = scaleToInteger(stats.max, valueMode);
+
+  // Minimum range value the user has set
+  const [minValue, setMinValue] = useState<number>(statsMin);
+  // Maximum range value the user has set
+  const [maxValue, setMaxValue] = useState<number>(statsMax);
+  // True once range selector container is visible, preventing rendering while collapsed
+  const [isContainerVisible, setIsContainerVisible] = useState(false);
+
+  // Called when the user changes the range selector values. Applies the new range values to the
+  // query string if the user makes no new changes during a short delay.
+  function onChange(min: number, max: number) {
+    setMinValue(min);
+    setMaxValue(max);
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    // Apply the new range settings if the user doesn't change the setting for a short while.
+    timerRef.current = setTimeout(() => {
+      applyRange(min, max);
+    }, RANGE_APPLY_DELAY);
+  }
+
+  // Called when the user clicks the apply button. Create a new query string with the selected
+  // range values and update the URL.
+  function applyRange(newMinValue: number, newMaxValue: number) {
+    query.deleteKeyValue(facet.field);
+    if (newMinValue > statsMin) {
+      query.addKeyValue(
+        facet.field,
+        `gte:${scaleToOriginal(newMinValue, valueMode)}`
+      );
+    }
+    if (newMaxValue < statsMax) {
+      query.addKeyValue(
+        facet.field,
+        `lte:${scaleToOriginal(newMaxValue, valueMode)}`
+      );
+    }
+    query.deleteKeyValue("from");
+    updateQuery(query.format());
+  }
+
+  // Called when the user resets the range selector values. It clears the range values from the
+  // query string and resets the range selector values to the min and max values from the stats.
+  function resetRange() {
+    query.deleteKeyValue(facet.field);
+    query.deleteKeyValue("from");
+    updateQuery(query.format());
+    setMinValue(statsMin);
+    setMaxValue(statsMax);
+  }
+
+  // If the minimum or maximum possible values for the facet have changed, update the range
+  // selector values. This usually happens because the user has changed another facet's selections.
+  useEffect(() => {
+    let limitedMin = statsMin;
+    let limitedMax = statsMax;
+    if (minRangeQueryValue || maxRangeQueryValue) {
+      // At least one range query exists for this facet, so use the values from the query string
+      // as the facet's value.
+      if (minRangeQueryValue) {
+        limitedMin =
+          minRangeQueryValue < statsMin ? statsMin : minRangeQueryValue;
+      }
+      if (maxRangeQueryValue) {
+        limitedMax =
+          maxRangeQueryValue > statsMax ? statsMax : maxRangeQueryValue;
+      }
+    }
+    setMinValue(limitedMin);
+    setMaxValue(limitedMax);
+  }, [statsMin, statsMax, minRangeQueryValue, maxRangeQueryValue]);
+
+  // <RangeSelector> measures its dimensions, but the dimensions are all zero when the facet
+  // expansion animation begins. Only start rendering the range selector when the width is greater
+  // than 0.
+  useEffect(() => {
+    if (ref.current) {
+      const resizeObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          if (!isContainerVisible && entry.contentRect.width > 0) {
+            setIsContainerVisible(true);
+          }
+        }
+      });
+      resizeObserver.observe(ref.current);
+
+      return () => resizeObserver.disconnect();
+    }
+  }, []);
+
+  // Reset-range button is disabled if neither the minimum nor maximum values exist in the query
+  // string.
+  const resetButtonDisabled =
+    minRangeQueryValue === null && maxRangeQueryValue === null;
+
+  return (
+    <div ref={ref} className="p-2">
+      <div className="flex justify-center gap-2 text-sm font-semibold">
+        <div className="flex-1 text-right">
+          {scaleToOriginal(minValue, valueMode)}
+        </div>
+        <div>&ndash;</div>
+        <div className="flex-1">{scaleToOriginal(maxValue, valueMode)}</div>
+      </div>
+      {isContainerVisible && (
+        <div className="flex items-center gap-1">
+          <RangeSelector
+            id={`${facet.field}-range`}
+            minValue={minValue}
+            maxValue={maxValue}
+            minRangeValue={statsMin}
+            maxRangeValue={statsMax}
+            onChange={onChange}
+            isDisabled={statsMin === statsMax}
+          />
+          <TooltipRef tooltipAttr={resetTooltipAttr}>
+            <div>
+              <Button
+                onClick={resetRange}
+                size="sm"
+                isDisabled={resetButtonDisabled}
+              >
+                <Icon.Reset className="h-4 w-4" />
+              </Button>
+            </div>
+          </TooltipRef>
+          <Tooltip tooltipAttr={resetTooltipAttr}>
+            Reset the range to the minimum and maximum values
+          </Tooltip>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/facets/custom-facets/tri-boolean-terms.tsx
+++ b/components/facets/custom-facets/tri-boolean-terms.tsx
@@ -88,7 +88,8 @@ export default function TriBooleanTerms({
     key: TriBoolean.Either,
     key_as_string: "either",
   };
-  const terms = facet.terms.concat(eitherTerm);
+  let terms = facet.terms as SearchResultsFacetTerm[];
+  terms = terms.concat(eitherTerm);
 
   // Determine the selected term.
   const selectedValue = currentSelection(facet.field, searchResults);

--- a/components/facets/facet-registry.js
+++ b/components/facets/facet-registry.js
@@ -1,11 +1,13 @@
 // components/facets/custom-facets
 import AuditTitle from "./custom-facets/audit-title";
+import FileSizeTerms from "./custom-facets/file-size-terms";
 import InternalActionAuditTerms from "./custom-facets/audit-internal-action-terms";
 import NoTermCountTitle from "./custom-facets/no-term-count-title";
 import StandardTagLabel from "./custom-facets/standard-tag-label";
 import StandardTermLabel from "./custom-facets/standard-term-label";
 import StandardTerms from "./custom-facets/standard-terms";
 import StandardTitle from "./custom-facets/standard-title";
+import FileSizeTagLabel from "./custom-facets/file-size-tag-label";
 import TaxaTagLabel from "./custom-facets/taxa-tag-label";
 import TaxaTermLabel from "./custom-facets/taxa-term-label";
 import TriBooleanTerms from "./custom-facets/tri-boolean-terms";
@@ -20,6 +22,7 @@ const facetRegistry = {
   // Custom tag labels.
   tagLabel: {
     "donors.taxa": TaxaTagLabel,
+    file_size: FileSizeTagLabel,
     taxa: TaxaTagLabel,
     standard: StandardTagLabel,
   },
@@ -35,6 +38,7 @@ const facetRegistry = {
   terms: {
     "audit.INTERNAL_ACTION.category": InternalActionAuditTerms,
     controlled_access: TriBooleanTerms,
+    file_size: FileSizeTerms,
     standard: StandardTerms,
   },
 
@@ -45,6 +49,7 @@ const facetRegistry = {
     "audit.NOT_COMPLIANT.category": AuditTitle,
     "audit.WARNING.category": AuditTitle,
     controlled_access: NoTermCountTitle,
+    file_size: NoTermCountTitle,
     standard: StandardTitle,
   },
 };

--- a/components/facets/facet-term-count.tsx
+++ b/components/facets/facet-term-count.tsx
@@ -3,7 +3,11 @@ import _ from "lodash";
 // components
 import { Tooltip, TooltipRef, useTooltip } from "../tooltip";
 // components/facets
-import type { SearchResults, SearchResultsFacet } from "../../globals.d";
+import type {
+  SearchResults,
+  SearchResultsFacet,
+  SearchResultsFacetTerm,
+} from "../../globals.d";
 // lib
 import { getTermSelections } from "../../lib/facets";
 
@@ -29,11 +33,10 @@ export function FacetTermCount({
   );
 
   // Build the help text for the aria and the tooltip.
+  const terms = facet.terms as SearchResultsFacetTerm[];
   const helpText = `${
     selectedTerms.length + negativeTerms.length
-  } selected of ${facet.terms.length} ${
-    facet.terms.length === 1 ? "term" : "terms"
-  }`;
+  } selected of ${terms.length} ${terms.length === 1 ? "term" : "terms"}`;
 
   // NOTE: The use of a loop index for React keys is a workaround for the lack of unique keys in
   // the facet term object. This is a temporary solution until the backend can guarantee a unique

--- a/components/facets/facet.js
+++ b/components/facets/facet.js
@@ -47,14 +47,10 @@ Facet.propTypes = {
   facet: PropTypes.shape({
     field: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
-    terms: PropTypes.arrayOf(
-      PropTypes.shape({
-        key: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-          .isRequired,
-        doc_count: PropTypes.number,
-        key_as_string: PropTypes.string,
-      })
-    ).isRequired,
+    terms: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.object),
+      PropTypes.object,
+    ]),
   }).isRequired,
   // Search results from data provider
   searchResults: PropTypes.object.isRequired,

--- a/components/form-elements/button.js
+++ b/components/form-elements/button.js
@@ -212,7 +212,12 @@ function LinkElement(props) {
       />
     );
   }
-  return <Link {...propsWithoutExceptions} prefetch={prefetch} />;
+  return (
+    <Link
+      {...propsWithoutExceptions}
+      {...(prefetch === false ? { prefetch: false } : {})}
+    />
+  );
 }
 
 LinkElement.propTypes = {

--- a/components/icon.js
+++ b/components/icon.js
@@ -252,6 +252,17 @@ const Icon = {
       <path d="M17.7,5.29c2-2-1-4.99-2.99-2.99l-4.62,4.62l2.99,2.99L17.7,5.29z" />
     </svg>
   ),
+  Reset: ({ className = null, testid = "icon-reset" }) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      data-testid={testid}
+    >
+      <path d="M10,3c-1.9,0-3.7.8-5,2.1v-1.4c0-.4-.3-.8-.8-.8s-.8.3-.8.8v3.4c0,.4.3.6.6.6h3.4c.4,0,.8-.3.8-.8s-.3-.8-.8-.8h-1.5c1-1.1,2.4-1.7,3.9-1.7,3,0,5.5,2.5,5.5,5.5s-2.5,5.5-5.5,5.5-3.9-1.1-4.8-2.9c-.2-.4-.7-.5-1-.3-.4.2-.5.7-.3,1,1.2,2.3,3.6,3.7,6.2,3.7,3.9,0,7-3.1,7-7s-3.1-7-7-7Z" />
+    </svg>
+  ),
   Sample: ({ className = null, testid = "icon-sample" }) => (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -462,6 +473,10 @@ Icon.Methodology.propTypes = {
   testid: PropTypes.string,
 };
 Icon.PencilSlash.propTypes = {
+  className: PropTypes.string,
+  testid: PropTypes.string,
+};
+Icon.Reset.propTypes = {
   className: PropTypes.string,
   testid: PropTypes.string,
 };

--- a/components/range-selector.tsx
+++ b/components/range-selector.tsx
@@ -1,0 +1,230 @@
+// node_modules
+import { useEffect, useRef } from "react";
+
+/**
+ * This component creates a range selector with two range inputs (min and max) and a container
+ * element that holds the range inputs as well as a dynamically updating legend. This combines two
+ * built-in range inputs, one to allow the user to set the minimum value of the range and one to
+ * set the maximum value. The right edge of the minimum range input is aligned with the left edge
+ * of the maximum range input. This split point changes position as the user drags the range inputs
+ * to the average of the two values. So as the user drags the minimum range input to the right, the
+ * maximum range input left end moves to the right as well.
+ *
+ * With the range minimums and maximums set to 0 and 100 (assuming those are the minimum and
+ * maximum values), the split point will be at the average, 50, meaning the right end of the
+ * minimum range input will be at 50 and the left end of the maximum range input will also be at 50.
+ * O--------------|----------------0
+ *
+ * As the user moves the maximum range input to the left, the split point moves to the left as
+ * well. The minimum range input gets narrower and the maximum range input gets wider.
+ * O----------|-----------O---------
+ *
+ * Moving the minimum range input to the right moves the split point to the right, making the
+ * minimum range input wider and the maximum range input narrower.
+ * -------------O----|----O---------
+ *
+ * Adapted from:
+ * https://codepen.io/joosts/pen/rNLdxvK
+ */
+
+/**
+ * The size of the range input thumb in pixels. This is used to calculate the width of the range
+ * inputs and their positions.
+ */
+const THUMB_SIZE = 14;
+
+/**
+ * This object provides a convenient way to pass the container and range input DOM elements to the
+ * functions to updateValue the data-value attributes and render the range selectors and legend.
+ */
+type RangeSelectorProps = {
+  /** Container DOM element; contains range inputs and legend */
+  container: HTMLElement;
+  /** Range DOM element for the minimum value of the range */
+  min: HTMLInputElement;
+  /** Range DOM element for the maximum value of the range */
+  max: HTMLInputElement;
+};
+
+/**
+ * Called to update the visual representation of the range selector. It updates the widths and
+ * positions of the minimum and maximum range inputs based on the split value.
+ * @param props - References the container and the min and max DOM elements
+ * @returns The updated min and max values for the change callback
+ */
+function update({ container, min, max }: RangeSelectorProps): {
+  minValue: number;
+  maxValue: number;
+} {
+  // Get the split value by averaging the min and max range input values.
+  const minValue = Number(min.value);
+  const maxValue = Number(max.value);
+  const average = (minValue + maxValue) / 2;
+
+  // Get the container width and the min and max range input values from its data attributes.
+  const rangeWidth = Number(container.getAttribute("data-width"));
+  const rangeMin = Number(container.getAttribute("data-min"));
+  const rangeMax = Number(container.getAttribute("data-max"));
+
+  // Update the minimum range input's max attribute and the maximum range input's min attribute to
+  // the split value.
+  const domSplitValue = Math.floor(average).toString();
+  min.setAttribute("max", domSplitValue);
+  max.setAttribute("min", domSplitValue);
+
+  // Set the widths of the minimum and maximum range inputs based on the split value.
+  const realWidth = rangeWidth - 2 * THUMB_SIZE;
+  const range = rangeMax - rangeMin;
+  const minWidth = Math.floor(
+    THUMB_SIZE + ((average - rangeMin) / range) * realWidth
+  );
+  const maxWidth = Math.floor(
+    THUMB_SIZE + ((rangeMax - average) / range) * realWidth
+  );
+
+  // Set the inline styles for the minimum and maximum range inputs so that the left end of the
+  // maximum range input is at the right end of the minimum range input, appearing as if it were
+  // one range control with two thumbs.
+  min.style.width = minWidth > 0 ? `${minWidth}px` : "50%";
+  max.style.width = maxWidth > 0 ? `${maxWidth}px` : "50%";
+  min.style.left = "0px";
+  max.style.left = minWidth > 0 ? `${minWidth}px` : "50%";
+
+  // Return the updated min and max values for the change callback.
+  return { minValue, maxValue };
+}
+
+/**
+ * Component to display a range selector allowing the user to select a range of values with a
+ * minimum and maximum value.
+ * @param id - The id of the range selector, unique within the page.
+ * @param minValue - The minimum value of the range selector.
+ * @param maxValue - The maximum value of the range selector.
+ * @param step - The step value for the range inputs.
+ */
+export function RangeSelector({
+  id,
+  minValue,
+  maxValue,
+  minRangeValue = minValue,
+  maxRangeValue = maxValue,
+  step = 1,
+  onChange,
+  isDisabled = false,
+}: {
+  id: string;
+  minValue: number;
+  maxValue: number;
+  minRangeValue?: number;
+  maxRangeValue?: number;
+  step?: number;
+  onChange: (min: number, max: number) => void;
+  isDisabled?: boolean;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const minRef = useRef<HTMLInputElement>(null);
+  const maxRef = useRef<HTMLInputElement>(null);
+
+  function onChangeMinValue(event: React.ChangeEvent<HTMLInputElement>) {
+    const value = Number(event.target.value);
+    onChange(value, maxValue);
+  }
+
+  function onChangeMaxValue(event: React.ChangeEvent<HTMLInputElement>) {
+    const value = Number(event.target.value);
+    onChange(minValue, value);
+  }
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const min = minRef.current;
+    const max = maxRef.current;
+    const props: RangeSelectorProps = {
+      container: containerRef.current,
+      min: minRef.current,
+      max: maxRef.current,
+    };
+
+    // Get the initial min and max values from the range input attributes.
+    const rangeMinValue = min.getAttribute("min");
+    const rangeMaxValue = max.getAttribute("max");
+
+    // Set the initial data-min and data-max attributes for the container.
+    container.setAttribute("data-min", rangeMinValue);
+    container.setAttribute("data-max", rangeMaxValue);
+    container.setAttribute("data-width", container.offsetWidth.toString());
+
+    // The range-selector elements have their attributes set, so update the styles and
+    // attributes of the range inputs and the container.
+    update(props);
+
+    // Wrapper function for `updateValue()` to pass the proper function type to
+    // `addEventListener()`. Pass the updated minimum and maximum values to the onChange callback.
+    function updateListener() {
+      update(props);
+    }
+
+    // Add event listeners to the min and max range inputs to update the attributes and styles of
+    // the range inputs and the container.
+    if (min && max) {
+      min.addEventListener("input", updateListener);
+      max.addEventListener("input", updateListener);
+    }
+
+    // Remove event listeners when the range selector is unmounted.
+    return () => {
+      if (min) {
+        min.removeEventListener("input", updateListener);
+      }
+      if (max) {
+        max.removeEventListener("input", updateListener);
+      }
+    };
+  }, []);
+
+  const minId = `min-${id}`;
+  const maxId = `max-${id}`;
+  return (
+    <div
+      id={id}
+      ref={containerRef}
+      className="relative h-[14px] w-full"
+      data-range-selector
+    >
+      <label htmlFor={minId} className="hidden">
+        Minimum
+      </label>
+      <input
+        ref={minRef}
+        id={minId}
+        name="min-range-selector"
+        type="range"
+        step={step}
+        min={minRangeValue}
+        max={maxRangeValue}
+        value={minValue}
+        onChange={onChangeMinValue}
+        className="absolute"
+        disabled={isDisabled}
+        aria-label="Range selector minimum value"
+      />
+      <label htmlFor={maxId} className="hidden">
+        Maximum
+      </label>
+      <input
+        ref={maxRef}
+        id={maxId}
+        name="max-range-selector"
+        type="range"
+        step={step}
+        min={minRangeValue}
+        max={maxRangeValue}
+        value={maxValue}
+        onChange={onChangeMaxValue}
+        className="absolute"
+        disabled={isDisabled}
+        aria-label="Range selector maximum value"
+      />
+    </div>
+  );
+}

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -205,7 +205,9 @@ export interface SearchResultsFacet {
   /** Title to display for the facet */
   title: string;
   /** List of terms in the facet */
-  terms: SearchResultsFacetTerm[];
+  terms: SearchResultsFacetTerm[] | unknown;
+  /** Facet type as configured in search config */
+  type: string;
   /** Total number of objects selected within this facet; only in parent facets */
   total?: number;
   /** True if facet term selected but not in search config */

--- a/lib/__tests__/facets.test.ts
+++ b/lib/__tests__/facets.test.ts
@@ -54,6 +54,7 @@ describe("Test the getVisibleFacets function", () => {
             doc_count: 1,
           },
         ],
+        type: "terms",
         total: 1,
       },
       {
@@ -65,18 +66,21 @@ describe("Test the getVisibleFacets function", () => {
             doc_count: 1,
           },
         ],
+        type: "terms",
         total: 1,
       },
       {
         field: "bar",
         title: "Bar",
         terms: [{ key: "two", doc_count: 1 }],
+        type: "terms",
         total: 1,
       },
       {
         field: "audit.INTERNAL_ACTION.category",
         title: "Audit category: DCC ACTION",
         terms: [{ key: "mismatched status", doc_count: 1 }],
+        type: "terms",
         total: 1,
       },
     ];
@@ -90,12 +94,14 @@ describe("Test the getVisibleFacets function", () => {
             doc_count: 1,
           },
         ],
+        type: "terms",
         total: 1,
       },
       {
         field: "bar",
         title: "Bar",
         terms: [{ key: "two", doc_count: 1 }],
+        type: "terms",
         total: 1,
       },
     ];
@@ -109,18 +115,21 @@ describe("Test the getVisibleFacets function", () => {
             doc_count: 1,
           },
         ],
+        type: "terms",
         total: 1,
       },
       {
         field: "bar",
         title: "Bar",
         terms: [{ key: "two", doc_count: 1 }],
+        type: "terms",
         total: 1,
       },
       {
         field: "audit.INTERNAL_ACTION.category",
         title: "Audit category: DCC ACTION",
         terms: [{ key: "mismatched status", doc_count: 1 }],
+        type: "terms",
         total: 1,
       },
     ];
@@ -191,6 +200,7 @@ describe("Test the checkHierarchicalFacet function", () => {
             doc_count: 1,
           },
         ],
+        type: "terms",
         total: 3,
       })
     ).toEqual(false);
@@ -233,6 +243,7 @@ describe("Test the checkHierarchicalFacet function", () => {
             },
           },
         ],
+        type: "terms",
         total: 23,
       })
     ).toEqual(true);
@@ -293,6 +304,7 @@ describe("Test the CollectAllChildFacets function", () => {
             },
           },
         ],
+        type: "terms",
         total: 23,
       },
       {
@@ -312,6 +324,7 @@ describe("Test the CollectAllChildFacets function", () => {
             doc_count: 1,
           },
         ],
+        type: "terms",
         total: 3,
       },
     ];
@@ -347,6 +360,7 @@ describe("Test filterOutChildFacets function", () => {
             doc_count: 1,
           },
         ],
+        type: "terms",
         total: 1,
       },
       {
@@ -358,6 +372,7 @@ describe("Test filterOutChildFacets function", () => {
             doc_count: 1,
           },
         ],
+        type: "terms",
         total: 1,
       },
       {
@@ -369,6 +384,7 @@ describe("Test filterOutChildFacets function", () => {
             isEqual: true,
           },
         ],
+        type: "terms",
         appended: true,
         total: 1,
       },
@@ -416,6 +432,7 @@ describe("Test filterOutChildFacets function", () => {
             },
           },
         ],
+        type: "terms",
         total: 30,
       },
       {
@@ -435,6 +452,7 @@ describe("Test filterOutChildFacets function", () => {
             doc_count: 1,
           },
         ],
+        type: "terms",
         total: 3,
         appended: false,
       },
@@ -447,6 +465,7 @@ describe("Test filterOutChildFacets function", () => {
             isEqual: true,
           },
         ],
+        type: "terms",
         appended: true,
         total: 3,
       },
@@ -489,6 +508,7 @@ describe("Test filterOutChildFacets function", () => {
             },
           },
         ],
+        type: "terms",
         total: 30,
       },
       {
@@ -508,6 +528,7 @@ describe("Test filterOutChildFacets function", () => {
             doc_count: 1,
           },
         ],
+        type: "terms",
         total: 3,
         appended: false,
       },
@@ -519,7 +540,7 @@ describe("Test filterOutChildFacets function", () => {
 
 describe("Test the getTermSelections function", () => {
   it("should return only non-selected terms for a facet with no selections", () => {
-    const facet = {
+    const facet: SearchResultsFacet = {
       field: "lab.title",
       title: "Lab",
       terms: [
@@ -528,6 +549,7 @@ describe("Test the getTermSelections function", () => {
           doc_count: 3,
         },
       ],
+      type: "terms",
       total: 3,
     };
 
@@ -547,7 +569,7 @@ describe("Test the getTermSelections function", () => {
   });
 
   it("should return selected terms for a facet with selections", () => {
-    const facet = {
+    const facet: SearchResultsFacet = {
       field: "lab.title",
       title: "Lab",
       terms: [
@@ -556,6 +578,7 @@ describe("Test the getTermSelections function", () => {
           doc_count: 3,
         },
       ],
+      type: "terms",
       total: 3,
     };
 
@@ -580,7 +603,7 @@ describe("Test the getTermSelections function", () => {
   });
 
   it("should return negative-selected terms for a facet with negative selections", () => {
-    const facet = {
+    const facet: SearchResultsFacet = {
       field: "lab.title",
       title: "Lab",
       terms: [
@@ -589,6 +612,7 @@ describe("Test the getTermSelections function", () => {
           doc_count: 3,
         },
       ],
+      type: "terms",
       total: 3,
     };
 
@@ -613,7 +637,7 @@ describe("Test the getTermSelections function", () => {
   });
 
   it("should return selected child facets for a hierarchical facet with selections", () => {
-    const facet = {
+    const facet: SearchResultsFacet = {
       field: "assay_term.assay_slims",
       title: "Assay",
       terms: [
@@ -636,6 +660,7 @@ describe("Test the getTermSelections function", () => {
           },
         },
       ],
+      type: "terms",
       total: 23,
     };
 
@@ -657,6 +682,37 @@ describe("Test the getTermSelections function", () => {
     expect(selectedTerms).toEqual(["MPRA"]);
     expect(negativeTerms).toEqual([]);
     expect(nonSelectedTerms).toEqual(["STARR-seq"]);
+  });
+
+  it("should return return an empty array for a stats facet", () => {
+    const facet: SearchResultsFacet = {
+      field: "file_size",
+      title: "File Size",
+      terms: {
+        count: 2,
+        min: 9828031,
+        max: 98280399,
+        avg: 54054215,
+        sum: 108108430,
+      },
+      total: 2,
+      type: "stats",
+      appended: false,
+    };
+
+    const filters: SearchResultsFilter[] = [
+      {
+        field: "type",
+        term: "File",
+        remove: "/search/",
+      },
+    ];
+
+    const { selectedTerms, negativeTerms, nonSelectedTerms } =
+      getTermSelections(facet, filters);
+    expect(selectedTerms).toEqual([]);
+    expect(negativeTerms).toEqual([]);
+    expect(nonSelectedTerms).toEqual([]);
   });
 });
 

--- a/lib/search-results.ts
+++ b/lib/search-results.ts
@@ -9,7 +9,8 @@ import {
   Profiles,
   ProfilesProps,
   SearchResults,
-} from "../globals.d";
+  SearchResultsFacetTerm,
+} from "../globals";
 
 /**
  * Builds an array of concrete types returned from search results. The profiles object has to have
@@ -31,7 +32,8 @@ export function generateSearchResultsTypes(
     );
     if (typeFacet) {
       // Get all concrete types from the search results.
-      const allResultTypes = typeFacet.terms.map((term) => term.key);
+      const terms = typeFacet.terms as SearchResultsFacetTerm[];
+      const allResultTypes = terms.map((term) => term.key);
       const concreteTypes = allResultTypes.filter((type) => {
         const typeSubtypes = (profiles as ProfilesProps)._subtypes[type];
         return (

--- a/pages/multireport.js
+++ b/pages/multireport.js
@@ -150,9 +150,9 @@ export default function MultiReport({ searchResults }) {
         <div className="lg:flex lg:items-start lg:gap-1">
           <FacetSection searchResults={searchResults} />
           <div className="min-w-0 grow">
+            <FacetTags searchResults={searchResults} />
             {items.length > 0 ? (
               <>
-                <FacetTags searchResults={searchResults} />
                 <SearchResultsHeader
                   searchResults={searchResults}
                   reportViewExtras={{

--- a/pages/search.js
+++ b/pages/search.js
@@ -54,9 +54,9 @@ export default function Search({ searchResults, accessoryData = null }) {
       <div className="lg:flex lg:items-start lg:gap-1">
         <FacetSection searchResults={searchResults} />
         <div className="grow">
+          <FacetTags searchResults={searchResults} />
           {searchResults.total > 0 ? (
             <>
-              <FacetTags searchResults={searchResults} />
               <SearchResultsHeader searchResults={searchResults} />
               <TableCount count={searchResults.total} />
               {totalPages > 1 && <SearchPager searchResults={searchResults} />}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -663,3 +663,54 @@ a {
   th[data-highlight] {
   background-color: #232326;
 }
+
+/**
+ * Define styles for the `<RangeSelector>` component input elements.
+ */
+[data-range-selector] > input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  outline: none !important;
+  background: transparent;
+  background-image: linear-gradient(
+    to bottom,
+    transparent 0%,
+    transparent 30%,
+    #a0a0a0 30%,
+    #a0a0a0 70%,
+    transparent 70%,
+    transparent 100%
+  );
+}
+
+[data-range-selector] > input[type="range"]:disabled {
+  background-image: linear-gradient(
+    to bottom,
+    transparent 0%,
+    transparent 30%,
+    #e0e0e0 30%,
+    #e0e0e0 70%,
+    transparent 70%,
+    transparent 100%
+  );
+}
+
+[data-range-selector] > input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+  background: #e0e0e0;
+  border: 1px solid #404040;
+  border-radius: 100%;
+}
+
+/**
+* Disabled thumb
+*/
+[data-range-selector] > input[type="range"]:disabled::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  opacity: 0;
+}


### PR DESCRIPTION
This had a big impact on Jest tests, so a lot of the changes are the Jest scripts (*.test.ts; *.test.tsx, *.test.js)

We don’t use the components/facets/custom-facets/stats-terms.tsx file, but I developed that first before changing this to a file-size ticket. We’ll need stats-terms.tsx in the future, so I kept it here for future development instead of deleting all that work. But right now that code isn’t important.

The components/form-elements/button.js change is unrelated to this ticket, but it fixes a NextJS dev-mode console message I introduced in the last release. NextJS gives that warning for passing `prefetch={true}` even though it’s completely valid.

The most important files here are:
* components/range-selector.tsx
* components/facets/custom-facets/file-size-terms.tsx