### PR TITLE
IGVF-2322 Upgrade to Tailwind CSS v4

### DIFF
--- a/components/__tests__/dropdown.test.js
+++ b/components/__tests__/dropdown.test.js
@@ -15,7 +15,7 @@ describe("Test dropdown components", () => {
         <div>
           <div>
             <DropdownRef dropdownAttr={dropdownAttr}>
-              <button className="h-6 rounded border border-button-primary bg-button-primary px-2 text-xs text-button-primary">
+              <button className="h-6 rounded-sm border border-button-primary bg-button-primary px-2 text-xs text-button-primary">
                 Selector
               </button>
             </DropdownRef>
@@ -112,7 +112,7 @@ describe("Test error conditions in the dropdown components", () => {
         <div>
           <div>
             <DropdownRef dropdownAttr={dropdownAttr}>
-              <button className="h-6 rounded border border-button-primary bg-button-primary px-2 text-xs text-button-primary">
+              <button className="h-6 rounded-sm border border-button-primary bg-button-primary px-2 text-xs text-button-primary">
                 Selector
               </button>
             </DropdownRef>

--- a/components/audit.js
+++ b/components/audit.js
@@ -183,7 +183,7 @@ function AuditNarrative({ level, category, detail }) {
         level
       )}-${toShishkebabCase(category)}`}
     >
-      <MarkdownSection className="ml-5 prose-p:text-sm">
+      <MarkdownSection className="prose-p:text-sm ml-5">
         {detail}
       </MarkdownSection>
     </div>
@@ -211,7 +211,7 @@ function AuditCategory({ level, category, categoryAudits, children }) {
   return (
     <li>
       <button
-        className="flex items-center gap-1 text-sm font-semibold"
+        className="flex cursor-pointer items-center gap-1 text-sm font-semibold"
         onClick={() => setOpenedCategories(!isCategoryOpen)}
         aria-label={`${
           isCategoryOpen ? "Close" : "Open"
@@ -272,11 +272,11 @@ function AuditLevel({ level, levelAudits, children }) {
 
   return (
     <li
-      className={`my-0.5 rounded border border-data-border`}
+      className={`border-data-border my-0.5 rounded-sm border`}
       data-testid={`audit-level-${toShishkebabCase(level)}`}
     >
       <h2
-        className={`flex items-center gap-1 rounded-t-sm border-b border-data-border px-1 py-0.5 text-sm font-semibold ${background}`}
+        className={`border-data-border flex items-center gap-1 rounded-t-sm border-b px-1 py-0.5 text-sm font-semibold ${background}`}
       >
         <Icon className={`h-4 w-4 ${color}`} />
         {humanReadable}
@@ -390,7 +390,7 @@ export function AuditStatus({ item, auditState }) {
     return (
       <button
         onClick={auditState.toggleDetailsOpen}
-        className={`flex h-[22px] shrink items-center rounded-full border border-audit px-1 ${
+        className={`border-audit flex h-[22px] shrink cursor-pointer items-center rounded-full border px-1 ${
           auditState.isDetailOpen
             ? "bg-button-audit-open"
             : "bg-button-audit-closed"

--- a/components/checkfiles-version.tsx
+++ b/components/checkfiles-version.tsx
@@ -14,7 +14,7 @@ export function CheckfilesVersion({ file }: { file: FileObject }) {
     return (
       <a
         href={`https://github.com/IGVF-DACC/checkfiles/releases/tag/${file.checkfiles_version}`}
-        className={`${className} rounded-sm no-underline`}
+        className={`${className} rounded-xs no-underline`}
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -34,7 +34,7 @@ export function CheckfilesVersion({ file }: { file: FileObject }) {
     return (
       <a
         href="https://github.com/IGVF-DACC/checkfiles/tags"
-        className={`${className} rounded-sm no-underline`}
+        className={`${className} rounded-xs no-underline`}
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/components/collapse-control.js
+++ b/components/collapse-control.js
@@ -101,7 +101,7 @@ export function CollapseControlInline({ length, isCollapsed, setIsCollapsed }) {
   return (
     <button
       onClick={() => setIsCollapsed(!isCollapsed)}
-      className="ml-1 inline items-center rounded-sm border border-collapse-ctrl bg-collapse-ctrl pl-1.5 pr-1 text-xs font-bold text-collapse-ctrl"
+      className="ml-1 inline items-center rounded-xs border border-collapse-ctrl bg-collapse-ctrl pl-1.5 pr-1 text-xs font-bold text-collapse-ctrl"
       data-testid="collapse-control-inline"
       aria-label={label}
     >
@@ -143,7 +143,7 @@ export function CollapseControlVertical({
     ? `Show all ${length} items in list`
     : `Show fewer items in list`;
   const borderClass = isFullBorder
-    ? "border rounded-sm"
+    ? "border rounded-xs"
     : "border-b border-l border-r rounded-b-sm";
 
   return (

--- a/components/copy-button.js
+++ b/components/copy-button.js
@@ -83,7 +83,13 @@ CopyButton.propTypes = {
  * Supply a function as the child of this button that takes an argument that gets set to true for
  * two seconds after the user clicks the copy button.
  */
-function Icon({ target, label, size = "md", className = "", children }) {
+function Icon({
+  target,
+  label,
+  size = "md",
+  className = "cursor-pointer",
+  children,
+}) {
   const { isCopied, initiateCopy } = useCopyAction(target);
 
   return (

--- a/components/data-grid.tsx
+++ b/components/data-grid.tsx
@@ -114,7 +114,7 @@ export const DataGridContainer = forwardRef(function DataGridContainer(
     <div
       ref={ref}
       role={role}
-      className={`border-1 grid w-full gap-px overflow-x-auto border border-panel bg-gray-300 text-sm dark:outline-gray-700 dark:bg-gray-700${
+      className={`border grid w-full gap-px overflow-x-auto border border-panel bg-gray-300 text-sm dark:outline-gray-700 dark:bg-gray-700${
         className ? ` ${className}` : ""
       }`}
     >

--- a/components/data-table.tsx
+++ b/components/data-table.tsx
@@ -43,7 +43,7 @@ function DefaultHeaderCell({
 }) {
   return (
     <th
-      className="sticky top-0 z-[2] border-b border-r border-panel bg-table-header-cell p-2 text-left align-bottom last:border-r-0"
+      className="sticky top-0 z-2 border-b border-r border-panel bg-table-header-cell p-2 text-left align-bottom last:border-r-0"
       {...(rowSpan > 1 ? { rowSpan } : {})}
       {...(colSpan > 1 ? { colSpan } : {})}
     >
@@ -107,7 +107,7 @@ function SingleRow({
   isHeaderSegment: boolean;
 }) {
   return (
-    <tr className="[&>td]:last:border-b-0 last:[&>td]:border-r-0">
+    <tr className="last:[&>td]:border-b-0 [&>td]:last:border-r-0">
       {cells.map((cell) => {
         const DefaultCellWrapper =
           isHeaderSegment || cell.isHeaderCell

--- a/components/dropdown.js
+++ b/components/dropdown.js
@@ -174,7 +174,7 @@ export function Dropdown({ dropdownAttr, className = null, children }) {
             data-testid={dropdownAttr.id}
             aria-labelledby={`${dropdownAttr.id}-ref`}
             className={
-              className || "rounded border border-panel bg-panel shadow-lg"
+              className || "rounded-sm border border-panel bg-panel shadow-lg"
             }
             ref={dropdownAttr.dropdownEl}
             style={dropdownAttr.styles}

--- a/components/facets/custom-facets/date-range-terms.tsx
+++ b/components/facets/custom-facets/date-range-terms.tsx
@@ -186,7 +186,7 @@ export default function DateRangeTerms({
       <>
         <div className="flex flex-col justify-center gap-1 p-2">
           <button
-            className="flex w-full rounded border border-button-secondary bg-button-secondary fill-button-secondary px-2 py-1 text-button-secondary"
+            className="flex w-full rounded-sm border border-button-secondary bg-button-secondary fill-button-secondary px-2 py-1 text-button-secondary"
             onClick={onDateRangeTrigger}
             data-testid={`date-range-trigger-${facet.field}`}
             aria-label={`${facet.title} range from ${humanReadableStartDate} to ${humanReadableEndDate}`}

--- a/components/facets/custom-facets/standard-term-label.js
+++ b/components/facets/custom-facets/standard-term-label.js
@@ -8,7 +8,7 @@ import PropTypes from "prop-types";
 export default function StandardTermLabel({ term, isNegative, isChildTerm }) {
   return (
     <div
-      className={`flex grow items-center justify-between gap-2 leading-[1.1] [&>div:first-child]:break-anywhere ${
+      className={`flex grow items-center justify-between gap-2 leading-[1.1] [&>div:first-child]:wrap-anywhere ${
         isChildTerm ? "text-xs font-light" : "text-sm font-normal"
       }`}
     >

--- a/components/facets/custom-facets/standard-terms.js
+++ b/components/facets/custom-facets/standard-terms.js
@@ -33,7 +33,7 @@ function TermsSelectorsButton({ onClick, label, children }) {
   return (
     <button
       onClick={onClick}
-      className="h-5 grow rounded border border-button-secondary bg-button-secondary fill-button-secondary text-xs text-button-secondary"
+      className="h-5 grow rounded-sm border border-button-secondary bg-button-secondary fill-button-secondary text-xs text-button-secondary"
       aria-label={label}
       type="button"
     >

--- a/components/facets/custom-facets/tri-boolean-terms.tsx
+++ b/components/facets/custom-facets/tri-boolean-terms.tsx
@@ -104,13 +104,13 @@ export default function TriBooleanTerms({
       {terms.map((term) => (
         <Field
           key={term.key}
-          className="flex cursor-pointer items-center gap-2 rounded border border-transparent px-2 hover:border-data-border"
+          className="flex cursor-pointer items-center gap-2 rounded-sm border border-transparent px-2 hover:border-data-border"
         >
           <Radio
             value={term.key}
-            className="group flex size-4 items-center justify-center rounded-full border bg-white data-[checked]:bg-gray-500"
+            className="group flex size-4 items-center justify-center rounded-full border bg-white data-checked:bg-gray-500"
           >
-            <span className="invisible size-1.5 rounded-full bg-white group-data-[checked]:visible" />
+            <span className="invisible size-1.5 rounded-full bg-white group-data-checked:visible" />
           </Radio>
           <Label
             className="flex w-full cursor-pointer justify-between text-sm"

--- a/components/facets/facet-section.js
+++ b/components/facets/facet-section.js
@@ -28,7 +28,7 @@ function ClearAll({ searchResults }) {
   const isDisabled = uniqueSelectedFields.length === 0;
   return (
     <button
-      className="h-5 w-full grow rounded border border-button-secondary bg-button-secondary fill-button-secondary text-xs text-button-secondary disabled:border-button-secondary-disabled disabled:text-button-secondary-disabled"
+      className="h-5 w-full grow rounded-sm border border-button-secondary bg-button-secondary fill-button-secondary text-xs text-button-secondary disabled:border-button-secondary-disabled disabled:text-button-secondary-disabled"
       aria-label="Clear all filters"
       onClick={onClearAll}
       disabled={isDisabled}

--- a/components/facets/facet-tags.js
+++ b/components/facets/facet-tags.js
@@ -46,7 +46,7 @@ function FacetTag({ filter, facets }) {
   return (
     <Link
       href={filter.remove}
-      className={`flex items-center rounded border py-0.5 pl-1 pr-0 text-facet-tag no-underline ${tagClassName}`}
+      className={`flex items-center rounded-sm border py-0.5 pl-1 pr-0 text-facet-tag no-underline ${tagClassName}`}
       aria-label={`Clear ${title} filter for ${filter.term}`}
       key={filter.field}
     >

--- a/components/facets/facet.js
+++ b/components/facets/facet.js
@@ -19,12 +19,12 @@ export default function Facet({
   return (
     <div
       key={facet.field}
-      className="border-t border-panel"
+      className="border-panel border-t"
       data-testid={`facet-container-${facet.field}`}
     >
       <button
         onClick={updateOpen}
-        className={`w-full px-4 pb-2 pt-2 ${
+        className={`w-full cursor-pointer px-4 pt-2 pb-2 ${
           isFacetOpen ? "bg-gray-600 dark:bg-gray-400" : ""
         }`}
         data-testid={`facettrigger-${facet.field}`}

--- a/components/form-elements/__tests__/button.test.js
+++ b/components/form-elements/__tests__/button.test.js
@@ -167,7 +167,7 @@ describe("Test the Tailwind CSS classes resulting from using the `hasIconOnly` f
         <Circle />
       </Button>
     );
-    expect(container.firstChild).toHaveClass("px-2 rounded");
+    expect(container.firstChild).toHaveClass("px-2 rounded-sm");
   });
 
   it("renders an icon-only link button with the correct classes", () => {
@@ -176,7 +176,7 @@ describe("Test the Tailwind CSS classes resulting from using the `hasIconOnly` f
         <Circle />
       </ButtonLink>
     );
-    expect(container.firstChild).toHaveClass("px-2 rounded");
+    expect(container.firstChild).toHaveClass("px-2 rounded-sm");
   });
 });
 
@@ -194,13 +194,13 @@ describe("Test AttachedButtons wrapper component", () => {
     const buttons = screen.getAllByRole("button");
     expect(buttons.length).toBe(3);
     expect(buttons[0]).toHaveClass(
-      "border-r-0 last:border-r rounded-none first:rounded-l last:rounded-r"
+      "flex items-center justify-center border font-semibold leading-none px-4 rounded-sm text-sm h-8 [&>svg]:h-4 [&>svg]:w-4 bg-button-primary border-button-primary text-button-primary fill-button-primary disabled:bg-button-primary-disabled disabled:border-button-primary-disabled disabled:text-button-primary-disabled disabled:fill-button-primary-disabled border-r-0 last:border-r !rounded-none first:!rounded-l-sm last:!rounded-r-sm"
     );
     expect(buttons[1]).toHaveClass(
-      "border-r-0 last:border-r rounded-none first:rounded-l last:rounded-r"
+      "flex items-center justify-center border font-semibold leading-none px-4 rounded-sm text-sm h-8 [&>svg]:h-4 [&>svg]:w-4 bg-button-primary border-button-primary text-button-primary fill-button-primary disabled:bg-button-primary-disabled disabled:border-button-primary-disabled disabled:text-button-primary-disabled disabled:fill-button-primary-disabled border-r-0 last:border-r !rounded-none first:!rounded-l-sm last:!rounded-r-sm"
     );
     expect(buttons[2]).toHaveClass(
-      "border-r-0 last:border-r rounded-none first:rounded-l last:rounded-r"
+      "flex items-center justify-center border font-semibold leading-none px-4 rounded-sm text-sm h-8 [&>svg]:h-4 [&>svg]:w-4 bg-button-primary border-button-primary text-button-primary fill-button-primary disabled:bg-button-primary-disabled disabled:border-button-primary-disabled disabled:text-button-primary-disabled disabled:fill-button-primary-disabled border-r-0 last:border-r !rounded-none first:!rounded-l-sm last:!rounded-r-sm"
     );
   });
 

--- a/components/form-elements/__tests__/select.test.js
+++ b/components/form-elements/__tests__/select.test.js
@@ -20,7 +20,7 @@ describe("Test the Select component", () => {
     const select = screen.getByRole("combobox");
     expect(select).toBeInTheDocument();
     expect(select).toHaveClass(
-      "block w-full appearance-none rounded border border-form-element bg-form-element py-0 pl-1 pr-5 font-medium text-form-element disabled:border-form-element-disabled disabled:text-form-element-disabled text-sm h-8 leading-[180%]"
+      "block w-full appearance-none rounded-sm border border-form-element bg-form-element py-0 pl-1 pr-5 font-medium text-form-element disabled:border-form-element-disabled disabled:text-form-element-disabled text-sm h-8 leading-[180%]"
     );
 
     // Selecting an option should call the onChange handler.

--- a/components/form-elements/button.js
+++ b/components/form-elements/button.js
@@ -242,7 +242,7 @@ export function AttachedButtons({ testid = null, className = "", children }) {
       return React.cloneElement(child, {
         className: `${
           child.props.className || ""
-        } border-r-0 last:border-r rounded-none first:rounded-l last:rounded-r`,
+        } border-r-0 last:border-r !rounded-none first:!rounded-l-sm last:!rounded-r-sm`,
       });
     }
     return child;

--- a/components/form-elements/list-select.js
+++ b/components/form-elements/list-select.js
@@ -190,7 +190,7 @@ function Option({
   children,
 }) {
   const selectedButtonStyle = selected ? "bg-slate-200 dark:bg-slate-800" : "";
-  const roundedCheckStyle = isMultiple ? "rounded-sm" : "rounded-full";
+  const roundedCheckStyle = isMultiple ? "rounded-xs" : "rounded-full";
   const selectedCheckStyle = selected
     ? "bg-slate-500"
     : "border border-form-element";
@@ -199,7 +199,7 @@ function Option({
     <button
       id={id}
       onClick={() => onClick(id)}
-      className={`my-0.5 flex w-full items-center rounded p-1 px-2 ${selectedButtonStyle}`}
+      className={`my-0.5 flex w-full items-center rounded-sm p-1 px-2 ${selectedButtonStyle}`}
       aria-label={`${parentLabel ? `${parentLabel} ` : ""}${label}${
         selected ? " selected" : ""
       } list item`}

--- a/components/form-elements/select.js
+++ b/components/form-elements/select.js
@@ -45,7 +45,7 @@ export default function Select({
       )}
       <div className="relative">
         <select
-          className={`block w-full appearance-none rounded border border-form-element bg-form-element py-0 pl-1 pr-5 font-medium text-form-element disabled:border-form-element-disabled disabled:text-form-element-disabled ${selectSizeClasses[size]}`}
+          className={`block w-full appearance-none rounded-sm border border-form-element bg-form-element py-0 pl-1 pr-5 font-medium text-form-element disabled:border-form-element-disabled disabled:text-form-element-disabled ${selectSizeClasses[size]}`}
           id={name}
           name={name}
           value={value}

--- a/components/form-elements/text-field.js
+++ b/components/form-elements/text-field.js
@@ -55,7 +55,7 @@ export default function TextField({
         </FormLabel>
       )}
       <input
-        className={`block w-full rounded border border-form-element bg-form-element text-form-element disabled:border-form-element-disabled disabled:text-form-element-disabled ${sizeClasses[size]}`}
+        className={`block w-full rounded-sm border border-form-element bg-form-element text-form-element disabled:border-form-element-disabled disabled:text-form-element-disabled ${sizeClasses[size]}`}
         aria-label={fieldLabel || label}
         name={name}
         id={name}

--- a/components/id-search-trigger.js
+++ b/components/id-search-trigger.js
@@ -103,7 +103,7 @@ export default function IdSearchTrigger() {
         <div>
           <button
             onClick={onTriggerClick}
-            className="grow-0 rounded"
+            className="grow-0 rounded-sm"
             data-testid="id-search-trigger"
             title={`Go to an item${UC.rsquo}s page from its identifier (${UC.cmd}${UC.shift}K or ${UC.ctrl}${UC.shift}K)`}
           >

--- a/components/modal.js
+++ b/components/modal.js
@@ -48,7 +48,7 @@ export default function Modal({
       />
       <div className="fixed inset-0 overflow-y-auto">
         <Dialog.Panel
-          className={`mx-auto my-5 max-w-4xl overflow-hidden rounded-xl border border-modal-border bg-white drop-shadow-lg dark:bg-gray-900 xl:my-20 ${widthClasses}`}
+          className={`border-modal-border mx-auto my-5 max-w-4xl overflow-hidden rounded-xl border bg-white drop-shadow-lg xl:my-20 dark:bg-gray-900 ${widthClasses}`}
         >
           {children}
         </Dialog.Panel>
@@ -96,7 +96,7 @@ function Header({
 
   return (
     <div
-      className={`flex items-center justify-between border-b border-modal-border p-2 ${className}`}
+      className={`border-modal-border flex items-center justify-between border-b p-2 ${className}`}
     >
       {headerChildren}
       {onClose ? <CloseButton label={closeLabel} onClick={onClose} /> : null}
@@ -117,7 +117,7 @@ Header.propTypes = {
  * Wraps the contents of a modal to provide a standard padding. You can skip using this if you
  * don't want padding, or non-standard padding.
  */
-function Body({ className = null, children }) {
+function Body({ className = "", children }) {
   return (
     <div className={className}>
       <div className="p-2">{children}</div>
@@ -135,7 +135,7 @@ Body.propTypes = {
  */
 function Footer({ children }) {
   return (
-    <div className="flex justify-end gap-1 border-t border-modal-border bg-gray-50 p-1.5 dark:bg-gray-800">
+    <div className="border-modal-border flex justify-end gap-1 border-t bg-gray-50 p-1.5 dark:bg-gray-800">
       {children}
     </div>
   );

--- a/components/navigation.js
+++ b/components/navigation.js
@@ -50,7 +50,7 @@ function NavExpandIcon({ className = null, testid = "icon-nav-expand" }) {
       stroke="currentColor"
       data-testid={testid}
     >
-      <g className="fill-none stroke-nav-collapse stroke-1">
+      <g className="stroke-nav-collapse fill-none stroke-1">
         <path
           d="M13.1,15.5H6.9c-1.3,0-2.4-1.1-2.4-2.4V6.9c0-1.3,1.1-2.4,2.4-2.4h6.2c1.3,0,2.4,1.1,2.4,2.4v6.2
 	C15.5,14.4,14.4,15.5,13.1,15.5z"
@@ -81,7 +81,7 @@ function NavCollapseIcon({ className = null, testid = "icon-nav-collapse" }) {
       stroke="currentColor"
       data-testid={testid}
     >
-      <g className="fill-none stroke-nav-collapse stroke-1">
+      <g className="stroke-nav-collapse fill-none stroke-1">
         <path
           d="M13.1,15.5H6.9c-1.3,0-2.4-1.1-2.4-2.4V6.9c0-1.3,1.1-2.4,2.4-2.4h6.2c1.3,0,2.4,1.1,2.4,2.4v6.2
 	C15.5,14.4,14.4,15.5,13.1,15.5z"
@@ -167,7 +167,7 @@ function navigationClasses(isNarrowNav, isChildItem) {
   const childClasses = isChildItem
     ? "text-sm font-normal"
     : "text-base font-medium";
-  return `flex w-full items-center rounded-full border border-transparent px-2 py-1 text-left text-white no-underline hover:bg-nav-highlight disabled:text-gray-500 md:text-black md:hover:border md:hover:border-nav-border md:hover:bg-nav-highlight md:dark:text-gray-200 ${childClasses}`;
+  return `cursor-pointer flex w-full items-center rounded-full border border-transparent px-2 py-1 text-left text-white no-underline hover:bg-nav-highlight disabled:text-gray-500 md:text-black md:hover:border md:hover:border-nav-border md:hover:bg-nav-highlight md:dark:text-gray-200 ${childClasses}`;
 }
 
 /**
@@ -857,7 +857,7 @@ function NavigationCollapsed({ navigationClick, toggleNavCollapsed }) {
   const { isAuthenticated } = useAuth0();
 
   return (
-    <NavigationList className="w-full [&>ul>li]:my-2 [&>ul]:flex [&>ul]:flex-col [&>ul]:items-center">
+    <NavigationList className="w-full [&>ul]:flex [&>ul]:flex-col [&>ul]:items-center [&>ul>li]:my-2">
       <NavigationCollapseItem
         toggleNavCollapsed={toggleNavCollapsed}
         isNavCollapsed

--- a/components/page-component/chevron-navigation.js
+++ b/components/page-component/chevron-navigation.js
@@ -44,7 +44,7 @@ export default function ChevronNavigation(items) {
   if (itemTitles.length > 0) {
     return (
       <nav data-testid="chevron-navigation">
-        <ul className="flex flex-wrap gap-1 overflow-hidden px-4 @container/chevronMenu">
+        <ul className="flex flex-wrap gap-1 overflow-hidden px-4 @container/chevron-menu">
           {itemTitles.map((itemTitle, index) => {
             // Get the link and color for the title, separated by a pipe character
             const [href, color] = items[itemTitle].split("|");

--- a/components/profiles.js
+++ b/components/profiles.js
@@ -117,7 +117,7 @@ export function SchemaVersion({ schema, isLinked = false }) {
     return (
       <Link
         href={`${path}/changelog`}
-        className={`${className} rounded-sm`}
+        className={`${className} rounded-xs`}
       >{`v${version}`}</Link>
     );
   }

--- a/components/report/column-selector.js
+++ b/components/report/column-selector.js
@@ -20,7 +20,7 @@ import {
  * Displays the buttons to hide or show all columns at once.
  */
 function ChangeAllControls({ onChangeAll }) {
-  const className = "flex-grow md:flex-grow-0";
+  const className = "grow md:grow-0";
   return (
     <div className="flex gap-1">
       <Button className={className} onClick={() => onChangeAll(true)}>
@@ -145,7 +145,7 @@ ColumnCheckboxes.propTypes = {
 function Note({ className = "", children }) {
   return (
     <div
-      className={`text-center text-sm text-gray-500 dark:text-gray-300 md:flex-grow md:text-left ${className}`}
+      className={`text-center text-sm text-gray-500 dark:text-gray-300 md:grow md:text-left ${className}`}
     >
       {children}
     </div>

--- a/components/search-modal.js
+++ b/components/search-modal.js
@@ -128,7 +128,7 @@ export default function SearchModal({
               value={searchTerm}
               onChange={onChange}
               onKeyDown={onKeyDown}
-              className="block w-full border-none bg-transparent py-3 text-black outline-none dark:text-white"
+              className="block w-full border-none bg-transparent py-3 text-black outline-hidden dark:text-white"
               data-autofocus
             />
             <button

--- a/components/search/list-renderer/image.js
+++ b/components/search/list-renderer/image.js
@@ -39,7 +39,7 @@ export default function ImageItem({ item, accessoryData = null }) {
           {image?.uuid || item["@id"]}
         </SearchListItemUniqueId>
         <SearchListItemTitle>
-          <div className="break-anywhere">
+          <div className="wrap-anywhere">
             {attachment?.download || item["@id"]}
           </div>
         </SearchListItemTitle>
@@ -61,11 +61,11 @@ export default function ImageItem({ item, accessoryData = null }) {
             <SearchListItemSupplementContent>
               <div className="max-h-40 w-full max-w-sm">
                 <div className="relative h-full w-full">
-                  <div className="inline-block border border-data-border bg-white">
+                  <div className="border-data-border inline-block border bg-white">
                     <img
                       src={imageUrl}
                       alt={`Preview image of ${image.summary}`}
-                      className="h-auto max-h-40 w-full object-contain object-left-top"
+                      className="h-auto max-h-40 w-full object-contain object-top-left"
                     />
                   </div>
                 </div>

--- a/components/section-directory.tsx
+++ b/components/section-directory.tsx
@@ -246,7 +246,7 @@ export function SecDir({ sections }: { sections: SectionList }) {
           <>
             <TooltipRef tooltipAttr={tooltipAttr}>
               <MenuButton
-                className="flex justify-center rounded-t-sm bg-menu-trigger p-1 data-[hover]:bg-menu-trigger-hover data-[open]:bg-menu-trigger-open"
+                className="bg-menu-trigger data-hover:bg-menu-trigger-hover data-open:bg-menu-trigger-open flex cursor-pointer justify-center rounded-t-sm p-1"
                 aria-label="Open section directory menu"
                 aria-expanded={open}
                 onPointerEnter={onPointerEnter}
@@ -257,7 +257,7 @@ export function SecDir({ sections }: { sections: SectionList }) {
             </TooltipRef>
             <MenuItems
               anchor="bottom end"
-              className="z-20 rounded-b-lg border border-menu-items bg-menu-items shadow-lg"
+              className="border-menu-items bg-menu-items z-20 rounded-b-lg border shadow-lg"
               onPointerEnter={onPointerEnter}
               onPointerLeave={() => onPointerLeave(close)}
             >
@@ -266,7 +266,7 @@ export function SecDir({ sections }: { sections: SectionList }) {
                   <a
                     href={`#${section.id}`}
                     onClick={(e) => onItemClick(e, close)}
-                    className="block px-4 py-0.5 text-sm font-medium text-menu-item no-underline hover:bg-menu-item-hover hover:text-menu-item-hover data-[focus]:bg-menu-item-hover data-[focus]:text-menu-item-hover"
+                    className="text-menu-item hover:bg-menu-item-hover hover:text-menu-item-hover data-focus:bg-menu-item-hover data-focus:text-menu-item-hover block px-4 py-0.5 text-sm font-medium no-underline"
                   >
                     {ItemRenderer ? (
                       <ItemRenderer

--- a/components/site-search-trigger.js
+++ b/components/site-search-trigger.js
@@ -17,7 +17,7 @@ function SearchTriggerExpanded({ onClick }) {
   return (
     <button
       onClick={onClick}
-      className="flex h-8 w-full grow items-center gap-2 rounded border border-panel bg-form-element p-2 text-form-element"
+      className="flex h-8 w-full grow items-center gap-2 rounded-sm border border-panel bg-form-element p-2 text-form-element"
       data-testid="site-search-trigger-expanded"
       label="Search the site for a word or phrase"
     >

--- a/components/tooltip.js
+++ b/components/tooltip.js
@@ -135,7 +135,7 @@ export function Tooltip({ tooltipAttr, children }) {
       {tooltipAttr.isVisible &&
         createPortal(
           <div
-            className="z-[100] max-w-[90%] rounded-md border border-gray-500 bg-gray-800 px-2 py-1 text-xs text-white drop-shadow-md dark:border-white dark:bg-gray-300 dark:text-black md:max-w-[40%] 2xl:max-w-[20%]"
+            className="z-100 max-w-[90%] rounded-md border border-gray-500 bg-gray-800 px-2 py-1 text-xs text-white drop-shadow-md dark:border-white dark:bg-gray-300 dark:text-black md:max-w-[40%] 2xl:max-w-[20%]"
             ref={tooltipAttr.tooltipEl}
             style={tooltipAttr.styles}
             role="tooltip"

--- a/components/vertical-scroll-indicators.js
+++ b/components/vertical-scroll-indicators.js
@@ -20,7 +20,7 @@ function ScrollIndicator({ className = "", children }) {
           props: {
             ...child.props,
             className:
-              "h-8 w-8 text-white rounded-full bg-brand opacity-70 hover:opacity-100 focus:opacity-100 focus:outline-none",
+              "h-8 w-8 text-white rounded-full bg-brand opacity-70 hover:opacity-100 focus:opacity-100 focus:outline-hidden",
           },
         }
       : child;

--- a/lib/__tests__/form-elements.test.ts
+++ b/lib/__tests__/form-elements.test.ts
@@ -4,28 +4,28 @@ describe("Test generateButtonClasses", () => {
   it("should return the correct classes for primary button with default size", () => {
     const result = generateButtonClasses();
     expect(result).toBe(
-      "items-center justify-center border font-semibold leading-none px-4 rounded text-sm h-8 [&>svg]:h-4 [&>svg]:w-4 bg-button-primary border-button-primary text-button-primary fill-button-primary disabled:bg-button-primary-disabled disabled:border-button-primary-disabled disabled:text-button-primary-disabled disabled:fill-button-primary-disabled"
+      "items-center justify-center border font-semibold leading-none px-4 rounded-sm text-sm h-8 [&>svg]:h-4 [&>svg]:w-4 bg-button-primary border-button-primary text-button-primary fill-button-primary disabled:bg-button-primary-disabled disabled:border-button-primary-disabled disabled:text-button-primary-disabled disabled:fill-button-primary-disabled"
     );
   });
 
   it("should return the correct classes for secondary button with default size", () => {
     const result = generateButtonClasses("secondary");
     expect(result).toBe(
-      "items-center justify-center border font-semibold leading-none px-4 rounded text-sm h-8 [&>svg]:h-4 [&>svg]:w-4 bg-button-secondary border-button-secondary text-button-secondary fill-button-secondary disabled:bg-button-secondary-disabled disabled:border-button-secondary-disabled disabled:text-button-secondary-disabled disabled:fill-button-secondary-disabled"
+      "items-center justify-center border font-semibold leading-none px-4 rounded-sm text-sm h-8 [&>svg]:h-4 [&>svg]:w-4 bg-button-secondary border-button-secondary text-button-secondary fill-button-secondary disabled:bg-button-secondary-disabled disabled:border-button-secondary-disabled disabled:text-button-secondary-disabled disabled:fill-button-secondary-disabled"
     );
   });
 
   it("should return the correct classes for primary button with size 'lg'", () => {
     const result = generateButtonClasses("primary", "lg");
     expect(result).toBe(
-      "items-center justify-center border font-semibold leading-none px-6 rounded text-base h-10 [&>svg]:h-5 [&>svg]:w-5 bg-button-primary border-button-primary text-button-primary fill-button-primary disabled:bg-button-primary-disabled disabled:border-button-primary-disabled disabled:text-button-primary-disabled disabled:fill-button-primary-disabled"
+      "items-center justify-center border font-semibold leading-none px-6 rounded-sm text-base h-10 [&>svg]:h-5 [&>svg]:w-5 bg-button-primary border-button-primary text-button-primary fill-button-primary disabled:bg-button-primary-disabled disabled:border-button-primary-disabled disabled:text-button-primary-disabled disabled:fill-button-primary-disabled"
     );
   });
 
   it("should return the correct classes with the hasIconOnly option", () => {
     const result = generateButtonClasses("primary", "lg", true);
     expect(result).toBe(
-      "items-center justify-center border font-semibold leading-none px-3 rounded form-element-height-lg [&>svg]:h-5 [&>svg]:w-5 bg-button-primary border-button-primary text-button-primary fill-button-primary disabled:bg-button-primary-disabled disabled:border-button-primary-disabled disabled:text-button-primary-disabled disabled:fill-button-primary-disabled"
+      "items-center justify-center border font-semibold leading-none px-3 rounded-sm form-element-height-lg [&>svg]:h-5 [&>svg]:w-5 bg-button-primary border-button-primary text-button-primary fill-button-primary disabled:bg-button-primary-disabled disabled:border-button-primary-disabled disabled:text-button-primary-disabled disabled:fill-button-primary-disabled"
     );
   });
 

--- a/lib/form-elements.ts
+++ b/lib/form-elements.ts
@@ -17,18 +17,18 @@ const iconSizes = {
  * Tailwind CSS classes for each of the button sizes.
  */
 const buttonSizeClasses = {
-  sm: `px-2 rounded text-xs h-6 ${iconSizes.sm}`,
-  md: `px-4 rounded text-sm h-8 ${iconSizes.md}`,
-  lg: `px-6 rounded text-base h-10 ${iconSizes.lg}`,
+  sm: `px-2 rounded-sm text-xs h-6 ${iconSizes.sm}`,
+  md: `px-4 rounded-sm text-sm h-8 ${iconSizes.md}`,
+  lg: `px-6 rounded-sm text-base h-10 ${iconSizes.lg}`,
 };
 
 /**
  * Tailwind CSS classes for each of the icon-only button sizes.
  */
 const iconButtonSizeClasses = {
-  sm: `px-1.5 rounded form-element-height-sm ${iconSizes.sm}`,
-  md: `px-2 rounded form-element-height-md ${iconSizes.md}`,
-  lg: `px-3 rounded form-element-height-lg ${iconSizes.lg}`,
+  sm: `px-1.5 rounded-sm form-element-height-sm ${iconSizes.sm}`,
+  md: `px-2 rounded-sm form-element-height-md ${iconSizes.md}`,
+  lg: `px-3 rounded-sm form-element-height-lg ${iconSizes.lg}`,
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.25.1",
+        "@tailwindcss/postcss": "^4.1.8",
         "@tailwindcss/typography": "^0.5.4",
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/react": "^16.0.0",
@@ -62,7 +63,6 @@
         "@types/jest": "^29.5.3",
         "@types/lodash": "^4.14.195",
         "auth0-js": "^9.19.0",
-        "autoprefixer": "^10.4.7",
         "coveralls": "^3.1.1",
         "cypress": "^13.3.3",
         "eslint": "^9.25.1",
@@ -75,9 +75,9 @@
         "jest-environment-jsdom": "^29.0.2",
         "postcss": "^8.4.14",
         "prettier": "^3.0.0",
-        "prettier-plugin-tailwindcss": "^0.6.5",
+        "prettier-plugin-tailwindcss": "^0.6.12",
         "pretty-format": "^29.5.0",
-        "tailwindcss": "^3.4.10"
+        "tailwindcss": "^4.1.8"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -90,6 +90,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1148,61 +1149,16 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
       "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+        "minipass": "^7.0.4"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1631,6 +1587,7 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
       "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1644,6 +1601,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1652,6 +1610,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1659,12 +1618,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -2069,15 +2030,6 @@
         "node": ">=12.4.0"
       }
     },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@react-aria/focus": {
       "version": "3.19.1",
       "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.19.1.tgz",
@@ -2332,6 +2284,267 @@
       "integrity": "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==",
       "peerDependencies": {
         "tailwindcss": ">=3.2.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.8.tgz",
+      "integrity": "sha512-OWwBsbC9BFAJelmnNcrKuf+bka2ZxCE2A4Ft53Tkg4uoiE67r/PMEYwCsourC26E+kmxfwE0hVzMdxqeW+xu7Q==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "enhanced-resolve": "^5.18.1",
+        "jiti": "^2.4.2",
+        "lightningcss": "1.30.1",
+        "magic-string": "^0.30.17",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.1.8"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.8.tgz",
+      "integrity": "sha512-d7qvv9PsM5N3VNKhwVUhpK6r4h9wtLkJ6lz9ZY9aeZgrUWk1Z8VPyqyDT9MZlem7GTGseRQHkeB1j3tC7W1P+A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "detect-libc": "^2.0.4",
+        "tar": "^7.4.3"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.1.8",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.8",
+        "@tailwindcss/oxide-darwin-x64": "4.1.8",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.8",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.8",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.8",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.8",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.8",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.8",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.8",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.8",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.8"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.8.tgz",
+      "integrity": "sha512-Fbz7qni62uKYceWYvUjRqhGfZKwhZDQhlrJKGtnZfuNtHFqa8wmr+Wn74CTWERiW2hn3mN5gTpOoxWKk0jRxjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.8.tgz",
+      "integrity": "sha512-RdRvedGsT0vwVVDztvyXhKpsU2ark/BjgG0huo4+2BluxdXo8NDgzl77qh0T1nUxmM11eXwR8jA39ibvSTbi7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.8.tgz",
+      "integrity": "sha512-t6PgxjEMLp5Ovf7uMb2OFmb3kqzVTPPakWpBIFzppk4JE4ix0yEtbtSjPbU8+PZETpaYMtXvss2Sdkx8Vs4XRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.8.tgz",
+      "integrity": "sha512-g8C8eGEyhHTqwPStSwZNSrOlyx0bhK/V/+zX0Y+n7DoRUzyS8eMbVshVOLJTDDC+Qn9IJnilYbIKzpB9n4aBsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.8.tgz",
+      "integrity": "sha512-Jmzr3FA4S2tHhaC6yCjac3rGf7hG9R6Gf2z9i9JFcuyy0u79HfQsh/thifbYTF2ic82KJovKKkIB6Z9TdNhCXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.8.tgz",
+      "integrity": "sha512-qq7jXtO1+UEtCmCeBBIRDrPFIVI4ilEQ97qgBGdwXAARrUqSn/L9fUrkb1XP/mvVtoVeR2bt/0L77xx53bPZ/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.8.tgz",
+      "integrity": "sha512-O6b8QesPbJCRshsNApsOIpzKt3ztG35gfX9tEf4arD7mwNinsoCKxkj8TgEE0YRjmjtO3r9FlJnT/ENd9EVefQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.8.tgz",
+      "integrity": "sha512-32iEXX/pXwikshNOGnERAFwFSfiltmijMIAbUhnNyjFr3tmWmMJWQKU2vNcFX0DACSXJ3ZWcSkzNbaKTdngH6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.8.tgz",
+      "integrity": "sha512-s+VSSD+TfZeMEsCaFaHTaY5YNj3Dri8rST09gMvYQKwPphacRG7wbuQ5ZJMIJXN/puxPcg/nU+ucvWguPpvBDg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.8.tgz",
+      "integrity": "sha512-CXBPVFkpDjM67sS1psWohZ6g/2/cd+cq56vPxK4JeawelxwK4YECgl9Y9TjkE2qfF+9/s1tHHJqrC4SS6cVvSg==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@emnapi/wasi-threads": "^1.0.2",
+        "@napi-rs/wasm-runtime": "^0.2.10",
+        "@tybys/wasm-util": "^0.9.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.8.tgz",
+      "integrity": "sha512-7GmYk1n28teDHUjPlIx4Z6Z4hHEgvP5ZW2QS9ygnDAdI/myh3HTHjDqtSqgu1BpRoI4OiLx+fThAyA1JePoENA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.8.tgz",
+      "integrity": "sha512-fou+U20j+Jl0EHwK92spoWISON2OBnCazIc038Xj2TdweYV33ZRkS9nwqiUi2d/Wba5xg5UoHfvynnb/UB49cQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.8.tgz",
+      "integrity": "sha512-vB/vlf7rIky+w94aWMw34bWW1ka6g6C3xIOdICKX2GC0VcLtL6fhlLiafF0DVIwa9V6EHz8kbWMkS2s2QvvNlw==",
+      "dev": true,
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.1.8",
+        "@tailwindcss/oxide": "4.1.8",
+        "postcss": "^8.4.41",
+        "tailwindcss": "4.1.8"
       }
     },
     "node_modules/@tailwindcss/typography": {
@@ -4001,6 +4214,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4019,15 +4233,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
-    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -4055,11 +4265,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/arg": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -4320,43 +4525,6 @@
         "winchan": "^0.2.2"
       }
     },
-    "node_modules/autoprefixer": {
-      "version": "10.4.21",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "browserslist": "^4.24.4",
-        "caniuse-lite": "^1.0.30001702",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.1.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4558,17 +4726,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/blob-util": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -4763,14 +4920,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelcase-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001707",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
@@ -4856,38 +5005,13 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
       "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "node": ">=18"
       }
     },
     "node_modules/ci-info": {
@@ -5305,6 +5429,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -6127,6 +6252,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -6145,11 +6279,6 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
-    },
-    "node_modules/didyoumean": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
     },
     "node_modules/diff": {
       "version": "7.0.0",
@@ -6172,11 +6301,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/dlv": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -6219,11 +6343,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
-    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -6261,7 +6380,8 @@
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "node_modules/empty-schema": {
       "version": "0.1.5",
@@ -7462,32 +7582,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -7532,19 +7626,6 @@
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
-    "node_modules/fraction.js": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/framer-motion": {
@@ -7595,6 +7676,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -7771,27 +7853,6 @@
       "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -8322,17 +8383,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
@@ -8374,6 +8424,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -8453,6 +8504,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8846,23 +8898,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/javascript-lp-solver": {
@@ -9832,11 +9867,12 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "devOptional": true,
       "bin": {
-        "jiti": "bin/jiti.js"
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-cookie": {
@@ -10086,21 +10122,239 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+    "node_modules/lightningcss": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
+      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
       "engines": {
-        "node": ">=14"
+        "node": ">= 12.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/antonk52"
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-darwin-arm64": "1.30.1",
+        "lightningcss-darwin-x64": "1.30.1",
+        "lightningcss-freebsd-x64": "1.30.1",
+        "lightningcss-linux-arm-gnueabihf": "1.30.1",
+        "lightningcss-linux-arm64-gnu": "1.30.1",
+        "lightningcss-linux-arm64-musl": "1.30.1",
+        "lightningcss-linux-x64-gnu": "1.30.1",
+        "lightningcss-linux-x64-musl": "1.30.1",
+        "lightningcss-win32-arm64-msvc": "1.30.1",
+        "lightningcss-win32-x64-msvc": "1.30.1"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
+      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
     },
     "node_modules/listr2": {
       "version": "3.14.0",
@@ -10322,6 +10576,15 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -10492,8 +10755,21 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mitt": {
@@ -10501,20 +10777,25 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
       "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg=="
     },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.8",
@@ -10635,14 +10916,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10680,14 +10953,6 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -11005,27 +11270,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -11059,6 +11305,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11067,6 +11314,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -11148,6 +11396,7 @@
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
       "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11171,110 +11420,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postcss-import": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dependencies": {
-        "postcss-value-parser": "^4.0.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/postcss-js": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
-      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dependencies": {
-        "camelcase-css": "^2.0.1"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >= 16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.21"
-      }
-    },
-    "node_modules/postcss-load-config": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
-      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "lilconfig": "^3.0.0",
-        "yaml": "^2.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "postcss": ">=8.0.9",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "postcss": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/postcss-nested": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
-      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "postcss-selector-parser": "^6.1.1"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.14"
-      }
-    },
-    "node_modules/postcss-nested/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/postcss-selector-parser": {
       "version": "6.0.10",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
@@ -11287,11 +11432,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -11715,14 +11855,6 @@
         "react": ">= 0.14.0"
       }
     },
-    "node_modules/read-cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dependencies": {
-        "pify": "^2.3.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -11735,17 +11867,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
       }
     },
     "node_modules/redent": {
@@ -12013,6 +12134,7 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
@@ -12572,6 +12694,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -12580,30 +12703,12 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -12716,18 +12821,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -12798,35 +12892,6 @@
         }
       }
     },
-    "node_modules/sucrase": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
-      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "commander": "^4.0.0",
-        "glob": "^10.3.10",
-        "lines-and-columns": "^1.1.6",
-        "mz": "^2.7.0",
-        "pirates": "^4.0.1",
-        "ts-interface-checker": "^0.1.9"
-      },
-      "bin": {
-        "sucrase": "bin/sucrase",
-        "sucrase-node": "bin/sucrase-node"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/sucrase/node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/superagent": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.6.tgz",
@@ -12865,6 +12930,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -12913,52 +12979,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.17",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
-      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "arg": "^5.0.2",
-        "chokidar": "^3.6.0",
-        "didyoumean": "^1.2.2",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.3.2",
-        "glob-parent": "^6.0.2",
-        "is-glob": "^4.0.3",
-        "jiti": "^1.21.6",
-        "lilconfig": "^3.1.3",
-        "micromatch": "^4.0.8",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^3.0.0",
-        "picocolors": "^1.1.1",
-        "postcss": "^8.4.47",
-        "postcss-import": "^15.1.0",
-        "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.2",
-        "postcss-nested": "^6.2.0",
-        "postcss-selector-parser": "^6.1.2",
-        "resolve": "^1.22.8",
-        "sucrase": "^3.35.0"
-      },
-      "bin": {
-        "tailwind": "lib/cli.js",
-        "tailwindcss": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
+      "integrity": "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og=="
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -12967,6 +12990,32 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/test-exclude": {
@@ -13024,25 +13073,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/throttleit": {
@@ -13193,11 +13223,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/ts-interface-checker": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -13473,7 +13498,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -13715,91 +13741,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -13882,17 +13823,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
-    },
-    "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.25.1",
+    "@tailwindcss/postcss": "^4.1.8",
     "@tailwindcss/typography": "^0.5.4",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
@@ -67,7 +68,6 @@
     "@types/jest": "^29.5.3",
     "@types/lodash": "^4.14.195",
     "auth0-js": "^9.19.0",
-    "autoprefixer": "^10.4.7",
     "coveralls": "^3.1.1",
     "cypress": "^13.3.3",
     "eslint": "^9.25.1",
@@ -80,8 +80,8 @@
     "jest-environment-jsdom": "^29.0.2",
     "postcss": "^8.4.14",
     "prettier": "^3.0.0",
-    "prettier-plugin-tailwindcss": "^0.6.5",
+    "prettier-plugin-tailwindcss": "^0.6.12",
     "pretty-format": "^29.5.0",
-    "tailwindcss": "^3.4.10"
+    "tailwindcss": "^4.1.8"
   }
 }

--- a/pages/assays.tsx
+++ b/pages/assays.tsx
@@ -70,7 +70,7 @@ function FixedHeaderCell({
 }) {
   return (
     <th
-      className={`bg-assay-summary-matrix-data-column-header sticky top-0 z-[2] border-b border-r border-panel p-2 text-left align-bottom last:border-r-0 ${widthClasses}`}
+      className={`bg-assay-summary-matrix-data-column-header sticky top-0 z-2 border-b border-r border-panel p-2 text-left align-bottom last:border-r-0 ${widthClasses}`}
     >
       {children}
     </th>
@@ -82,7 +82,7 @@ function FixedHeaderCell({
  */
 function CounterHeaderCell({ children }: { children: React.ReactNode }) {
   return (
-    <th className="bg-assay-summary-matrix-data-column-header sticky top-0 z-[2] w-[50px] whitespace-nowrap border-b border-r border-panel px-1 py-2 align-bottom font-semibold text-black last:border-r-0">
+    <th className="bg-assay-summary-matrix-data-column-header sticky top-0 z-2 w-[50px] whitespace-nowrap border-b border-r border-panel px-1 py-2 align-bottom font-semibold text-black last:border-r-0">
       <div className="mx-auto inline-flex rotate-180 justify-self-center text-start text-black [writing-mode:vertical-lr] dark:text-white">
         {children}
       </div>

--- a/pages/cell-models/[view].tsx
+++ b/pages/cell-models/[view].tsx
@@ -455,7 +455,7 @@ export default function TissueSummary({
             <LabelYAxis label={cellModel.matrix.y.label} />
             <div
               role="table"
-              className="border-1 grid w-max auto-rows-min gap-px overflow-x-auto border border-panel bg-gray-400 text-sm dark:bg-gray-600 dark:outline-gray-700"
+              className="border grid w-max auto-rows-min gap-px overflow-x-auto border border-panel bg-gray-400 text-sm dark:bg-gray-600 dark:outline-gray-700"
             >
               <DataGrid data={dataGrid} meta={{ view }} />
             </div>

--- a/pages/computational-tools.tsx
+++ b/pages/computational-tools.tsx
@@ -183,7 +183,7 @@ function convertSoftwareToDataTable(
  */
 function DefaultHeaderCell({ children }: { children: React.ReactNode }) {
   return (
-    <th className="sticky top-0 z-[2] border-b border-r border-panel bg-computational-tools-header p-2 text-left align-bottom text-computational-tools-header last:border-r-0">
+    <th className="sticky top-0 z-2 border-b border-r border-panel bg-computational-tools-header p-2 text-left align-bottom text-computational-tools-header last:border-r-0">
       {children}
     </th>
   );
@@ -217,7 +217,7 @@ function CategoryHeaderCell({
  */
 function PurposeColumnHeader({ children }: { children: React.ReactNode }) {
   return (
-    <th className="sticky top-0 z-[2] w-96 border-b border-r border-panel bg-computational-tools-header p-2 text-left text-computational-tools-header last:border-r-0">
+    <th className="sticky top-0 z-2 w-96 border-b border-r border-panel bg-computational-tools-header p-2 text-left text-computational-tools-header last:border-r-0">
       {children}
     </th>
   );
@@ -228,7 +228,7 @@ function PurposeColumnHeader({ children }: { children: React.ReactNode }) {
  */
 function ReferencesColumnHeader({ children }: { children: React.ReactNode }) {
   return (
-    <th className="sticky top-0 z-[2] w-80 border-b border-r border-panel bg-computational-tools-header p-2 text-left text-computational-tools-header last:border-r-0">
+    <th className="sticky top-0 z-2 w-80 border-b border-r border-panel bg-computational-tools-header p-2 text-left text-computational-tools-header last:border-r-0">
       {children}
     </th>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -98,7 +98,7 @@ PredictionsIcon.propTypes = {
 function Statistic({ graphic, label, value, query, colorClass }) {
   return (
     <div
-      className={`my-4 grow basis-1/3 rounded border @xl/home:my-0 ${colorClass}`}
+      className={`my-4 grow basis-1/3 rounded-sm border @xl/home:my-0 ${colorClass}`}
     >
       <Link
         href={`/search/?${query}`}

--- a/pages/profiles/[...profile].js
+++ b/pages/profiles/[...profile].js
@@ -127,7 +127,7 @@ function SchemaJsonPanel({
         >
           <JsonPanel
             id={`schema-json-property-${attributeId}`}
-            className="ml-5 border border-panel text-xs"
+            className="border-panel ml-5 border text-xs"
             isLowContrast
           >
             {JSON.stringify(attribute, null, 2)}
@@ -166,7 +166,7 @@ function CopyAttributeNameControl({ attributeName }) {
   return (
     <>
       <TooltipRef tooltipAttr={tooltipAttr}>
-        <button onClick={initiateCopy}>
+        <button onClick={initiateCopy} className="cursor-pointer">
           {isCopied ? (
             <CheckCircleIcon className="h-3 w-3" />
           ) : (
@@ -206,7 +206,7 @@ function Dependency({
         <button
           id={dependencyControlId}
           onClick={(e) => setJsonDetailOpen(dependencyId, e.altKey)}
-          className="flex items-center text-sm font-bold text-schema-prop"
+          className="text-schema-prop flex items-center text-sm font-bold"
           aria-label={`${dependencyId} dependency`}
           aria-expanded={isJsonDetailOpen}
           aria-controls={dependencyPanelId}
@@ -216,11 +216,11 @@ function Dependency({
           ) : (
             <PlusIcon className="mr-1 h-4 w-4" />
           )}
-          <div className="break-all text-left">{dependencyId}</div>
+          <div className="text-left break-all">{dependencyId}</div>
         </button>
         <CopyAttributeNameControl attributeName={dependencyId} />
       </div>
-      <div className="ml-5 text-sm text-schema-prop-description">
+      <div className="text-schema-prop-description ml-5 text-sm">
         {dependency.comment}
       </div>
       <SchemaJsonPanel
@@ -446,7 +446,7 @@ function SchemaProperty({
         <button
           id={propertyControlId}
           onClick={(e) => setJsonDetailOpen(propertyId, e.altKey)}
-          className="flex items-center text-sm font-bold text-schema-prop"
+          className="text-schema-prop flex cursor-pointer items-center text-sm font-bold"
           aria-label={`${propertyId} property${
             isHighlighted ? " (highlighted)" : ""
           }`}
@@ -459,7 +459,7 @@ function SchemaProperty({
             <PlusIcon className="mr-1 h-4 w-4" />
           )}
           <div
-            className={`scroll-mt-40 break-all text-left @2xl:scroll-mt-32 ${
+            className={`scroll-mt-40 text-left break-all @2xl:scroll-mt-32 ${
               isHighlighted ? "bg-schema-name-highlight" : ""
             }`}
           >
@@ -473,7 +473,7 @@ function SchemaProperty({
         </div>
       </div>
       {property.description && (
-        <div className="ml-5 text-sm text-schema-prop-description">
+        <div className="text-schema-prop-description ml-5 text-sm">
           {property.description}
         </div>
       )}
@@ -567,7 +567,7 @@ function SchemaProperties({
 
   return (
     <>
-      <section className="sticky top-[37px] z-10 border-b border-panel bg-schema-search px-4 py-2">
+      <section className="border-panel bg-schema-search sticky top-[37px] z-10 border-b px-4 py-2">
         <FormLabel>Search Schema Properties</FormLabel>
         <div className="mb-4">
           <SchemaSearchField
@@ -761,7 +761,7 @@ function SchemaTab({ id, tabTitle, tabUrl = "", children }) {
       <TooltipRef tooltipAttr={tooltipAttr}>
         <button
           onClick={initiateCopy}
-          className="absolute bottom-0 right-1 top-0 my-auto"
+          className="absolute top-0 right-1 bottom-0 my-auto"
         >
           {isCopied ? (
             <CheckCircleIcon className="h-3 w-3" />

--- a/pages/tissue-summary/[taxa].tsx
+++ b/pages/tissue-summary/[taxa].tsx
@@ -390,7 +390,7 @@ function PanelContent({
           <LabelYAxis label={yLabel} />
           <div
             role="table"
-            className="border-1 grid w-max auto-rows-min gap-px overflow-x-auto border border-panel bg-gray-400 text-sm dark:bg-gray-600 dark:outline-gray-700"
+            className="border grid w-max auto-rows-min gap-px overflow-x-auto border border-panel bg-gray-400 text-sm dark:bg-gray-600 dark:outline-gray-700"
           >
             <DataGrid data={dataGrid} meta={{ taxa }} />
           </div>

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
+    "@tailwindcss/postcss": {},
   },
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,16 +1,19 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+@plugin "@tailwindcss/typography";
+@config '../tailwind.config.ts';
 
+/*
+  The default border color has changed to `currentcolor` in Tailwind CSS v4,
+  so we've added these compatibility styles to make sure everything still
+  looks the same as it did with Tailwind CSS v3.
+
+  If we ever want to remove these styles, we need to add an explicit border
+  color utility to any element that depends on these defaults.
+*/
 @layer base {
   html,
   body {
     height: 100vh;
-  }
-
-  a {
-    color: inherit;
-    text-decoration: none;
   }
 
   * {
@@ -28,47 +31,50 @@
     background-color: var(--color-tooltip-code-background);
     color: var(--color-tooltip-code-text);
   }
+
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    border-color: var(--color-gray-200, currentcolor);
+  }
+
+  a {
+    @apply underline;
+  }
 }
 
-@layer components {
-  .form-element-height-sm {
-    min-height: 1.25rem;
-  }
+@utility form-element-height-sm {
+  min-height: 1.25rem;
+}
 
-  .form-element-height-md {
-    min-height: 1.75rem;
-  }
+@utility form-element-height-md {
+  min-height: 1.75rem;
+}
 
-  .form-element-height-lg {
-    min-height: 2.5rem;
-  }
+@utility form-element-height-lg {
+  min-height: 2.5rem;
 }
 
 /** Colors to represent different fileset types */
-@layer utilities {
-  .fore-fileset-type-analysis {
-    @apply fill-sky-600;
-  }
-
-  .fore-fileset-type-prediction {
-    @apply fill-teal-600;
-  }
-
-  .fore-fileset-type-measurement {
-    @apply fill-yellow-600;
-  }
-
-  .back-fileset-type-analysis {
-    @apply border-sky-600 bg-sky-100 hover:bg-sky-200 dark:bg-sky-900 dark:hover:bg-sky-800;
-  }
-
-  .back-fileset-type-prediction {
-    @apply border-teal-600 bg-teal-200 hover:bg-teal-300 dark:bg-teal-900 dark:hover:bg-teal-800;
-  }
-
-  .back-fileset-type-measurement {
-    @apply border-yellow-600 bg-yellow-100 hover:bg-yellow-200 dark:bg-yellow-900 dark:hover:bg-yellow-800;
-  }
+@utility fore-fileset-type-analysis {
+  @apply fill-sky-600;
+}
+@utility fore-fileset-type-prediction {
+  @apply fill-teal-600;
+}
+@utility fore-fileset-type-measurement {
+  @apply fill-yellow-600;
+}
+@utility back-fileset-type-analysis {
+  @apply border-sky-600 bg-sky-100 hover:bg-sky-200 dark:bg-sky-900 dark:hover:bg-sky-800;
+}
+@utility back-fileset-type-prediction {
+  @apply border-teal-600 bg-teal-200 hover:bg-teal-300 dark:bg-teal-900 dark:hover:bg-teal-800;
+}
+@utility back-fileset-type-measurement {
+  @apply border-yellow-600 bg-yellow-100 hover:bg-yellow-200 dark:bg-yellow-900 dark:hover:bg-yellow-800;
 }
 
 :root {
@@ -585,10 +591,6 @@
   --color-computational-tools-category-unknown: #606060;
 }
 
-a {
-  @apply underline;
-}
-
 /**
  * #page-content styles apply to the markdown content of Page objects.
  */
@@ -819,4 +821,9 @@ a {
 .dark .rdrStartEdge,
 .dark .rdrEndEdge {
   background-color: #7c6c4e;
+}
+
+/** Mask the right end of the term count "LEDs" to fade out */
+.facet-term-count-mask {
+  @apply [mask-image:linear-gradient(to_right,rgba(0,0,0,1)_calc(100%-30px),rgba(0,0,0,0)_100%)] [--webkit-mask-image:linear-gradient(to_right,rgba(0,0,0,1)_calc(100%-30px),rgba(0,0,0,0)_100%)];
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,19 +2,21 @@ import type { Config } from "tailwindcss";
 
 const tailwindConfig: Config = {
   darkMode: "class",
-  content: [
-    "./pages/**/*.{js,ts,tsx}",
-    "./components/**/*.{js,ts,tsx}",
-    "./lib/**/*.{js,ts,tsx}",
-  ],
-  safelist: [
-    "fore-fileset-type-analysis",
-    "back-fileset-type-analysis",
-    "fore-fileset-type-prediction",
-    "back-fileset-type-prediction",
-    "fore-fileset-type-measurement",
-    "back-fileset-type-measurement",
-  ],
+  content: {
+    files: [
+      "./pages/**/*.{js,ts,tsx}",
+      "./components/**/*.{js,ts,tsx}",
+      "./lib/**/*.{js,ts,tsx}",
+    ],
+    safelist: [
+      "fore-fileset-type-analysis",
+      "back-fileset-type-analysis",
+      "fore-fileset-type-prediction",
+      "back-fileset-type-prediction",
+      "fore-fileset-type-measurement",
+      "back-fileset-type-measurement",
+    ],
+  },
   variants: {
     extend: {
       width: ["only"],
@@ -523,43 +525,6 @@ const tailwindConfig: Config = {
       },
     },
   },
-  plugins: [
-    require("@tailwindcss/typography"),
-    require("@tailwindcss/container-queries"),
-
-    function ({ addVariant }) {
-      addVariant("only-child", "&:only-child");
-    },
-
-    // Add .break-anywhere class until this gets built into Tailwind CSS. A PR exists for this but
-    // it hasn't been merged yet:
-    // https://github.com/tailwindlabs/tailwindcss/pull/12128
-    function ({ addUtilities }) {
-      const newUtilities = {
-        ".break-anywhere": {
-          "@supports (overflow-wrap: anywhere)": {
-            "overflow-wrap": "anywhere",
-          },
-          "@supports not (overflow-wrap: anywhere)": {
-            "word-break": "break-word",
-          },
-        },
-      };
-      addUtilities(newUtilities);
-    },
-
-    // Mask to fade the facet term count indicators on the right edge.
-    function ({ addUtilities }) {
-      addUtilities({
-        ".facet-term-count-mask": {
-          maskImage:
-            "linear-gradient(to right, rgba(0, 0, 0, 1) calc(100% - 30px), rgba(0, 0, 0, 0) 100%)",
-          WebkitMaskImage:
-            "linear-gradient(to right, rgba(0, 0, 0, 1) calc(100% - 30px), rgba(0, 0, 0, 0) 100%)",
-        },
-      });
-    },
-  ],
-};
+} as unknown as Config;
 
 export default tailwindConfig;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "jsx": "preserve",
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noEmit": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Not sure there’s really a way to code review this. Tailwind updated some class names. Some formerly default styles now have to be added manually. The relationship between globals.css and tailwind.config.ts has changed, and actually this is a transition method of keeping tailwind.config.ts and referencing it from globals.css. In theory, you can put all of tailwind.config.ts into globals.css, but I doubt I ever will as this has some costs too.