### PR TITLE
IGVF-2792 Fix section directory for JSON display

### DIFF
--- a/components/__tests__/section-directory.test.tsx
+++ b/components/__tests__/section-directory.test.tsx
@@ -67,7 +67,7 @@ interface MockSessionProviderProps {
   value: any; // Replace `any` with the type used in your context
 }
 
-export function MockSessionProvider({
+function MockSessionProvider({
   children,
   value,
 }: MockSessionProviderProps): JSX.Element {
@@ -124,9 +124,43 @@ describe("Test useSecDir() custom React hook", () => {
     ]);
   });
 
-  it("should update the sections based on the DOM elements", () => {
+  it("should update the sections based on the DOM elements with empty context", () => {
     const { result } = renderHook(() => useSecDir(), {
       wrapper: WrapperEmpty,
+    });
+
+    act(() => {
+      // Force React to re-evaluate the effect.
+      jest.runAllTimers();
+    });
+
+    // Assert the sections are updated
+    expect(result.current?.items).toEqual([
+      { id: "sec-dir-section-1", title: "Section 1" },
+      { id: "sec-dir-section-2", title: "Section 2" },
+    ]);
+  });
+
+  it("should update the sections with `isJson` set to true", () => {
+    const { result } = renderHook(() => useSecDir({ isJson: true }), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      // Force React to re-evaluate the effect.
+      jest.runAllTimers();
+    });
+
+    // Assert the sections are updated
+    expect(result.current?.items).toEqual([
+      { id: "sec-dir-section-1", title: "Section 1" },
+      { id: "sec-dir-section-2", title: "Section 2" },
+    ]);
+  });
+
+  it("should update the sections with `isJson` set to false", () => {
+    const { result } = renderHook(() => useSecDir({ isJson: false }), {
+      wrapper: Wrapper,
     });
 
     act(() => {

--- a/components/section-directory.tsx
+++ b/components/section-directory.tsx
@@ -168,9 +168,9 @@ function handleSelect(
   // Add a CSS class to the element to highlight it when scrolling to it. After a short time,
   // remove it.
   if (!isScrollToTop) {
-    element.classList.add("bg-section-directory");
+    element.classList.add("sec-dir-highlight");
     setTimeout(() => {
-      element.classList.remove("bg-section-directory");
+      element.classList.remove("sec-dir-highlight");
     }, ANCHOR_HIGHLIGHT_TIME);
   }
 }
@@ -302,17 +302,32 @@ export function SecDir({ sections }: { sections: SectionList }) {
  * If the section titles can change as the page loads or any other reason, you can pass an
  * arbitrary string in `hash` to this hook to collect the section titles again whenever the hash
  * changes. If you don't pass a hash, this hook will only collect the sections once on page load.
+ *
+ * The `isJson` property can be used in place of `hash` to trigger collecting the sections, but
+ * specifically for the JSON switch. This is useful when the page has a JSON switch that changes
+ * the content of the page, and you want to collect the sections again when the user switches
+ * between JSON and object formats. `hash` is ignored if `isJson` is provided with either `true`
+ * or `false` values.
  * @param renderer React component to render each item in the section directory menu
  * @param hash Hash to use to trigger this hook to collect the sections again
+ * @param isJson Use in place of `hash` to trigger collecting the sections, but for the JSON switch
  * @returns List of sections on the page to pass to SecDir
  */
 export function useSecDir({
   renderer = null,
   hash = "",
+  isJson,
 }: {
   renderer?: RendererComponent;
   hash?: string;
+  isJson?: boolean;
 } = {}): SectionList {
+  // If isJson is provided (true or false), use it as the basis for the hash. Otherwise use the
+  // hash (if any) as is.
+  if (typeof isJson === "boolean") {
+    hash = isJson ? "json" : "object";
+  }
+
   // Use the session properties `auth.userid` property to detect the user login so we can update
   // the section directory in case new panels appear.
   const { sessionProperties } = useContext(SessionContext as any) as {

--- a/pages/alignment-files/[...id].js
+++ b/pages/alignment-files/[...id].js
@@ -54,7 +54,7 @@ export default function AlignmentFile({
   qualityMetrics,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -71,7 +71,7 @@ export default function AnalysisSet({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/analysis-step-versions/[id].js
+++ b/pages/analysis-step-versions/[id].js
@@ -28,7 +28,7 @@ export default function AnalysisStepVersion({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/analysis-steps/[id].js
+++ b/pages/analysis-steps/[id].js
@@ -30,7 +30,7 @@ export default function AnalysisStep({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/assay-terms/[name].js
+++ b/pages/assay-terms/[name].js
@@ -22,7 +22,7 @@ import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
 
 export default function AssayOntologyTerm({ assayOntologyTerm, isA, isJson }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/auxiliary-sets/[id].js
+++ b/pages/auxiliary-sets/[id].js
@@ -57,7 +57,7 @@ export default function AuxiliarySet({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   // Split the files into those with an @type of TabularFile and all others.
   const groupedFiles = _.groupBy(files, (file) =>

--- a/pages/biomarkers/[id].js
+++ b/pages/biomarkers/[id].js
@@ -30,7 +30,7 @@ export default function Biomarker({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/configuration-files/[...id].js
+++ b/pages/configuration-files/[...id].js
@@ -46,7 +46,7 @@ export default function ConfigurationFile({
   qualityMetrics,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/construct-library-sets/[id].js
+++ b/pages/construct-library-sets/[id].js
@@ -262,7 +262,7 @@ export default function ConstructLibrarySet({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/crispr-modifications/[uuid].js
+++ b/pages/crispr-modifications/[uuid].js
@@ -37,7 +37,7 @@ export default function CrisprModification({
   isJson,
   attribution = null,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/curated-sets/[id].js
+++ b/pages/curated-sets/[id].js
@@ -50,7 +50,7 @@ export default function CuratedSet({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/degron-modifications/[uuid].js
+++ b/pages/degron-modifications/[uuid].js
@@ -37,7 +37,7 @@ export default function DegronModification({
   isJson,
   attribution = null,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/documents/[id].js
+++ b/pages/documents/[id].js
@@ -28,7 +28,7 @@ import { truncateText } from "../../lib/general";
 import { isJsonFormat } from "../../lib/query-utils";
 
 export default function Document({ document, attribution = null, isJson }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/human-donors/[uuid].js
+++ b/pages/human-donors/[uuid].js
@@ -44,7 +44,7 @@ export default function HumanDonor({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/image-files/[...id].js
+++ b/pages/image-files/[...id].js
@@ -44,7 +44,7 @@ export default function ImageFile({
   qualityMetrics,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/images/[id].js
+++ b/pages/images/[id].js
@@ -26,7 +26,7 @@ import FetchRequest from "../../lib/fetch-request";
 import { isJsonFormat } from "../../lib/query-utils";
 
 export default function Image({ image, attribution = null, isJson }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/in-vitro-systems/[id].js
+++ b/pages/in-vitro-systems/[id].js
@@ -73,7 +73,7 @@ export default function InVitroSystem({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/index-files/[...id].tsx
+++ b/pages/index-files/[...id].tsx
@@ -72,7 +72,7 @@ export default function IndexFile({
   qualityMetrics: QualityMetricObject[];
   isJson: boolean;
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   const hasReferencePanel =
     indexFile.assembly || indexFile.transcriptome_annotation;

--- a/pages/institutional-certificates/[...id].tsx
+++ b/pages/institutional-certificates/[...id].tsx
@@ -45,7 +45,7 @@ export default function InstitutionalCertificate({
   attribution: any;
   isJson: boolean;
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
   const submittedBy = institutionalCertificate.submitted_by as UserObject;
 
   // Array but schema allows exactly one URL.

--- a/pages/matrix-files/[...id].js
+++ b/pages/matrix-files/[...id].js
@@ -51,7 +51,7 @@ export default function MatrixFile({
   qualityMetrics,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/measurement-sets/[id].js
+++ b/pages/measurement-sets/[id].js
@@ -126,7 +126,7 @@ export default function MeasurementSet({
   isJson,
 }) {
   const tooltipAttr = useTooltip("external-image-url");
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   // Split the files into those with an @type of ImageFile and all others.
   const groupedFiles = _.groupBy(files, (file) =>

--- a/pages/model-files/[...id].js
+++ b/pages/model-files/[...id].js
@@ -45,7 +45,7 @@ export default function ModelFile({
   qualityMetrics,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/model-sets/[id].js
+++ b/pages/model-sets/[id].js
@@ -53,7 +53,7 @@ export default function ModelSet({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/mpra-quality-metrics/[id].tsx
+++ b/pages/mpra-quality-metrics/[id].tsx
@@ -34,7 +34,7 @@ export default function MpraQualityMetric({
   qualityMetricOf: FileObject[];
   isJson: boolean;
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/multiplexed-samples/[uuid].js
+++ b/pages/multiplexed-samples/[uuid].js
@@ -62,7 +62,7 @@ export default function MultiplexedSample({
   barcodeMap,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   const reportLink = `/multireport/?type=Sample&field=%40id&field=multiplexed_in&field=taxa&field=sample_terms.term_name&field=donors&field=disease_terms&field=status&field=summary&field=%40type&multiplexed_in.accession=${multiplexedSample.accession}&field=construct_library_sets`;
 

--- a/pages/perturb-seq-quality-metrics/[id].tsx
+++ b/pages/perturb-seq-quality-metrics/[id].tsx
@@ -34,7 +34,7 @@ export default function PerturbSeqQualityMetric({
   qualityMetricOf: FileObject[];
   isJson: boolean;
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/phenotypic-features/[id].js
+++ b/pages/phenotypic-features/[id].js
@@ -29,7 +29,7 @@ export default function PhenotypicFeature({
   isJson,
   attribution = null,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   const title = getPhenotypicFeatureTitle(phenotypicFeature);
   const feature = `${phenotypicFeature.feature.term_name} (${phenotypicFeature.feature.term_id})`;

--- a/pages/prediction-sets/[id].js
+++ b/pages/prediction-sets/[id].js
@@ -64,7 +64,7 @@ export default function PredictionSet({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/primary-cells/[uuid].js
+++ b/pages/primary-cells/[uuid].js
@@ -68,7 +68,7 @@ export default function PrimaryCell({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/publications/[id].js
+++ b/pages/publications/[id].js
@@ -52,7 +52,7 @@ export default function Publication({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/reference-files/[...id].js
+++ b/pages/reference-files/[...id].js
@@ -55,7 +55,7 @@ export default function ReferenceFile({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/rodent-donors/[uuid].js
+++ b/pages/rodent-donors/[uuid].js
@@ -42,7 +42,7 @@ export default function RodentDonor({
   sources = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/sequence-files/[...id].js
+++ b/pages/sequence-files/[...id].js
@@ -57,7 +57,7 @@ export default function SequenceFile({
   isJson,
   seqspecs,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/signal-files/[...id].js
+++ b/pages/signal-files/[...id].js
@@ -51,7 +51,7 @@ export default function SignalFile({
   qualityMetrics,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/single-cell-atac-seq-quality-metrics/[id].tsx
+++ b/pages/single-cell-atac-seq-quality-metrics/[id].tsx
@@ -34,7 +34,7 @@ export default function PerturbSeqQualityMetric({
   qualityMetricOf: FileObject[];
   isJson: boolean;
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/single-cell-rna-seq-quality-metrics/[id].tsx
+++ b/pages/single-cell-rna-seq-quality-metrics/[id].tsx
@@ -34,7 +34,7 @@ export default function PerturbSeqQualityMetric({
   qualityMetricOf: FileObject[];
   isJson: boolean;
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/software-versions/[id].js
+++ b/pages/software-versions/[id].js
@@ -32,7 +32,7 @@ export default function SoftwareVersion({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/software/[id].js
+++ b/pages/software/[id].js
@@ -37,7 +37,7 @@ export default function Software({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/starr-seq-quality-metrics/[id].tsx
+++ b/pages/starr-seq-quality-metrics/[id].tsx
@@ -34,7 +34,7 @@ export default function PerturbSeqQualityMetric({
   qualityMetricOf: FileObject[];
   isJson: boolean;
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/tabular-files/[...id].js
+++ b/pages/tabular-files/[...id].js
@@ -58,7 +58,7 @@ export default function TabularFile({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/technical-samples/[uuid].js
+++ b/pages/technical-samples/[uuid].js
@@ -49,7 +49,7 @@ export default function TechnicalSample({
   multiplexedInSamples,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/tissues/[uuid].js
+++ b/pages/tissues/[uuid].js
@@ -67,7 +67,7 @@ export default function Tissue({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/treatments/[uuid].js
+++ b/pages/treatments/[uuid].js
@@ -37,7 +37,7 @@ export default function Treatment({
   sources,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/whole-organisms/[id].js
+++ b/pages/whole-organisms/[id].js
@@ -60,7 +60,7 @@ export default function WholeOrganism({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/pages/workflows/[id].js
+++ b/pages/workflows/[id].js
@@ -42,7 +42,7 @@ export default function Workflow({
   attribution = null,
   isJson,
 }) {
-  const sections = useSecDir();
+  const sections = useSecDir({ isJson });
 
   return (
     <>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -678,22 +678,45 @@
 }
 
 /**
- * For highlighting the a section directory anchor when the user selects it. It appears with a
- * background color, then fading to transparent.
+ * For highlighting the a section directory anchor when the user selects it. This shows a flashing
+ * dot to the left of the section directory anchor.
  */
-.bg-section-directory {
-  animation: highlight 2s linear;
-}
+@layer utilities {
+  @keyframes flash-multi {
+    0%,
+    20%,
+    40%,
+    60%,
+    80%,
+    100% {
+      opacity: 0;
+    }
+    10%,
+    30%,
+    50%,
+    70%,
+    90% {
+      opacity: 1;
+    }
+  }
 
-@keyframes highlight {
-  0% {
-    background-color: var(--color-section-directory-highlight);
+  .sec-dir-highlight {
+    position: relative;
   }
-  60% {
-    background-color: var(--color-section-directory-highlight);
-  }
-  100% {
-    background-color: transparent;
+
+  .sec-dir-highlight::before {
+    content: "";
+    position: absolute;
+    left: -1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 0.8rem;
+    height: 0.8rem;
+    background-color: oklch(62.3% 0.214 259.815);
+    border-radius: 9999px;
+    opacity: 0;
+    animation: flash-multi 2s ease-in-out forwards;
+    pointer-events: none;
   }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,25 +2,17 @@ import type { Config } from "tailwindcss";
 
 const tailwindConfig: Config = {
   darkMode: "class",
-  content: {
-    files: [
-      "./pages/**/*.{js,ts,tsx}",
-      "./components/**/*.{js,ts,tsx}",
-      "./lib/**/*.{js,ts,tsx}",
-    ],
-    safelist: [
-      "fore-fileset-type-analysis",
-      "back-fileset-type-analysis",
-      "fore-fileset-type-prediction",
-      "back-fileset-type-prediction",
-      "fore-fileset-type-measurement",
-      "back-fileset-type-measurement",
-    ],
-  },
-  variants: {
-    extend: {
-      width: ["only"],
-    },
+  content: ["./pages/**/*.{js,tsx}", "./components/**/*.{js,tsx}"],
+  safelist: [
+    "fore-fileset-type-analysis",
+    "back-fileset-type-analysis",
+    "fore-fileset-type-prediction",
+    "back-fileset-type-prediction",
+    "fore-fileset-type-measurement",
+    "back-fileset-type-measurement",
+  ],
+  compilerOptions: {
+    moduleResolution: "bundler",
   },
   theme: {
     container: {


### PR DESCRIPTION
You can trigger the rebuilding of the section directory by changing the hash you pass to it. I now pass a new property to `useSecDir` — `isJson` — that changes the hash when switching between normal and JSON modes, triggering the rebuilding of the section directory so that it only shows **Top of Page** while in JSON mode, and then showing all the section on the page while in normal mode.

I also updated the highlighting when you choose a section directory item and scroll to the corresponding section.

I merged in changes from the IGVF-2824-optimize-tailwind branch as they’re just too small to justify their own ticket. This cleans up the Tailwind CSS configuration to better work with Tailwind CSS v4.