### PR TITLE
IGVF-2925 Add assay title tooltips to Assays table page

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -11,6 +11,8 @@ export default defineConfig({
   env: {
     // Disable internal instrumentation that might rely on missing marks.
     CYPRESS_INTERNAL_ENV: "production",
+    // Disable Next.js performance measurement
+    __NEXT_DISABLE_TELEMETRY: "1",
   },
   e2e: {
     baseUrl: "http://localhost:3000",
@@ -27,8 +29,20 @@ export default defineConfig({
           launchOptions.args.push("--disable-gpu");
           launchOptions.args.push("--disable-software-rasterizer");
           launchOptions.args.push("--mute-audio");
+          launchOptions.args.push("--disable-background-timer-throttling");
+          launchOptions.args.push("--disable-backgrounding-occluded-windows");
+          launchOptions.args.push("--disable-features=TranslateUI");
+          launchOptions.args.push("--disable-web-security");
         }
         return launchOptions;
+      });
+
+      // Suppress console warnings about performance marks
+      on("task", {
+        log(message) {
+          console.log(message);
+          return null;
+        },
       });
     },
   },

--- a/lib/__tests__/general.test.ts
+++ b/lib/__tests__/general.test.ts
@@ -1,5 +1,6 @@
 import {
   abbreviateNumber,
+  arbitraryTypeToText,
   convertTextToTitleCase,
   dataSize,
   isValidPath,
@@ -400,5 +401,91 @@ describe("Test the convertTextToTitleCase function", () => {
     expect(convertTextToTitleCase("hello_world")).toBe("Hello_world");
     expect(convertTextToTitleCase("helloworld")).toBe("Helloworld");
     expect(convertTextToTitleCase("")).toBe("");
+  });
+});
+
+describe("Test the arbitraryTypeToText function", () => {
+  it("should return strings as-is", () => {
+    expect(arbitraryTypeToText("hello world")).toBe("hello world");
+    expect(arbitraryTypeToText("")).toBe("");
+    expect(arbitraryTypeToText("test string")).toBe("test string");
+  });
+
+  it("should convert numbers to strings", () => {
+    expect(arbitraryTypeToText(42)).toBe("42");
+    expect(arbitraryTypeToText(0)).toBe("0");
+    expect(arbitraryTypeToText(-15)).toBe("-15");
+    expect(arbitraryTypeToText(3.14159)).toBe("3.14159");
+  });
+
+  it("should convert arrays to comma-separated strings", () => {
+    expect(arbitraryTypeToText(["a", "b", "c"])).toBe("a, b, c");
+    expect(arbitraryTypeToText([1, 2, 3])).toBe("1, 2, 3");
+    expect(arbitraryTypeToText([])).toBe("");
+    expect(arbitraryTypeToText(["single"])).toBe("single");
+  });
+
+  it("should handle nested arrays", () => {
+    expect(
+      arbitraryTypeToText([
+        ["a", "b"],
+        ["c", "d"],
+      ])
+    ).toBe("a, b, c, d");
+    expect(
+      arbitraryTypeToText([
+        [1, 2],
+        [3, 4],
+      ])
+    ).toBe("1, 2, 3, 4");
+  });
+
+  it("should handle mixed arrays", () => {
+    expect(arbitraryTypeToText(["string", 42, true])).toBe("string, 42, true");
+    expect(arbitraryTypeToText([null, undefined, "test"])).toBe(
+      "null, undefined, test"
+    );
+  });
+
+  it("should convert objects to JSON strings", () => {
+    expect(arbitraryTypeToText({ name: "test", value: 42 })).toBe(
+      '{"name":"test","value":42}'
+    );
+    expect(arbitraryTypeToText({})).toBe("{}");
+    expect(arbitraryTypeToText({ nested: { prop: "value" } })).toBe(
+      '{"nested":{"prop":"value"}}'
+    );
+  });
+
+  it("should handle null and undefined values", () => {
+    expect(arbitraryTypeToText(null)).toBe("null");
+    expect(arbitraryTypeToText(undefined)).toBe("undefined");
+  });
+
+  it("should handle boolean values", () => {
+    expect(arbitraryTypeToText(true)).toBe("true");
+    expect(arbitraryTypeToText(false)).toBe("false");
+  });
+
+  it("should handle special values", () => {
+    expect(arbitraryTypeToText(NaN)).toBe("NaN");
+    expect(arbitraryTypeToText(Infinity)).toBe("Infinity");
+    expect(arbitraryTypeToText(-Infinity)).toBe("-Infinity");
+  });
+
+  it("should handle complex nested structures", () => {
+    const complexValue = {
+      strings: ["a", "b"],
+      numbers: [1, 2],
+      nested: { prop: "value" },
+    };
+    expect(arbitraryTypeToText(complexValue)).toBe(
+      '{"strings":["a","b"],"numbers":[1,2],"nested":{"prop":"value"}}'
+    );
+  });
+
+  it("should handle arrays containing objects", () => {
+    const arrayWithObjects = [{ id: 1 }, { id: 2 }];
+    expect(arbitraryTypeToText(arrayWithObjects)).toBe('{"id":1}, {"id":2}');
   });
 });

--- a/lib/__tests__/ontology-terms.test.ts
+++ b/lib/__tests__/ontology-terms.test.ts
@@ -75,7 +75,7 @@ describe("ontology-terms", () => {
       );
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "/search-quick/?type=AssayTerm&field=definition&field=term_name&term_name=imaging%20assay&term_name=in%20vitro%20CRISPR%20screen%20assay",
+        "/search-quick/?type=AssayTerm&field=term_name&field=definition&term_name=imaging%20assay&term_name=in%20vitro%20CRISPR%20screen%20assay",
         expect.anything()
       );
       expect(result).toEqual({
@@ -172,7 +172,7 @@ describe("ontology-terms", () => {
       );
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "/search-quick/?type=AssayTerm&field=definition&field=term_name&term_name=RNA-seq%20%26%20ChIP-seq&term_name=test%2Ftitle",
+        "/search-quick/?type=AssayTerm&field=term_name&field=definition&term_name=RNA-seq%20%26%20ChIP-seq&term_name=test%2Ftitle",
         expect.anything()
       );
     });

--- a/lib/general.ts
+++ b/lib/general.ts
@@ -328,3 +328,25 @@ export function convertTextToTitleCase(text: string): string {
     })
     .join(" ");
 }
+
+/**
+ * Convert an arbitrarily typed value to a string. Arrays of arbitrary types convert to a comma
+ * separated list of strings. Objects convert to their JSON representation.
+ * @param value Arbitrarily typed value to convert to a string
+ * @returns Value converted to a string
+ */
+export function arbitraryTypeToText(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return value.toString();
+  }
+  if (Array.isArray(value)) {
+    return value.map(arbitraryTypeToText).join(", ");
+  }
+  if (typeof value === "object" && value !== null) {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}


### PR DESCRIPTION
The changes to `cypress/support/e2e.js` are a further effort to prevent the old and frustrating `SyntaxError: Failed to execute 'measure' on 'Performance': The mark 'beforeRender' does not exist.` errors when Cypress runs on CircleCI.