### PR TITLE
IGVF-2200 Use embedded file-set samples on file pages

### DIFF
--- a/pages/alignment-files/[...id].js
+++ b/pages/alignment-files/[...id].js
@@ -33,13 +33,11 @@ import {
   requestDocuments,
   requestFileSets,
   requestFiles,
-  requestSamples,
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import {
   checkForFileDownloadPath,
-  collectFileFileSetSamples,
   convertFileDownloadPathToFilePagePath,
 } from "../../lib/files";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -51,7 +49,6 @@ export default function AlignmentFile({
   derivedFrom,
   derivedFromFileSets,
   inputFileFor,
-  fileSetSamples,
   fileFormatSpecifications,
   referenceFiles,
   isJson,
@@ -134,8 +131,8 @@ export default function AlignmentFile({
               panelId="file-format-specifications"
             />
           )}
-          {fileSetSamples.length > 0 && (
-            <SampleTable samples={fileSetSamples} />
+          {alignmentFile.file_set.samples?.length > 0 && (
+            <SampleTable samples={alignmentFile.file_set.samples} />
           )}
           {derivedFrom.length > 0 && (
             <DerivedFromTable
@@ -173,8 +170,6 @@ AlignmentFile.propTypes = {
   derivedFromFileSets: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Files that derive from this file
   inputFileFor: PropTypes.array.isRequired,
-  // Samples associated with this file's file set
-  fileSetSamples: PropTypes.array.isRequired,
   // Set of documents for file specifications
   fileFormatSpecifications: PropTypes.arrayOf(PropTypes.object),
   // Attribution for this file
@@ -235,14 +230,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
     const referenceFiles = alignmentFile.reference_files
       ? await requestFiles(alignmentFile.reference_files, request)
       : [];
-    const embeddedFileSetSamples = collectFileFileSetSamples(alignmentFile);
-    const fileSetSamplePaths = embeddedFileSetSamples.map(
-      (sample) => sample["@id"]
-    );
-    const fileSetSamples =
-      fileSetSamplePaths.length > 0
-        ? await requestSamples(fileSetSamplePaths, request)
-        : [];
     const attribution = await buildAttribution(
       alignmentFile,
       req.headers.cookie
@@ -254,7 +241,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         derivedFrom,
         derivedFromFileSets,
         inputFileFor,
-        fileSetSamples,
         fileFormatSpecifications,
         pageContext: { title: alignmentFile.accession },
         attribution,

--- a/pages/configuration-files/[...id].js
+++ b/pages/configuration-files/[...id].js
@@ -25,10 +25,8 @@ import {
   requestDocuments,
   requestFileSets,
   requestFiles,
-  requestSamples,
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
-import { collectFileFileSetSamples } from "../../lib/files";
 import FetchRequest from "../../lib/fetch-request";
 import {
   checkForFileDownloadPath,
@@ -44,7 +42,6 @@ export default function ConfigurationFile({
   derivedFrom,
   derivedFromFileSets,
   inputFileFor,
-  fileSetSamples,
   fileFormatSpecifications,
   isJson,
 }) {
@@ -87,8 +84,8 @@ export default function ConfigurationFile({
               panelId="file-format-specifications"
             />
           )}
-          {fileSetSamples.length > 0 && (
-            <SampleTable samples={fileSetSamples} />
+          {configurationFile.file_set.samples?.length > 0 && (
+            <SampleTable samples={configurationFile.file_set.samples} />
           )}
           {derivedFrom.length > 0 && (
             <DerivedFromTable
@@ -128,8 +125,6 @@ ConfigurationFile.propTypes = {
   derivedFromFileSets: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Files that derive from this file
   inputFileFor: PropTypes.array.isRequired,
-  // Samples associated with this file's file set
-  fileSetSamples: PropTypes.array.isRequired,
   // Set of documents for file specifications
   fileFormatSpecifications: PropTypes.arrayOf(PropTypes.object),
   // Attribution for this file
@@ -188,14 +183,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         request
       );
     }
-    const embeddedFileSetSamples = collectFileFileSetSamples(configurationFile);
-    const fileSetSamplePaths = embeddedFileSetSamples.map(
-      (sample) => sample["@id"]
-    );
-    const fileSetSamples =
-      fileSetSamplePaths.length > 0
-        ? await requestSamples(fileSetSamplePaths, request)
-        : [];
     const attribution = await buildAttribution(
       configurationFile,
       req.headers.cookie
@@ -208,7 +195,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         derivedFrom,
         derivedFromFileSets,
         inputFileFor,
-        fileSetSamples,
         fileFormatSpecifications,
         pageContext: { title: configurationFile.accession },
         attribution,

--- a/pages/image-files/[...id].js
+++ b/pages/image-files/[...id].js
@@ -24,10 +24,8 @@ import {
   requestDocuments,
   requestFileSets,
   requestFiles,
-  requestSamples,
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
-import { collectFileFileSetSamples } from "../../lib/files";
 import FetchRequest from "../../lib/fetch-request";
 import {
   checkForFileDownloadPath,
@@ -42,7 +40,6 @@ export default function ImageFile({
   derivedFrom,
   derivedFromFileSets,
   inputFileFor,
-  fileSetSamples,
   fileFormatSpecifications,
   isJson,
 }) {
@@ -76,8 +73,8 @@ export default function ImageFile({
               panelId="file-format-specifications"
             />
           )}
-          {fileSetSamples.length > 0 && (
-            <SampleTable samples={fileSetSamples} />
+          {imageFile.file_set.samples?.length > 0 && (
+            <SampleTable samples={imageFile.file_set.samples} />
           )}
           {derivedFrom.length > 0 && (
             <DerivedFromTable
@@ -115,8 +112,6 @@ ImageFile.propTypes = {
   derivedFromFileSets: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Files that derive from this file
   inputFileFor: PropTypes.array.isRequired,
-  // Samples associated with this file's file set
-  fileSetSamples: PropTypes.array.isRequired,
   // Set of documents for file specifications
   fileFormatSpecifications: PropTypes.arrayOf(PropTypes.object),
   // Attribution for this file
@@ -173,14 +168,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
     const referenceFiles = imageFile.reference_files
       ? await requestFiles(imageFile.reference_files, request)
       : [];
-    const embeddedFileSetSamples = collectFileFileSetSamples(imageFile);
-    const fileSetSamplePaths = embeddedFileSetSamples.map(
-      (sample) => sample["@id"]
-    );
-    const fileSetSamples =
-      fileSetSamplePaths.length > 0
-        ? await requestSamples(fileSetSamplePaths, request)
-        : [];
     const attribution = await buildAttribution(imageFile, req.headers.cookie);
     return {
       props: {
@@ -189,7 +176,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         derivedFrom,
         derivedFromFileSets,
         inputFileFor,
-        fileSetSamples,
         fileFormatSpecifications,
         pageContext: { title: imageFile.accession },
         attribution,

--- a/pages/index-files/[...id].tsx
+++ b/pages/index-files/[...id].tsx
@@ -32,10 +32,8 @@ import {
   requestDocuments,
   requestFileSets,
   requestFiles,
-  requestSamples,
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
-import { collectFileFileSetSamples } from "../../lib/files";
 import FetchRequest from "../../lib/fetch-request";
 import { type ErrorObject } from "../../lib/fetch-request.d";
 import {
@@ -60,7 +58,6 @@ export default function IndexFile({
   derivedFrom,
   derivedFromFileSets,
   inputFileFor,
-  fileSetSamples,
   fileFormatSpecifications,
   isJson,
 }: {
@@ -70,7 +67,6 @@ export default function IndexFile({
   derivedFrom: any[];
   derivedFromFileSets: FileSetObject[];
   inputFileFor: FileObject[];
-  fileSetSamples: any[];
   fileFormatSpecifications: any[];
   isJson: boolean;
 }) {
@@ -79,6 +75,7 @@ export default function IndexFile({
   const hasReferencePanel =
     indexFile.assembly || indexFile.transcriptome_annotation;
   const hasAlignmentPanel = "filtered" in indexFile || "redacted" in indexFile;
+  const fileSet = indexFile.file_set as FileSetObject;
 
   return (
     <>
@@ -161,8 +158,8 @@ export default function IndexFile({
               panelId="file-format-specifications"
             />
           )}
-          {fileSetSamples.length > 0 && (
-            <SampleTable samples={fileSetSamples} />
+          {fileSet.samples?.length > 0 && (
+            <SampleTable samples={fileSet.samples as object[]} />
           )}
           {derivedFrom.length > 0 && (
             <DerivedFromTable
@@ -248,16 +245,6 @@ export async function getServerSideProps(
       );
     }
 
-    const embeddedFileSetSamples = collectFileFileSetSamples(indexFile);
-
-    const fileSetSamplePaths = embeddedFileSetSamples.map(
-      (sample) => sample["@id"]
-    );
-    const fileSetSamples =
-      fileSetSamplePaths.length > 0
-        ? await requestSamples(fileSetSamplePaths, request)
-        : [];
-
     const attribution = await buildAttribution(indexFile, req.headers.cookie);
 
     return {
@@ -267,7 +254,6 @@ export async function getServerSideProps(
         derivedFrom,
         derivedFromFileSets,
         inputFileFor,
-        fileSetSamples,
         fileFormatSpecifications,
         pageContext: { title: indexFile.accession },
         attribution,

--- a/pages/matrix-files/[...id].js
+++ b/pages/matrix-files/[...id].js
@@ -30,13 +30,11 @@ import {
   requestDocuments,
   requestFileSets,
   requestFiles,
-  requestSamples,
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import {
   checkForFileDownloadPath,
-  collectFileFileSetSamples,
   convertFileDownloadPathToFilePagePath,
 } from "../../lib/files";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -48,7 +46,6 @@ export default function MatrixFile({
   derivedFrom,
   derivedFromFileSets,
   inputFileFor,
-  fileSetSamples,
   fileFormatSpecifications,
   referenceFiles,
   isJson,
@@ -93,8 +90,8 @@ export default function MatrixFile({
               title="File Format Specifications"
             />
           )}
-          {fileSetSamples.length > 0 && (
-            <SampleTable samples={fileSetSamples} />
+          {matrixFile.file_set.samples?.length > 0 && (
+            <SampleTable samples={matrixFile.file_set.samples} />
           )}
           {referenceFiles.length > 0 && (
             <FileTable
@@ -139,8 +136,6 @@ MatrixFile.propTypes = {
   derivedFromFileSets: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Files that derive from this file
   inputFileFor: PropTypes.array.isRequired,
-  // Samples associated with the file's file sets
-  fileSetSamples: PropTypes.array.isRequired,
   // Set of documents for file specifications
   fileFormatSpecifications: PropTypes.arrayOf(PropTypes.object),
   // Attribution for this file
@@ -201,14 +196,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
     const referenceFiles = matrixFile.reference_files
       ? await requestFiles(matrixFile.reference_files, request)
       : [];
-    const embeddedFileSetSamples = collectFileFileSetSamples(matrixFile);
-    const fileSetSamplePaths = embeddedFileSetSamples.map(
-      (sample) => sample["@id"]
-    );
-    const fileSetSamples =
-      fileSetSamplePaths.length > 0
-        ? await requestSamples(fileSetSamplePaths, request)
-        : [];
     const attribution = await buildAttribution(matrixFile, req.headers.cookie);
     return {
       props: {
@@ -217,7 +204,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         derivedFrom,
         derivedFromFileSets,
         inputFileFor,
-        fileSetSamples,
         fileFormatSpecifications,
         pageContext: { title: matrixFile.accession },
         attribution,

--- a/pages/model-files/[...id].js
+++ b/pages/model-files/[...id].js
@@ -25,13 +25,11 @@ import {
   requestDocuments,
   requestFileSets,
   requestFiles,
-  requestSamples,
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import {
   checkForFileDownloadPath,
-  collectFileFileSetSamples,
   convertFileDownloadPathToFilePagePath,
 } from "../../lib/files";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -42,7 +40,6 @@ export default function ModelFile({
   documents,
   derivedFrom,
   derivedFromFileSets,
-  fileSetSamples,
   inputFileFor,
   fileFormatSpecifications,
   isJson,
@@ -78,8 +75,8 @@ export default function ModelFile({
               panelId="file-format-specifications"
             />
           )}
-          {fileSetSamples.length > 0 && (
-            <SampleTable samples={fileSetSamples} />
+          {modelFile.file_set.samples?.length > 0 && (
+            <SampleTable samples={modelFile.file_set.samples} />
           )}
           {derivedFrom.length > 0 && (
             <DerivedFromTable
@@ -117,8 +114,6 @@ ModelFile.propTypes = {
   derivedFromFileSets: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Files that derive from this file
   inputFileFor: PropTypes.array.isRequired,
-  // Samples associated with file sets embedded in this file
-  fileSetSamples: PropTypes.array.isRequired,
   // File specification documents
   fileFormatSpecifications: PropTypes.arrayOf(PropTypes.object),
   // Attribution for this file
@@ -176,16 +171,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         request
       );
     }
-
-    const embeddedFileSetSamples = collectFileFileSetSamples(modelFile);
-    const fileSetSamplePaths = embeddedFileSetSamples.map(
-      (sample) => sample["@id"]
-    );
-    const fileSetSamples =
-      fileSetSamplePaths.length > 0
-        ? await requestSamples(fileSetSamplePaths, request)
-        : [];
-
     const attribution = await buildAttribution(modelFile, req.headers.cookie);
     return {
       props: {
@@ -194,7 +179,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         derivedFrom,
         derivedFromFileSets,
         inputFileFor,
-        fileSetSamples,
         fileFormatSpecifications,
         pageContext: { title: modelFile.accession },
         attribution,

--- a/pages/reference-files/[...id].js
+++ b/pages/reference-files/[...id].js
@@ -33,13 +33,11 @@ import {
   requestDocuments,
   requestFileSets,
   requestFiles,
-  requestSamples,
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import {
   checkForFileDownloadPath,
-  collectFileFileSetSamples,
   convertFileDownloadPathToFilePagePath,
 } from "../../lib/files";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -50,7 +48,6 @@ export default function ReferenceFile({
   derivedFrom,
   derivedFromFileSets,
   inputFileFor,
-  fileSetSamples,
   fileFormatSpecifications,
   integratedIn,
   attribution = null,
@@ -128,8 +125,8 @@ export default function ReferenceFile({
               panelId="file-format-specifications"
             />
           )}
-          {fileSetSamples.length > 0 && (
-            <SampleTable samples={fileSetSamples} />
+          {referenceFile.file_set.samples?.length > 0 && (
+            <SampleTable samples={referenceFile.file_set.samples} />
           )}
           {derivedFrom.length > 0 && (
             <DerivedFromTable
@@ -176,8 +173,6 @@ ReferenceFile.propTypes = {
   derivedFromFileSets: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Files that derive from this file
   inputFileFor: PropTypes.array.isRequired,
-  // Samples associated with the file's file sets
-  fileSetSamples: PropTypes.array,
   // Set of documents for file specifications
   fileFormatSpecifications: PropTypes.arrayOf(PropTypes.object),
   // ConstructLibraryset this file was integrated in
@@ -241,14 +236,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
       );
       integratedIn = await requestFileSets(integratedInPaths, request);
     }
-    const embeddedFileSetSamples = collectFileFileSetSamples(referenceFile);
-    const fileSetSamplePaths = embeddedFileSetSamples.map(
-      (sample) => sample["@id"]
-    );
-    const fileSetSamples =
-      fileSetSamplePaths.length > 0
-        ? await requestSamples(fileSetSamplePaths, request)
-        : [];
     const attribution = await buildAttribution(
       referenceFile,
       req.headers.cookie
@@ -260,7 +247,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         derivedFrom,
         derivedFromFileSets,
         inputFileFor,
-        fileSetSamples,
         fileFormatSpecifications,
         integratedIn,
         pageContext: { title: referenceFile.accession },

--- a/pages/sequence-files/[...id].js
+++ b/pages/sequence-files/[...id].js
@@ -33,14 +33,12 @@ import {
   requestDocuments,
   requestFileSets,
   requestFiles,
-  requestSamples,
   requestSeqspecFiles,
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import {
   checkForFileDownloadPath,
-  collectFileFileSetSamples,
   convertFileDownloadPathToFilePagePath,
 } from "../../lib/files";
 import { truthyOrZero } from "../../lib/general";
@@ -52,7 +50,6 @@ export default function SequenceFile({
   derivedFrom,
   derivedFromFileSets,
   inputFileFor,
-  fileSetSamples,
   fileFormatSpecifications,
   seqspecDocument,
   attribution = null,
@@ -169,8 +166,8 @@ export default function SequenceFile({
               panelId="file-format-specifications"
             />
           )}
-          {fileSetSamples.length > 0 && (
-            <SampleTable samples={fileSetSamples} />
+          {sequenceFile.file_set.samples?.length > 0 && (
+            <SampleTable samples={sequenceFile.file_set.samples} />
           )}
           {derivedFrom.length > 0 && (
             <DerivedFromTable
@@ -214,8 +211,6 @@ SequenceFile.propTypes = {
   derivedFrom: PropTypes.array,
   // Filesets derived from files belong to
   derivedFromFileSets: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Samples associated with this file's file set
-  fileSetSamples: PropTypes.array.isRequired,
   // Files that derive from this file
   inputFileFor: PropTypes.array.isRequired,
   // Set of documents for file specifications
@@ -283,14 +278,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
     const seqspecDocuments = sequenceFile.seqspec_document
       ? await requestDocuments([sequenceFile.seqspec_document], request)
       : null;
-    const embeddedFileSetSamples = collectFileFileSetSamples(sequenceFile);
-    const fileSetSamplePaths = embeddedFileSetSamples.map(
-      (sample) => sample["@id"]
-    );
-    const fileSetSamples =
-      fileSetSamplePaths.length > 0
-        ? await requestSamples(fileSetSamplePaths, request)
-        : [];
     const attribution = await buildAttribution(
       sequenceFile,
       req.headers.cookie
@@ -302,7 +289,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         derivedFrom,
         derivedFromFileSets,
         inputFileFor,
-        fileSetSamples,
         fileFormatSpecifications,
         seqspecDocument: seqspecDocuments ? seqspecDocuments[0] : null,
         pageContext: { title: sequenceFile.accession },

--- a/pages/signal-files/[...id].js
+++ b/pages/signal-files/[...id].js
@@ -30,13 +30,11 @@ import {
   requestDocuments,
   requestFileSets,
   requestFiles,
-  requestSamples,
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import {
   checkForFileDownloadPath,
-  collectFileFileSetSamples,
   convertFileDownloadPathToFilePagePath,
 } from "../../lib/files";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -48,7 +46,6 @@ export default function SignalFile({
   derivedFrom,
   derivedFromFileSets,
   inputFileFor,
-  fileSetSamples,
   fileFormatSpecifications,
   referenceFiles,
   isJson,
@@ -118,8 +115,8 @@ export default function SignalFile({
               panelId="file-format-specifications"
             />
           )}
-          {fileSetSamples.length > 0 && (
-            <SampleTable samples={fileSetSamples} />
+          {signalFile.file_set.samples?.length > 0 && (
+            <SampleTable samples={signalFile.file_set.samples} />
           )}
           {derivedFrom.length > 0 && (
             <DerivedFromTable
@@ -164,8 +161,6 @@ SignalFile.propTypes = {
   derivedFromFileSets: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Files that derive from this file
   inputFileFor: PropTypes.array.isRequired,
-  // Samples associated with the file's file sets
-  fileSetSamples: PropTypes.array.isRequired,
   // Set of documents for file specifications
   fileFormatSpecifications: PropTypes.arrayOf(PropTypes.object),
   // Attribution for this file
@@ -226,14 +221,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
     const referenceFiles = signalFile.reference_files
       ? await requestFiles(signalFile.reference_files, request)
       : [];
-    const embeddedFileSetSamples = collectFileFileSetSamples(signalFile);
-    const fileSetSamplePaths = embeddedFileSetSamples.map(
-      (sample) => sample["@id"]
-    );
-    const fileSetSamples =
-      fileSetSamplePaths.length > 0
-        ? await requestSamples(fileSetSamplePaths, request)
-        : [];
     const attribution = await buildAttribution(signalFile, req.headers.cookie);
     return {
       props: {
@@ -242,7 +229,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         derivedFrom,
         derivedFromFileSets,
         inputFileFor,
-        fileSetSamples,
         fileFormatSpecifications,
         pageContext: { title: signalFile.accession },
         attribution,

--- a/pages/tabular-files/[...id].js
+++ b/pages/tabular-files/[...id].js
@@ -38,7 +38,6 @@ import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
 import {
   checkForFileDownloadPath,
-  collectFileFileSetSamples,
   convertFileDownloadPathToFilePagePath,
 } from "../../lib/files";
 import { isJsonFormat } from "../../lib/query-utils";
@@ -50,7 +49,6 @@ export default function TabularFile({
   derivedFrom,
   derivedFromFileSets,
   inputFileFor,
-  fileSetSamples,
   fileFormatSpecifications,
   integratedIn,
   attribution = null,
@@ -112,8 +110,8 @@ export default function TabularFile({
               panelId="file-format-specifications"
             />
           )}
-          {fileSetSamples.length > 0 && (
-            <SampleTable samples={fileSetSamples} />
+          {tabularFile.file_set.samples?.length > 0 && (
+            <SampleTable samples={tabularFile.file_set.samples} />
           )}
           {derivedFrom.length > 0 && (
             <DerivedFromTable
@@ -171,8 +169,6 @@ TabularFile.propTypes = {
   derivedFromFileSets: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Files that derive from this file
   inputFileFor: PropTypes.array.isRequired,
-  // Samples that belong to this file's file set
-  fileSetSamples: PropTypes.array,
   // Set of documents for file specifications
   fileFormatSpecifications: PropTypes.arrayOf(PropTypes.object),
   // ConstructLibraryset this file was integrated in
@@ -240,14 +236,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
       );
       integratedIn = await requestFileSets(integratedInPaths, request);
     }
-    const embeddedFileSetSamples = collectFileFileSetSamples(tabularFile);
-    const fileSetSamplePaths = embeddedFileSetSamples.map(
-      (sample) => sample["@id"]
-    );
-    const fileSetSamples =
-      fileSetSamplePaths.length > 0
-        ? await requestSamples(fileSetSamplePaths, request)
-        : [];
     const attribution = await buildAttribution(tabularFile, req.headers.cookie);
     return {
       props: {
@@ -257,7 +245,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         derivedFrom,
         derivedFromFileSets,
         inputFileFor,
-        fileSetSamples,
         fileFormatSpecifications,
         integratedIn,
         pageContext: { title: tabularFile.accession },


### PR DESCRIPTION
File objects now embed enough data, we don’t have to request their file-set samples. Every changed page in this branch all have the same modification, with small variants in some cases.