### PR TITLE
IGVF-2958 Analysis step version table on workflow pages

### DIFF
--- a/components/analysis-step-version-table.tsx
+++ b/components/analysis-step-version-table.tsx
@@ -1,34 +1,89 @@
 // node_modules
 import { TableCellsIcon } from "@heroicons/react/20/solid";
+import _ from "lodash";
+import { useState } from "react";
 // components
+import Checkbox from "./checkbox";
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import Link from "./link-no-prefetch";
 import SeparatedList from "./separated-list";
 import SortableGrid from "./sortable-grid";
+// lib
+import { sortedSeparatedList } from "../lib/general";
 // root
 import { AnalysisStepVersionObject } from "../globals";
 
+/**
+ * Meta information passed to the sortable grid for the analysis step version table.
+ *
+ * @property isVersionColumnVisible - True to show the analysis step version column
+ */
+type TableMeta = {
+  isVersionColumnVisible: boolean;
+};
+
 const analysisStepVersionColumns = [
   {
-    id: "@id",
-    title: "Analysis Step Versions",
-    display: ({ source }: { source: AnalysisStepVersionObject }) => (
-      <Link href={source["@id"]}>{source["@id"]}</Link>
-    ),
+    id: "analysis_step_version",
+    title: "Analysis Step Version",
+    display: ({ source }) => {
+      return <Link href={source["@id"]}>{source["@id"]}</Link>;
+    },
+    hide: (data, columns, meta: TableMeta) => !meta.isVersionColumnVisible,
+    isSortable: false,
+  },
+  {
+    id: "analysis_step_title",
+    title: "Analysis Step Title",
+    display: ({ source }) => _.get(source, "analysis_step.title", ""),
+    sorter: (item) => _.get(item, "analysis_step.title", "").toLowerCase(),
+  },
+  {
+    id: "analysis_step_type",
+    title: "Analysis Step Types",
+    display: ({ source }) => {
+      const types = _.get(source, "analysis_step.analysis_step_types", []);
+      return types.length > 0 ? sortedSeparatedList(types) : "";
+    },
+    isSortable: false,
+  },
+  {
+    id: "analysis_step_input_content_types",
+    title: "Input Content Types",
+    display: ({ source }) => {
+      const inputTypes = _.get(source, "analysis_step.input_content_types", []);
+      return inputTypes.length > 0 ? sortedSeparatedList(inputTypes) : "";
+    },
+    isSortable: false,
+  },
+  {
+    id: "analysis_step_output_content_types",
+    title: "Output Content Types",
+    display: ({ source }) => {
+      const outputTypes = _.get(
+        source,
+        "analysis_step.output_content_types",
+        []
+      );
+      return outputTypes.length > 0 ? sortedSeparatedList(outputTypes) : "";
+    },
+    isSortable: false,
   },
   {
     id: "software_versions",
     title: "Software Versions",
     display: ({ source }: { source: AnalysisStepVersionObject }) => {
-      return (
-        <SeparatedList>
-          {source.software_versions.map((version) => (
-            <Link key={version["@id"]} href={version["@id"]}>
-              {version.name}
-            </Link>
-          ))}
-        </SeparatedList>
-      );
+      if (source.software_versions?.length > 0) {
+        return (
+          <SeparatedList>
+            {source.software_versions.map((version) => (
+              <Link key={version["@id"]} href={version["@id"]}>
+                {version.name}
+              </Link>
+            ))}
+          </SeparatedList>
+        );
+      }
     },
     isSortable: false,
   },
@@ -38,17 +93,17 @@ const analysisStepVersionColumns = [
  * Display a sortable table of the given analysis step versions. Optionally display a link to a
  * report page of the analysis steps in this table.
  *
- * @param analysisStepVersions - Analysis Step Versions to display in the table
- * @param reportLink - Optional link to a report page containing the same file sets as this table
- * @param reportLabel - Label for the report link if given
- * @param title - Title of the table
- * @param panelId - Unique ID for the panel in the section directory
+ * @param analysisStepVersions - Analysis step versions to display in the table
+ * @param [reportLink] - Link to a report page containing the same analysis step versions
+ * @param [reportLabel] - Label for the report link
+ * @param [title] - Title of the table
+ * @param [panelId] - ID of the panel containing the table
  */
 export function AnalysisStepVersionTable({
   analysisStepVersions,
   reportLink = "",
   reportLabel = "",
-  title = "Analysis Step Versions",
+  title = "Analysis Steps",
   panelId = "analysis-step-version-table",
 }: {
   analysisStepVersions: AnalysisStepVersionObject[];
@@ -57,15 +112,30 @@ export function AnalysisStepVersionTable({
   title?: string;
   panelId?: string;
 }) {
+  const [isVersionColumnVisible, setIsVersionColumnVisible] = useState(false);
+
   return (
     <>
-      <DataAreaTitle id={panelId}>
+      <DataAreaTitle id={panelId} secDirTitle={title}>
         {title}
-        {reportLink && (
-          <DataAreaTitleLink href={reportLink} label={reportLabel}>
-            <TableCellsIcon className="h-4 w-4" />
-          </DataAreaTitleLink>
-        )}
+        <div className="flex gap-1">
+          <Checkbox
+            id="show-analysis-step-versions-column"
+            checked={isVersionColumnVisible}
+            name="Show analysis-step-versions column"
+            onClick={() => setIsVersionColumnVisible(!isVersionColumnVisible)}
+            className="items-center [&>input]:mr-0"
+          >
+            <div className="order-first mr-1 text-sm">
+              Show analysis-step-versions column
+            </div>
+          </Checkbox>
+          {reportLink && (
+            <DataAreaTitleLink href={reportLink} label={reportLabel}>
+              <TableCellsIcon className="h-4 w-4" />
+            </DataAreaTitleLink>
+          )}
+        </div>
       </DataAreaTitle>
       <div className="overflow-hidden">
         <SortableGrid
@@ -73,6 +143,7 @@ export function AnalysisStepVersionTable({
           columns={analysisStepVersionColumns}
           keyProp="@id"
           pager={{}}
+          meta={{ isVersionColumnVisible } satisfies TableMeta}
         />
       </div>
     </>

--- a/lib/__tests__/common-requests.test.ts
+++ b/lib/__tests__/common-requests.test.ts
@@ -1,6 +1,7 @@
 import type { DatabaseObject, FileSetObject } from "../../globals.d";
 import {
   requestAnalysisSteps,
+  requestAnalysisStepVersions,
   requestAwards,
   requestBiomarkers,
   requestBiosamples,
@@ -81,6 +82,51 @@ describe("Test all the common requests", () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       "/search-quick/?type=AnalysisStep&field=aliases&field=input_content_types&field=name&field=output_content_types&field=status&field=step_label&field=title&@id=/analysis-steps/IGVFWF0000WORK-example-analysis-step/&limit=1",
+      expect.anything()
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(mockResult["@graph"][0]);
+  });
+
+  test("requestAnalysisStepVersions function", async () => {
+    const mockResult = {
+      "@graph": [
+        {
+          "@id":
+            "/analysis-step-versions/IGVFWF0000WORK-example-analysis-step-version/",
+          "@type": ["AnalysisStepVersion", "Item"],
+          analysis_step: {
+            "@id": "/analysis-steps/IGVFWF0000WORK-example-analysis-step/",
+            "@type": ["AnalysisStep", "Item"],
+            analysis_step_types: ["alignment", "quantification"],
+            input_content_types: ["reads"],
+            output_content_types: ["alignments", "transcriptome annotations"],
+            title: "Example Analysis Step",
+          },
+          software_versions: [
+            {
+              "@id":
+                "/software-versions/IGVFWF0000WORK-example-software-version/",
+              "@type": ["SoftwareVersion", "Item"],
+              name: "IGVFWF0000WORK-example-software-version",
+              status: "released",
+            },
+          ],
+        },
+      ],
+    };
+
+    // Mock the response for the getObject call within getMultipleObjectsBulk
+    mockFetch.mockResolvedValueOnce(createMockResponse(mockResult));
+
+    const request = new FetchRequest();
+    const result = await requestAnalysisStepVersions(
+      ["/analysis-step-versions/IGVFWF0000WORK-example-analysis-step-version/"],
+      request
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/search-quick/?type=AnalysisStepVersion&field=analysis_step.analysis_step_types&field=analysis_step.input_content_types&field=analysis_step.output_content_types&field=analysis_step.title&field=software_versions&@id=/analysis-step-versions/IGVFWF0000WORK-example-analysis-step-version/&limit=1",
       expect.anything()
     );
     expect(result).toHaveLength(1);

--- a/lib/common-requests.ts
+++ b/lib/common-requests.ts
@@ -3,6 +3,7 @@ import FetchRequest from "./fetch-request";
 import { type DatasetSummary } from "./home";
 // root
 import type {
+  AnalysisStepVersionObject,
   DatabaseObject,
   DataProviderObject,
   FileObject,
@@ -35,6 +36,33 @@ export async function requestAnalysisSteps(
       ["AnalysisStep"]
     )
   ).unwrap_or([]);
+}
+
+/**
+ * Retrieve the analysis step version objects for the given analysis step version paths from the
+ * data provider.
+ *
+ * @param paths - Paths to the analysis step version objects to request
+ * @param request - Request object to use to make the request
+ * @returns - Analysis step version objects requested
+ */
+export async function requestAnalysisStepVersions(
+  paths: Array<string>,
+  request: FetchRequest
+): Promise<Array<AnalysisStepVersionObject>> {
+  return (
+    await request.getMultipleObjectsBulk(
+      paths,
+      [
+        "analysis_step.analysis_step_types",
+        "analysis_step.input_content_types",
+        "analysis_step.output_content_types",
+        "analysis_step.title",
+        "software_versions",
+      ],
+      ["AnalysisStepVersion"]
+    )
+  ).unwrap_or([]) as AnalysisStepVersionObject[];
 }
 
 /**

--- a/pages/workflows/[id].js
+++ b/pages/workflows/[id].js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import AliasList from "../../components/alias-list";
 import AlternateAccessions from "../../components/alternate-accessions";
 import AnalysisStepTable from "../../components/analysis-step-table";
+import { AnalysisStepVersionTable } from "../../components/analysis-step-version-table";
 import Attribution from "../../components/attribution";
 import Breadcrumbs from "../../components/breadcrumbs";
 import { UniformlyProcessedBadge } from "../../components/common-pill-badges";
@@ -152,6 +153,13 @@ export default function Workflow({
               analysisSteps={analysisSteps}
               reportLink={`/multireport/?type=AnalysisStep&workflow.@id=${workflow["@id"]}`}
               reportLabel="Analysis Steps that link to this workflow"
+            />
+          )}
+          {workflow.analysis_step_versions?.length > 0 && (
+            <AnalysisStepVersionTable
+              analysisStepVersions={workflow.analysis_step_versions}
+              reportLink={`/multireport/?type=AnalysisStepVersion&workflows.@id=${workflow["@id"]}`}
+              reportLabel="Analysis Step Versions that link to this workflow"
             />
           )}
           {documents.length > 0 && <DocumentTable documents={documents} />}


### PR DESCRIPTION
I renamed the branch to get rid of the `feature/` prefix, disconnecting the PR in the process. The PR before rename is at https://github.com/IGVF-DACC/igvf-ui/pull/894

I’ll use this PR from now, but the code review information is in the old PR.