### PR TITLE
IGVF-2774 Disable link prefetch site wide

### DIFF
--- a/components/add.js
+++ b/components/add.js
@@ -85,9 +85,9 @@ function schemaToName(schema) {
 
 /**
  * Generates a button link to the #!add url for the given collection.
- * A custom label can be suplied with the `label` prop.
+ * A custom label can be supplied with the `label` prop.
  */
-export function AddLink({ schema, label = null, prefetch = true }) {
+export function AddLink({ schema, label = null }) {
   const { isAuthenticated } = useAuth0();
   if (isAuthenticated && canEdit(schema)) {
     const schemaName = schemaToName(schema);
@@ -104,7 +104,6 @@ export function AddLink({ schema, label = null, prefetch = true }) {
           size="sm"
           type="secondary"
           hasIconOnly
-          prefetch={prefetch}
         >
           <PlusIcon />
         </ButtonLink>
@@ -119,8 +118,6 @@ AddLink.propTypes = {
   schema: PropTypes.object.isRequired,
   // Label for the Add button
   label: PropTypes.string,
-  // False to disable link prefetching
-  prefetch: PropTypes.bool,
 };
 
 export function AddInstancePage({ collection }) {

--- a/components/analysis-set-file-table.js
+++ b/components/analysis-set-file-table.js
@@ -1,12 +1,12 @@
 // node_modules
 import { TableCellsIcon } from "@heroicons/react/20/solid";
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import { BatchDownloadActuator } from "./batch-download";
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import { FileAccessionAndDownload } from "./file-download";
 import { HostedFilePreview } from "./hosted-file-preview";
+import Link from "./link-no-prefetch";
 import SortableGrid from "./sortable-grid";
 import Status from "./status";
 import { UniformlyProcessedBadge } from "./common-pill-badges";

--- a/components/analysis-step-version-table.js
+++ b/components/analysis-step-version-table.js
@@ -1,10 +1,10 @@
 // node_modules
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import _ from "lodash";
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
+import Link from "./link-no-prefetch";
 import SeparatedList from "./separated-list";
 import SortableGrid from "./sortable-grid";
 

--- a/components/attribution.tsx
+++ b/components/attribution.tsx
@@ -1,8 +1,8 @@
 // node_modules
-import Link from "next/link";
 // components
 import Collections from "./collections";
 import { DataItemLabel, DataItemValue } from "./data-area";
+import Link from "./link-no-prefetch";
 import SeparatedList from "./separated-list";
 // lib
 import { type Attribution } from "../lib/attribution";

--- a/components/breadcrumbs.js
+++ b/components/breadcrumbs.js
@@ -1,9 +1,9 @@
 // node_modules
-import Link from "next/link";
 import { PropTypes } from "prop-types";
 import { useContext } from "react";
 // components
 import GlobalContext from "./global-context";
+import Link from "./link-no-prefetch";
 import SeparatedList from "./separated-list";
 import SessionContext from "./session-context";
 // lib

--- a/components/chart-file-set-lab.js
+++ b/components/chart-file-set-lab.js
@@ -1,8 +1,9 @@
 // node_modules
 import _ from "lodash";
 import dynamic from "next/dynamic";
-import Link from "next/link";
 import PropTypes from "prop-types";
+// components
+import Link from "./link-no-prefetch";
 // lib
 import {
   abbreviateNumber,
@@ -109,11 +110,7 @@ CustomXTick.propTypes = {
  * `shouldIncludeLinks` is true.
  */
 function BarLink({ path, children }) {
-  return (
-    <Link href={path} prefetch={false}>
-      {children}
-    </Link>
-  );
+  return <Link href={path}>{children}</Link>;
 }
 
 BarLink.propTypes = {

--- a/components/checkfiles-version.tsx
+++ b/components/checkfiles-version.tsx
@@ -1,5 +1,3 @@
-// node_modules
-import Link from "next/link";
 // root
 import { FileObject } from "../globals.d";
 
@@ -14,14 +12,14 @@ export function CheckfilesVersion({ file }: { file: FileObject }) {
 
   if (file.checkfiles_version) {
     return (
-      <Link
+      <a
         href={`https://github.com/IGVF-DACC/checkfiles/releases/tag/${file.checkfiles_version}`}
         className={`${className} rounded-sm no-underline`}
         target="_blank"
         rel="noopener noreferrer"
       >
         {file.checkfiles_version}
-      </Link>
+      </a>
     );
   }
 
@@ -34,14 +32,14 @@ export function CheckfilesVersion({ file }: { file: FileObject }) {
     file.upload_status === "invalidated"
   ) {
     return (
-      <Link
+      <a
         href="https://github.com/IGVF-DACC/checkfiles/tags"
         className={`${className} rounded-sm no-underline`}
         target="_blank"
         rel="noopener noreferrer"
       >
         Legacy version of checkfiles
-      </Link>
+      </a>
     );
   }
 

--- a/components/collections.tsx
+++ b/components/collections.tsx
@@ -1,7 +1,8 @@
 // node_modules
 import _ from "lodash";
 import Image from "next/image";
-import Link from "next/link";
+// components
+import Link from "./link-no-prefetch";
 
 /**
  * Type for the collection map object. The keys are collection names from the schema enum and the

--- a/components/common-data-items.js
+++ b/components/common-data-items.js
@@ -13,7 +13,6 @@
 // node_modules
 import { QuestionMarkCircleIcon } from "@heroicons/react/20/solid";
 import _ from "lodash";
-import Link from "next/link";
 import PropTypes from "prop-types";
 import { Fragment } from "react";
 // components
@@ -26,6 +25,7 @@ import {
   DataItemValueUrl,
 } from "./data-area";
 import DbxrefList from "./dbxref-list";
+import Link from "./link-no-prefetch";
 import ProductInfo from "./product-info";
 import SeparatedList from "./separated-list";
 import { Tooltip, TooltipRef, useTooltip } from "./tooltip";
@@ -567,7 +567,6 @@ export function FileDataItems({ item, children = null }) {
               <Link
                 href={item.file_set["@id"]}
                 aria-label={`FileSet ${item.file_set.accession}`}
-                key={item.file_set["@id"]}
               >
                 {item.file_set.accession}
               </Link>

--- a/components/derived-from-table.js
+++ b/components/derived-from-table.js
@@ -1,11 +1,11 @@
 // node_modules
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import PropTypes from "prop-types";
-import Link from "next/link";
 // components
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import { FileAccessionAndDownload } from "./file-download";
 import { HostedFilePreview } from "./hosted-file-preview";
+import Link from "./link-no-prefetch";
 import SortableGrid from "./sortable-grid";
 import Status from "./status";
 // lib

--- a/components/error.js
+++ b/components/error.js
@@ -1,11 +1,9 @@
 // node_modules
 import { useAuth0 } from "@auth0/auth0-react";
-import Link from "next/link";
 import PropTypes from "prop-types";
-import { useContext } from "react";
 // components
 import { ButtonAsLink } from "./form-elements";
-import SessionContext from "./session-context";
+import Link from "./link-no-prefetch";
 // lib
 import { loginAuthProvider } from "../lib/authentication";
 import { LINK_INLINE_STYLE } from "../lib/constants";

--- a/components/facets/facet-tags.js
+++ b/components/facets/facet-tags.js
@@ -1,10 +1,11 @@
 // node_modules
 import { useAuth0 } from "@auth0/auth0-react";
 import { XMarkIcon } from "@heroicons/react/20/solid";
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components/facets
 import facetRegistry from "./facet-registry";
+// components
+import Link from "../link-no-prefetch";
 // lib
 import {
   collectAllChildFacets,

--- a/components/file-graph/file-modal.tsx
+++ b/components/file-graph/file-modal.tsx
@@ -1,6 +1,5 @@
 // node_modules
 import { TableCellsIcon } from "@heroicons/react/20/solid";
-import Link from "next/link";
 // components
 import AliasList from "../alias-list";
 import {
@@ -12,6 +11,7 @@ import {
 import { FileDownload } from "../file-download";
 import { ButtonLink } from "../form-elements";
 import { HostedFilePreview } from "../hosted-file-preview";
+import Link from "../link-no-prefetch";
 import Modal from "../modal";
 import Status from "../status";
 // local

--- a/components/file-graph/file-set-modal.tsx
+++ b/components/file-graph/file-set-modal.tsx
@@ -1,6 +1,5 @@
 // node_modules
 import { TableCellsIcon } from "@heroicons/react/20/solid";
-import Link from "next/link";
 // components
 import AliasList from "../alias-list";
 import {
@@ -12,6 +11,7 @@ import {
 } from "../data-area";
 import { FileAccessionAndDownload } from "../file-download";
 import { HostedFilePreview } from "../hosted-file-preview";
+import Link from "../link-no-prefetch";
 import Modal from "../modal";
 import SeparatedList from "../separated-list";
 import SortableGrid from "../sortable-grid";

--- a/components/file-set-table.js
+++ b/components/file-set-table.js
@@ -1,10 +1,10 @@
 // node_modules
 import { TableCellsIcon } from "@heroicons/react/20/solid";
-import Link from "next/link";
 import PropTypes from "prop-types";
 import { useContext } from "react";
 // components
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
+import Link from "./link-no-prefetch";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import SeparatedList from "./separated-list";
 import SessionContext from "./session-context";

--- a/components/form-elements/button.js
+++ b/components/form-elements/button.js
@@ -19,9 +19,10 @@
  */
 
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 import React from "react";
+// components
+import Link from "../link-no-prefetch";
 // lib
 import { LINK_INLINE_STYLE } from "../../lib/constants";
 import { generateButtonClasses } from "../../lib/form-elements";
@@ -117,10 +118,9 @@ Button.displayName = "Button";
  */
 function LinkElement(props) {
   const { isExternal } = props;
-  const prefetch = props.prefetch ?? true;
 
-  // Make a copy of `props` but without `isExternal` nor `prefetch` in case it was included.
-  const { isExternal: _, prefetch: __, ...propsWithoutExceptions } = props;
+  // Make a copy of `props` but without `isExternal` in case it was included.
+  const { isExternal: _, ...propsWithoutExceptions } = props;
 
   if (isExternal) {
     return (
@@ -131,19 +131,12 @@ function LinkElement(props) {
       />
     );
   }
-  return (
-    <Link
-      {...propsWithoutExceptions}
-      {...(prefetch === false ? { prefetch: false } : {})}
-    />
-  );
+  return <Link {...propsWithoutExceptions} />;
 }
 
 LinkElement.propTypes = {
   // True for external links
   isExternal: PropTypes.bool,
-  // True to prefetch the link
-  prefetch: PropTypes.bool,
 };
 
 /**
@@ -165,7 +158,6 @@ export function ButtonLink({
   isInline = false,
   isDisabled = false,
   isExternal = false,
-  prefetch = true,
   className = "",
   children,
 }) {
@@ -190,7 +182,6 @@ export function ButtonLink({
   ) : (
     <LinkElement
       isExternal={isExternal}
-      prefetch={prefetch}
       href={href}
       aria-label={label}
       id={id}
@@ -224,8 +215,6 @@ ButtonLink.propTypes = {
   isDisabled: PropTypes.bool,
   // True if the link is external
   isExternal: PropTypes.bool,
-  // True to prefetch the link
-  prefetch: PropTypes.bool,
   // Additional Tailwind CSS classes to apply to the <button> element
   className: PropTypes.string,
 };

--- a/components/institutional-certificate-table.tsx
+++ b/components/institutional-certificate-table.tsx
@@ -1,10 +1,10 @@
 // node_modules
 import { TableCellsIcon } from "@heroicons/react/20/solid";
-import Link from "next/link";
 // components
 import { ControlledAccessIndicator } from "./controlled-access";
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import { DataUseLimitationStatus } from "./data-use-limitation-status";
+import Link from "./link-no-prefetch";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
 // lib

--- a/components/item-link.js
+++ b/components/item-link.js
@@ -1,7 +1,8 @@
 // node_modules
 import { ChevronDoubleRightIcon } from "@heroicons/react/20/solid";
-import Link from "next/link";
 import PropTypes from "prop-types";
+// components
+import Link from "./link-no-prefetch";
 
 /**
  * Displays the link to an object page, with a double-right chevron icon.

--- a/components/link-no-prefetch.tsx
+++ b/components/link-no-prefetch.tsx
@@ -1,0 +1,31 @@
+// node_modules
+import Link, { LinkProps } from "next/link";
+import { AnchorHTMLAttributes } from "react";
+
+/**
+ * Merges Next.js LinkProps with HTML anchor attributes.
+ */
+type LinkAndAnchorProps = LinkProps & AnchorHTMLAttributes<HTMLAnchorElement>;
+
+/**
+ * For all places you would normally use the NextJS `<Link>` component, import this one instead.
+ * This component disables prefetching to reduce the load on the NextJS server and potentially the
+ * data provider. This takes the same props as the NextJS `<Link>` component.
+ *
+ * This component uses an unnamed default export, so you can import it like this:
+ *
+ * ```ts
+ * import Link from "./components/link-no-prefetch";
+ * ```
+ *
+ * This lets you use `<Link>` in your code instead of `<LinkNoPrefetch>`.
+ */
+export default function LinkNoPrefetch(props: LinkAndAnchorProps) {
+  const { children, ...rest } = props;
+
+  return (
+    <Link {...rest} prefetch={false}>
+      {children}
+    </Link>
+  );
+}

--- a/components/link-reloadable.js
+++ b/components/link-reloadable.js
@@ -1,5 +1,5 @@
 // node_imports
-import Link from "next/link";
+import Link from "./link-no-prefetch";
 import { useContext } from "react";
 // components
 import GlobalContext from "../components/global-context";

--- a/components/linked-id-and-status.js
+++ b/components/linked-id-and-status.js
@@ -1,7 +1,7 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
+import Link from "./link-no-prefetch";
 import Status from "./status";
 
 /**

--- a/components/markdown-section.js
+++ b/components/markdown-section.js
@@ -1,8 +1,9 @@
 // node_modules
 import DOMPurify from "isomorphic-dompurify";
 import Markdown from "marked-react";
-import Link from "next/link";
 import PropTypes from "prop-types";
+// components
+import Link from "./link-no-prefetch";
 // lib
 import { isValidPath, isValidUrl } from "../lib/general";
 

--- a/components/navigation.js
+++ b/components/navigation.js
@@ -7,7 +7,6 @@ import {
   PlusIcon,
   QuestionMarkCircleIcon,
 } from "@heroicons/react/20/solid";
-import Link from "next/link";
 import PropTypes from "prop-types";
 import React, {
   Children,
@@ -28,6 +27,7 @@ import GlobalContext from "./global-context";
 import Icon from "./icon";
 import IdSearchTrigger from "./id-search-trigger";
 import IndexerState from "./indexer-state";
+import Link from "./link-no-prefetch";
 import { CreativeCommons, Email, Twitter } from "./site-info";
 import SiteLogo from "./logo";
 import Modal from "./modal";

--- a/components/no-collection-data.js
+++ b/components/no-collection-data.js
@@ -1,13 +1,12 @@
 // node_modules
 import { useAuth0 } from "@auth0/auth0-react";
-import Link from "next/link";
 import PropTypes from "prop-types";
 import { useContext } from "react";
 // components
 import { DataPanel } from "./data-area";
 import { ButtonAsLink } from "./form-elements";
 import GlobalContext from "./global-context";
-import SessionContext from "./session-context";
+import Link from "./link-no-prefetch";
 // lib
 import { loginAuthProvider } from "../lib/authentication";
 import { LINK_INLINE_STYLE } from "../lib/constants";

--- a/components/page-component/button-navigation.js
+++ b/components/page-component/button-navigation.js
@@ -1,7 +1,8 @@
 // node_modules
 import DOMPurify from "isomorphic-dompurify";
-import Link from "next/link";
 import PropTypes from "prop-types";
+// components
+import Link from "../link-no-prefetch";
 // lib
 import { isValidPath, isValidUrl } from "../../lib/general";
 import MarkdownSection from "../markdown-section";

--- a/components/page-component/page-navigation.js
+++ b/components/page-component/page-navigation.js
@@ -1,5 +1,5 @@
-// node_modules
-import Link from "next/link";
+// components
+import Link from "../link-no-prefetch";
 // lib
 import { isValidUrl } from "../../lib/general";
 

--- a/components/phenotypic-feature-table.js
+++ b/components/phenotypic-feature-table.js
@@ -1,8 +1,8 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import { DataAreaTitle } from "./data-area";
+import Link from "./link-no-prefetch";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import SortableGrid from "./sortable-grid";
 // lib

--- a/components/product-info.js
+++ b/components/product-info.js
@@ -1,6 +1,7 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
+// components
+import Link from "./link-no-prefetch";
 // lib
 import { pathToType } from "../lib/general";
 

--- a/components/profiles.js
+++ b/components/profiles.js
@@ -4,10 +4,10 @@ import {
   TableCellsIcon,
   XCircleIcon,
 } from "@heroicons/react/20/solid";
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import { AttachedButtons, ButtonLink, TextField } from "./form-elements";
+import Link from "./link-no-prefetch";
 import { useBrowserStateQuery } from "./presentation-status";
 // lib
 import { schemaToPath, SEARCH_MODE_TITLE } from "../lib/profiles";
@@ -67,7 +67,7 @@ SchemaSearchField.propTypes = {
 /**
  * Displays links to the search-list and report pages for the given schema object type.
  */
-export function SearchAndReportType({ type, title, prefetch = true }) {
+export function SearchAndReportType({ type, title }) {
   // Extra query-string parameters for list/report pages
   let extraQueries = useBrowserStateQuery();
   if (typesWithoutExtraQueries.includes(type)) {
@@ -82,7 +82,6 @@ export function SearchAndReportType({ type, title, prefetch = true }) {
         type="secondary"
         size="sm"
         hasIconOnly
-        prefetch={prefetch}
       >
         <Bars4Icon />
       </ButtonLink>
@@ -92,7 +91,6 @@ export function SearchAndReportType({ type, title, prefetch = true }) {
         type="secondary"
         size="sm"
         hasIconOnly
-        prefetch={prefetch}
       >
         <TableCellsIcon />
       </ButtonLink>
@@ -105,14 +103,12 @@ SearchAndReportType.propTypes = {
   type: PropTypes.string.isRequired,
   // Human-readable title for the schema
   title: PropTypes.string.isRequired,
-  // False to disable link prefetching
-  prefetch: PropTypes.bool,
 };
 
 /**
  * Display a schema's version number.
  */
-export function SchemaVersion({ schema, isLinked = false, prefetch = true }) {
+export function SchemaVersion({ schema, isLinked = false }) {
   const version = schema.properties.schema_version.default;
   const path = schemaToPath(schema);
   const className =
@@ -122,7 +118,6 @@ export function SchemaVersion({ schema, isLinked = false, prefetch = true }) {
       <Link
         href={`${path}/changelog`}
         className={`${className} rounded-sm`}
-        prefetch={prefetch}
       >{`v${version}`}</Link>
     );
   }
@@ -134,6 +129,4 @@ SchemaVersion.propTypes = {
   schema: PropTypes.object.isRequired,
   // True to link to the changelog page, false to just display the version number
   isLinked: PropTypes.bool,
-  // False to disable link prefetching
-  prefetch: PropTypes.bool,
 };

--- a/components/quality-metric.tsx
+++ b/components/quality-metric.tsx
@@ -12,7 +12,6 @@
  */
 
 // node_modules
-import Link from "next/link";
 import { useContext } from "react";
 // components
 import {
@@ -22,6 +21,7 @@ import {
   DataItemLabel,
   DataItemValue,
 } from "./data-area";
+import Link from "./link-no-prefetch";
 import Modal from "./modal";
 import SessionContext from "./session-context";
 // lib

--- a/components/report/cell-renderers.js
+++ b/components/report/cell-renderers.js
@@ -7,7 +7,6 @@
 
 // node_modules
 import _ from "lodash";
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import ChromosomeLocations from "../chromosome-locations";
@@ -17,6 +16,7 @@ import {
   DEFAULT_MAX_COLLAPSE_ITEMS_VERTICAL,
   useCollapseControl,
 } from "../collapse-control";
+import Link from "../link-no-prefetch";
 import MarkdownSection from "../markdown-section";
 import SeparatedList from "../separated-list";
 import { AliasesCell } from "../table-cells";

--- a/components/sample-table.js
+++ b/components/sample-table.js
@@ -1,11 +1,11 @@
 // node_modules
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import _ from "lodash";
-import Link from "next/link";
 import PropTypes from "prop-types";
 import { useContext } from "react";
 // components
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
+import Link from "./link-no-prefetch";
 import LinkedIdAndStatus from "./linked-id-and-status";
 import LinkedIdAndStatusStack from "./linked-id-and-status-stack";
 import SeparatedList from "./separated-list";

--- a/components/search/list-renderer/file.js
+++ b/components/search/list-renderer/file.js
@@ -1,6 +1,5 @@
 // node_modules
 import PropTypes from "prop-types";
-import Link from "next/link";
 import { useContext } from "react";
 // components/search/list-renderer
 import {
@@ -19,6 +18,7 @@ import {
 } from "./search-list-item";
 // components
 import { ExternallyHostedBadge } from "../../common-pill-badges";
+import Link from "../../link-no-prefetch";
 import SeparatedList from "../../separated-list";
 import SessionContext from "../../session-context";
 

--- a/components/search/list-renderer/index-file.tsx
+++ b/components/search/list-renderer/index-file.tsx
@@ -1,8 +1,8 @@
 // node_modules
 import PropTypes from "prop-types";
-import Link from "next/link";
 import { useContext } from "react";
 // components
+import Link from "../../link-no-prefetch";
 import SessionContext from "../../session-context";
 // components/search/list-renderer
 import {

--- a/components/search/list-renderer/open-reading-frame.js
+++ b/components/search/list-renderer/open-reading-frame.js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components/search/list-renderer
 import {
@@ -16,6 +15,7 @@ import {
   SearchListItemUniqueId,
 } from "./search-list-item";
 // components
+import Link from "../../link-no-prefetch";
 import SeparatedList from "../../separated-list";
 
 export default function OpenReadingFrame({ item: openReadingFrame }) {

--- a/components/seqspec-document.tsx
+++ b/components/seqspec-document.tsx
@@ -1,8 +1,8 @@
 // node_modules
 import { ArrowDownTrayIcon } from "@heroicons/react/20/solid";
-import Link from "next/link";
 // components
 import DocumentAttachmentLink from "./document-link";
+import Link from "./link-no-prefetch";
 // lib
 import { generateButtonClasses } from "../lib/form-elements";
 // root

--- a/components/sequencing-file-table.js
+++ b/components/sequencing-file-table.js
@@ -1,11 +1,11 @@
 // node_modules
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import _ from "lodash";
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import { FileAccessionAndDownload } from "./file-download";
+import Link from "./link-no-prefetch";
 import { SeqspecDocumentLink } from "./seqspec-document";
 import SortableGrid from "./sortable-grid";
 import Status from "./status";

--- a/components/source-prop.js
+++ b/components/source-prop.js
@@ -1,6 +1,7 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
+// components
+import Link from "./link-no-prefetch";
 // lib
 import { pathToType } from "../lib/general";
 

--- a/components/unspecified-property.js
+++ b/components/unspecified-property.js
@@ -1,8 +1,8 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 import { Fragment } from "react";
 // components
+import Link from "./link-no-prefetch";
 import SeparatedList from "./separated-list";
 
 /**

--- a/pages/alignment-files/[...id].js
+++ b/pages/alignment-files/[...id].js
@@ -1,6 +1,5 @@
 // node_modules
 import PropTypes from "prop-types";
-import Link from "next/link";
 // components
 import AlternateAccessions from "../../components/alternate-accessions";
 import Attribution from "../../components/attribution";
@@ -21,6 +20,7 @@ import { FileHeaderDownload } from "../../components/file-download";
 import FileTable from "../../components/file-table";
 import { HostedFilePreview } from "../../components/hosted-file-preview";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import { QualityMetricPanel } from "../../components/quality-metric";

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -1,10 +1,10 @@
 // node_modules
 import _ from "lodash";
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import AliasList from "../../components/alias-list";
 import AlternateAccessions from "../../components/alternate-accessions";
+import AnalysisSetFileTable from "../../components/analysis-set-file-table";
 import Attribution from "../../components/attribution";
 import Breadcrumbs from "../../components/breadcrumbs";
 import { ConstructLibraryTable } from "../../components/construct-library-table";
@@ -24,9 +24,9 @@ import DonorTable from "../../components/donor-table";
 import { EditableItem } from "../../components/edit";
 import { FileGraph } from "../../components/file-graph";
 import FileSetTable from "../../components/file-set-table";
-import AnalysisSetFileTable from "../../components/analysis-set-file-table";
 import InputFileSets from "../../components/input-file-sets";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";

--- a/pages/analysis-step-versions/[id].js
+++ b/pages/analysis-step-versions/[id].js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import Attribution from "../../components/attribution";
@@ -12,6 +11,7 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import { useSecDir } from "../../components/section-directory";

--- a/pages/analysis-steps/[id].js
+++ b/pages/analysis-steps/[id].js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 import { Fragment } from "react";
 // components
@@ -14,6 +13,7 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import { useSecDir } from "../../components/section-directory";

--- a/pages/auxiliary-sets/[id].js
+++ b/pages/auxiliary-sets/[id].js
@@ -1,6 +1,5 @@
 // node_modules
 import _ from "lodash";
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import AlternateAccessions from "../../components/alternate-accessions";
@@ -23,6 +22,7 @@ import FileSetFilesTables from "../../components/file-set-files-tables";
 import FileSetTable from "../../components/file-set-table";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";

--- a/pages/awards/[name].js
+++ b/pages/awards/[name].js
@@ -1,6 +1,5 @@
 // node_modules
 import PropTypes from "prop-types";
-import Link from "next/link";
 // components
 import Breadcrumbs from "../../components/breadcrumbs";
 import {
@@ -12,6 +11,7 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 // lib

--- a/pages/biomarkers/[id].js
+++ b/pages/biomarkers/[id].js
@@ -1,6 +1,5 @@
 // node_modules
 import PropTypes from "prop-types";
-import Link from "next/link";
 // components
 import AliasList from "../../components/alias-list";
 import Attribution from "../../components/attribution";
@@ -13,6 +12,7 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import { useSecDir } from "../../components/section-directory";

--- a/pages/cell-models/[view].tsx
+++ b/pages/cell-models/[view].tsx
@@ -1,6 +1,5 @@
 // node_modules
 import _ from "lodash";
-import Link from "next/link";
 import { useRouter } from "next/router";
 // components
 import Breadcrumbs from "../../components/breadcrumbs";
@@ -9,6 +8,7 @@ import DataGrid, {
   type DataGridFormat,
   type Row,
 } from "../../components/data-grid";
+import Link from "../../components/link-no-prefetch";
 import { LabelXAxis, LabelYAxis } from "../../components/matrix";
 import PagePreamble from "../../components/page-preamble";
 import { TabGroup, TabList, TabTitle } from "../../components/tabs";

--- a/pages/computational-tools.tsx
+++ b/pages/computational-tools.tsx
@@ -1,10 +1,10 @@
 // node_modules
 import _ from "lodash";
-import Link from "next/link";
 // components
 import { DataTable } from "../components/data-table";
 import { ButtonLink } from "../components/form-elements";
 import Icon from "../components/icon";
+import Link from "../components/link-no-prefetch";
 import PagePreamble from "../components/page-preamble";
 import SeparatedList from "../components/separated-list";
 // lib

--- a/pages/construct-library-sets/[id].js
+++ b/pages/construct-library-sets/[id].js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 import { Fragment } from "react";
 // components
@@ -20,6 +19,7 @@ import FileSetFilesTables from "../../components/file-set-files-tables";
 import FileSetTable from "../../components/file-set-table";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";
@@ -284,13 +284,16 @@ export default function ConstructLibrarySet({
                   <>
                     <DataItemLabel>Product ID</DataItemLabel>
                     <DataItemValue>
-                      <Link
+                      <a
                         href={`https://www.addgene.org/${
                           constructLibrarySet.product_id.split(":")[1]
                         }/`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title={`Addgene product page for ${constructLibrarySet.product_id}`}
                       >
                         {constructLibrarySet.product_id}
-                      </Link>
+                      </a>
                     </DataItemValue>
                   </>
                 )}

--- a/pages/crispr-modifications/[uuid].js
+++ b/pages/crispr-modifications/[uuid].js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import AliasList from "../../components/alias-list";
@@ -13,10 +12,11 @@ import {
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
-import ProductInfo from "../../components/product-info";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
+import ProductInfo from "../../components/product-info";
 import SampleTable from "../../components/sample-table";
 import { useSecDir } from "../../components/section-directory";
 import { StatusPreviewDetail } from "../../components/status";

--- a/pages/degron-modifications/[uuid].js
+++ b/pages/degron-modifications/[uuid].js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import AliasList from "../../components/alias-list";
@@ -13,10 +12,11 @@ import {
 } from "../../components/data-area";
 import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
-import ProductInfo from "../../components/product-info";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
+import ProductInfo from "../../components/product-info";
 import SampleTable from "../../components/sample-table";
 import { useSecDir } from "../../components/section-directory";
 import SeparatedList from "../../components/separated-list";

--- a/pages/genes/[id].js
+++ b/pages/genes/[id].js
@@ -1,9 +1,9 @@
 // node_modules
 import _ from "lodash";
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import Breadcrumbs from "../../components/breadcrumbs";
+import ChromosomeLocations from "../../components/chromosome-locations";
 import Collections from "../../components/collections";
 import {
   DataArea,
@@ -12,10 +12,10 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import DbxrefList from "../../components/dbxref-list";
-import ChromosomeLocations from "../../components/chromosome-locations";
 import { EditableItem } from "../../components/edit";
 import EnsemblLink from "../../components/ensemble-link";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import { StatusPreviewDetail } from "../../components/status";

--- a/pages/in-vitro-systems/[id].js
+++ b/pages/in-vitro-systems/[id].js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import AlternateAccessions from "../../components/alternate-accessions";
@@ -19,6 +18,7 @@ import { EditableItem } from "../../components/edit";
 import FileSetTable from "../../components/file-set-table";
 import { InstitutionalCertificateTable } from "../../components/institutional-certificate-table";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ModificationTable from "../../components/modification-table";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
 // components
@@ -7,6 +6,7 @@ import ChartFileSetLab from "../components/chart-file-set-lab";
 import { DataPanel } from "../components/data-area";
 import HomeTitle from "../components/home-title";
 import Icon from "../components/icon";
+import Link from "../components/link-no-prefetch";
 import { TabGroup, TabList, TabTitle } from "../components/tabs";
 // lib
 import { ServerCache } from "../lib/cache";

--- a/pages/institutional-certificates/[...id].tsx
+++ b/pages/institutional-certificates/[...id].tsx
@@ -1,6 +1,5 @@
 // node_modules
 import { GetServerSidePropsContext } from "next";
-import Link from "next/link";
 // components
 import Attribution from "../../components/attribution";
 import Breadcrumbs from "../../components/breadcrumbs";
@@ -15,6 +14,7 @@ import {
 import { DataUseLimitationStatus } from "../../components/data-use-limitation-status";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import SampleTable from "../../components/sample-table";
 import { useSecDir } from "../../components/section-directory";

--- a/pages/labs/[name].js
+++ b/pages/labs/[name].js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import Breadcrumbs from "../../components/breadcrumbs";
@@ -12,6 +11,7 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SeparatedList from "../../components/separated-list";

--- a/pages/measurement-sets/[id].js
+++ b/pages/measurement-sets/[id].js
@@ -1,7 +1,6 @@
 // node_modules
 import { QuestionMarkCircleIcon } from "@heroicons/react/20/solid";
 import _ from "lodash";
-import Link from "next/link";
 import PropTypes from "prop-types";
 import { Fragment } from "react";
 // components
@@ -29,6 +28,7 @@ import FileSetTable from "../../components/file-set-table";
 import FileSetFilesTables from "../../components/file-set-files-tables";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";

--- a/pages/model-sets/[id].js
+++ b/pages/model-sets/[id].js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import AlternateAccessions from "../../components/alternate-accessions";
@@ -21,6 +20,7 @@ import { EditableItem } from "../../components/edit";
 import FileSetTable from "../../components/file-set-table";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";

--- a/pages/multiplexed-samples/[uuid].js
+++ b/pages/multiplexed-samples/[uuid].js
@@ -1,6 +1,5 @@
 // node_modules
 import { Fragment } from "react";
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import AlternateAccessions from "../../components/alternate-accessions";
@@ -20,6 +19,7 @@ import { EditableItem } from "../../components/edit";
 import FileSetTable from "../../components/file-set-table";
 import { InstitutionalCertificateTable } from "../../components/institutional-certificate-table";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ModificationTable from "../../components/modification-table";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";

--- a/pages/phenotypic-features/[id].js
+++ b/pages/phenotypic-features/[id].js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import Attribution from "../../components/attribution";
@@ -12,6 +11,7 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import { useSecDir } from "../../components/section-directory";

--- a/pages/prediction-sets/[id].js
+++ b/pages/prediction-sets/[id].js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 import { Fragment } from "react";
 // components
@@ -23,6 +22,7 @@ import { FileGraph } from "../../components/file-graph";
 import FileSetTable from "../../components/file-set-table";
 import FileTable from "../../components/file-table";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";

--- a/pages/predictive-models.tsx
+++ b/pages/predictive-models.tsx
@@ -1,8 +1,8 @@
 // node_modules
 import _ from "lodash";
-import Link from "next/link";
 // components
 import { DataCellWithClasses, DataTable } from "../components/data-table";
+import Link from "../components/link-no-prefetch";
 import PagePreamble from "../components/page-preamble";
 import { CellLink } from "../components/static-table";
 // lib

--- a/pages/profiles/index.js
+++ b/pages/profiles/index.js
@@ -1,6 +1,5 @@
 // node_modules
 import { QuestionMarkCircleIcon } from "@heroicons/react/20/solid";
-import Link from "next/link";
 import router from "next/router";
 import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
@@ -16,6 +15,7 @@ import {
   FormLabel,
 } from "../../components/form-elements";
 import HelpTip from "../../components/help-tip";
+import Link from "../../components/link-no-prefetch";
 import PagePreamble from "../../components/page-preamble";
 import {
   SchemaSearchField,
@@ -249,11 +249,10 @@ function SubTree({
               className={`block scroll-mt-28 @xl:scroll-mt-24 ${
                 isTitleHighlighted ? "bg-schema-name-highlight" : ""
               }`}
-              prefetch={false}
             >
               {title}
             </Link>
-            <SchemaVersion schema={schema} prefetch={false} isLinked />
+            <SchemaVersion schema={schema} isLinked />
             <TooltipRef tooltipAttr={tooltipAttr}>
               <button>
                 <QuestionMarkCircleIcon className="h-4 w-4 cursor-pointer" />
@@ -262,25 +261,13 @@ function SubTree({
             <Tooltip tooltipAttr={tooltipAttr}>
               {schema.description || "No description available"}
             </Tooltip>
-            <SearchAndReportType
-              type={objectType}
-              title={title}
-              prefetch={false}
-            />
-            <AddLink
-              schema={schema}
-              label={`Add ${schema.title}`}
-              prefetch={false}
-            />
+            <SearchAndReportType type={objectType} title={title} />
+            <AddLink schema={schema} label={`Add ${schema.title}`} />
           </>
         ) : (
           <>
             {title}
-            <SearchAndReportType
-              type={objectType}
-              title={title}
-              prefetch={false}
-            />
+            <SearchAndReportType type={objectType} title={title} />
           </>
         )}
       </div>

--- a/pages/sequence-files/[...id].js
+++ b/pages/sequence-files/[...id].js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import AlternateAccessions from "../../components/alternate-accessions";
@@ -21,6 +20,7 @@ import { FileHeaderDownload } from "../../components/file-download";
 import FileTable from "../../components/file-table";
 import { HostedFilePreview } from "../../components/hosted-file-preview";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import { QualityMetricPanel } from "../../components/quality-metric";

--- a/pages/software-versions/[id].js
+++ b/pages/software-versions/[id].js
@@ -1,7 +1,7 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
+import AliasList from "../../components/alias-list";
 import Attribution from "../../components/attribution";
 import Breadcrumbs from "../../components/breadcrumbs";
 import {
@@ -14,16 +14,16 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import { useSecDir } from "../../components/section-directory";
 import { StatusPreviewDetail } from "../../components/status";
 // lib
+import buildAttribution from "../../lib/attribution";
 import { requestPublications } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import AliasList from "../../components/alias-list";
-import buildAttribution from "../../lib/attribution";
 import { isJsonFormat } from "../../lib/query-utils";
 
 export default function SoftwareVersion({

--- a/pages/software/[id].js
+++ b/pages/software/[id].js
@@ -1,7 +1,7 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
+import AliasList from "../../components/alias-list";
 import Attribution from "../../components/attribution";
 import Breadcrumbs from "../../components/breadcrumbs";
 import {
@@ -14,20 +14,20 @@ import {
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import { useSecDir } from "../../components/section-directory";
 import SoftwareVersionTable from "../../components/software-version-table";
 import { StatusPreviewDetail } from "../../components/status";
 // lib
+import buildAttribution from "../../lib/attribution";
 import {
   requestPublications,
   requestSoftwareVersions,
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import AliasList from "../../components/alias-list";
-import buildAttribution from "../../lib/attribution";
 import { isJsonFormat } from "../../lib/query-utils";
 
 export default function Software({

--- a/pages/technical-samples/[uuid].js
+++ b/pages/technical-samples/[uuid].js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import AlternateAccessions from "../../components/alternate-accessions";
@@ -17,6 +16,7 @@ import { EditableItem } from "../../components/edit";
 import FileSetTable from "../../components/file-set-table";
 import { InstitutionalCertificateTable } from "../../components/institutional-certificate-table";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import SampleTable from "../../components/sample-table";

--- a/pages/tissue-summary/[taxa].tsx
+++ b/pages/tissue-summary/[taxa].tsx
@@ -1,6 +1,5 @@
 // node_modules
 import _ from "lodash";
-import Link from "next/link";
 import { useRouter } from "next/router";
 // components
 import Breadcrumbs from "../../components/breadcrumbs";
@@ -9,6 +8,7 @@ import DataGrid, {
   type DataGridFormat,
   type Row,
 } from "../../components/data-grid";
+import Link from "../../components/link-no-prefetch";
 import { LabelXAxis, LabelYAxis } from "../../components/matrix";
 import NoCollectionData from "../../components/no-collection-data";
 import PagePreamble from "../../components/page-preamble";

--- a/pages/tissues/[uuid].js
+++ b/pages/tissues/[uuid].js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import AlternateAccessions from "../../components/alternate-accessions";
@@ -119,11 +118,13 @@ export default function Tissue({
                     <DataItemLabel>
                       Common Coordinate Framework Identifier
                     </DataItemLabel>
-                    <Link
+                    <a
                       href={`https://portal.hubmapconsortium.org/browse/sample/${tissue.ccf_id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
                     >
                       {tissue.ccf_id}
-                    </Link>
+                    </a>
                   </>
                 )}
               </BiosampleDataItems>

--- a/pages/users/[uuid].js
+++ b/pages/users/[uuid].js
@@ -1,5 +1,4 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
 import Breadcrumbs from "../../components/breadcrumbs";
@@ -10,6 +9,7 @@ import {
   DataPanel,
 } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
+import Link from "../../components/link-no-prefetch";
 import NoContent from "../../components/no-content";
 import JsonDisplay from "../../components/json-display";
 import ObjectPageHeader from "../../components/object-page-header";

--- a/pages/workflows/[id].js
+++ b/pages/workflows/[id].js
@@ -1,11 +1,12 @@
 // node_modules
-import Link from "next/link";
 import PropTypes from "prop-types";
 // components
+import AliasList from "../../components/alias-list";
 import AlternateAccessions from "../../components/alternate-accessions";
 import AnalysisStepTable from "../../components/analysis-step-table";
 import Attribution from "../../components/attribution";
 import Breadcrumbs from "../../components/breadcrumbs";
+import { UniformlyProcessedBadge } from "../../components/common-pill-badges";
 import {
   DataArea,
   DataItemLabel,
@@ -17,12 +18,13 @@ import {
 import DocumentTable from "../../components/document-table";
 import { EditableItem } from "../../components/edit";
 import JsonDisplay from "../../components/json-display";
+import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
 import { useSecDir } from "../../components/section-directory";
 import { StatusPreviewDetail } from "../../components/status";
-import { UniformlyProcessedBadge } from "../../components/common-pill-badges";
 // lib
+import buildAttribution from "../../lib/attribution";
 import {
   requestAnalysisSteps,
   requestDocuments,
@@ -30,8 +32,6 @@ import {
 } from "../../lib/common-requests";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import AliasList from "../../components/alias-list";
-import buildAttribution from "../../lib/attribution";
 import { isJsonFormat } from "../../lib/query-utils";
 
 export default function Workflow({


### PR DESCRIPTION
This is a scary number of changed files, but the vast majority just change the `Link` import from the `next/link` version to my own version in the `components` directory. A couple cases did their own prefetch before this ticket, and I removed that mechanism here because of the site-wide mechanism.