### PR TITLE
IGVF-2210 Update site-search query

### DIFF
--- a/components/search-modal.js
+++ b/components/search-modal.js
@@ -79,6 +79,7 @@ export default function SearchModal({
     if (trimmedTerm) {
       saveRecentTerm(trimmedTerm);
       closeModalAndExecuteSearch(trimmedTerm);
+      setSearchTerm("");
     }
   }
 

--- a/components/site-search-trigger.js
+++ b/components/site-search-trigger.js
@@ -72,7 +72,7 @@ export default function SiteSearchTrigger({ isExpanded }) {
   function closeModalAndExecuteSearch(searchTerm) {
     closeModal();
     if (searchTerm) {
-      router.push(`/site-search?term=${encodeUriElement(searchTerm)}`);
+      router.push(`/site-search/?query=${encodeUriElement(searchTerm)}`);
     }
   }
 

--- a/cypress/e2e/login-help.cy.js
+++ b/cypress/e2e/login-help.cy.js
@@ -26,7 +26,7 @@ describe("Make sure the login help appears in the correct situations", () => {
   });
 
   it("shows the login help when viewing no site-search results while signed out", () => {
-    cy.visit("/site-search/?term=abcdefg");
+    cy.visit("/site-search/?query=abcdefg");
     cy.contains("No matching items to display");
     cy.contains("Please sign in if you believe you should see matching items");
   });
@@ -36,7 +36,7 @@ describe("Make sure the login help appears in the correct situations", () => {
     cy.contains("Cypress Testing");
     cy.wait(1000);
 
-    cy.visit("/site-search/?term=abcdefg");
+    cy.visit("/site-search/?query=abcdefg");
     cy.contains("No matching items to display");
     cy.contains(
       "Please sign in if you believe you should see matching items"

--- a/lib/__tests__/errors.test.ts
+++ b/lib/__tests__/errors.test.ts
@@ -1,5 +1,5 @@
 import { ErrorObject } from "../fetch-request.d";
-import { logError, errorObjectToProps } from "../errors";
+import { generateErrorObject, errorObjectToProps, logError } from "../errors";
 
 describe("Test logError", () => {
   it("should log an error", () => {
@@ -58,6 +58,26 @@ describe("Test errorObjectToProps", () => {
       },
     };
     const actual = errorObjectToProps(errorObject);
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe("Test generateErrorObject", () => {
+  it("should generate an error object", () => {
+    const statusCode = 403;
+    const title = "Forbidden";
+    const description = "You do not have permission to access this resource.";
+    const detail = "This is a detailed error message.";
+    const expected: ErrorObject = {
+      isError: true,
+      "@type": ["Error"],
+      code: statusCode,
+      description,
+      detail,
+      status: statusCode.toString(),
+      title,
+    };
+    const actual = generateErrorObject(statusCode, title, description, detail);
     expect(actual).toEqual(expected);
   });
 });

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -37,3 +37,28 @@ export function errorObjectToProps(errorObject: ErrorObject): ServerSideProps {
     },
   };
 }
+
+/**
+ * Generate an error object to pass to NextJS with the appropriate status code and message.
+ * @param statusCode HTTP status code
+ * @param title - Short title of the error
+ * @param description - Short description of the error
+ * @param detail - Detailed description of the error
+ * @returns ErrorObject to pass to NextJS
+ */
+export function generateErrorObject(
+  statusCode: number,
+  title: string,
+  description: string,
+  detail: string
+): ErrorObject {
+  return {
+    isError: true,
+    "@type": ["Error"],
+    code: statusCode,
+    description,
+    detail,
+    status: statusCode.toString(),
+    title,
+  };
+}


### PR DESCRIPTION
In addition I fixed a bug in the search model not clearing the existing search term when closing the modal. I also do error handling in the `/site-search` endpoint in the unusual case that someone enters bad query-string parameters manually.