### PR TITLE
IGVF-2802 Correct link to GitHub project board

### DIFF
--- a/components/navigation.js
+++ b/components/navigation.js
@@ -784,7 +784,7 @@ function NavigationExpanded({ navigationClick, toggleNavCollapsed }) {
           </NavigationHrefItem>
           <NavigationHrefItem
             id="github-issues"
-            href="https://github.com/orgs/IGVF/projects/1/views/2?filterQuery=front-end%3A%22Data+Portal%22&visibleFields=%5B%22Title%22%2C%22Assignees%22%2C%22Status%22%2C114383190%5D"
+            href="/github-project-board"
             navigationClick={navigationClick}
             isChildItem
             isExternal

--- a/pages/github-project-board.tsx
+++ b/pages/github-project-board.tsx
@@ -1,0 +1,23 @@
+/**
+ * GitHub can override links to project boards depending on your browser's session state, producing
+ * the wrong results on the project board. You can work around this by linking instead to this page
+ * that redirects to the IGVF GitHub project board. This causes GitHub to ignore the session state.
+ */
+
+/**
+ * NextJS requires a default export even though the component is not used in this case.
+ */
+export default function GitHubProjectBoard() {
+  return null;
+}
+
+export async function getServerSideProps() {
+  const githubUrl =
+    "https://github.com/orgs/IGVF/projects/1/views/2?filterQuery=tag%3A%22Data%20Portal%22%20-status%3ADone&visibleFields=%5B%22Title%22,%22Assignees%22,%22Status%22,114383190%5D";
+  return {
+    redirect: {
+      destination: githubUrl,
+      permanent: false,
+    },
+  };
+}


### PR DESCRIPTION
This turns out to be more complex than I had originally thought. Just using this link with GitHub causes GitHub to redirect to the original link in the code base, even though putting this new link in the URL bar doesn’t cause this redirect. This apparently has something to do with GitHub using browser session storage when navigating to that URL which can cause these redirects.

To get around this, I added a new page that renders nothing, but that initiates a redirect to the new link. This prevents GitHub from using session storage data, apparently. It works reliably now.
