### PR TITLE
IGVF-3038 Fix file graph crash

### DIFF
--- a/components/file-graph/file-graph.tsx
+++ b/components/file-graph/file-graph.tsx
@@ -499,9 +499,26 @@ export function FileGraph({
   title?: string;
   panelId?: string;
 }) {
+  // Create a set of paths of files that are available to be included in the graph. Any files
+  // unavailable because of incomplete indexing or access privileges do not get included.
+  const availableFilePaths = new Set([
+    ...files.map((file) => file["@id"]),
+    ...derivedFromFiles.map((file) => file["@id"]),
+  ]);
+
+  // Copy the files but with unavailable files filtered out of their `derived_from` arrays.
+  const filesWithFilteredDerived = files.map((file) => ({
+    ...file,
+    derived_from:
+      file.derived_from?.filter((path) => availableFilePaths.has(path)) || [],
+  }));
+
   // Only consider native files that derive from other files or that other files derive from. From
   // these files look for cycles caused by circular `derived_from` relationships.
-  const includedFiles = trimIsolatedFiles(files, derivedFromFiles);
+  const includedFiles = trimIsolatedFiles(
+    filesWithFilteredDerived,
+    derivedFromFiles
+  );
   const cycles = detectCycles(includedFiles.concat(derivedFromFiles));
 
   const graphData =
@@ -523,7 +540,10 @@ export function FileGraph({
         </DataAreaTitle>
         {graphData ? (
           <DataPanel isPaddingSuppressed>
-            <Graph graphData={graphData} nativeFiles={files} />
+            <Graph
+              graphData={graphData}
+              nativeFiles={filesWithFilteredDerived}
+            />
           </DataPanel>
         ) : (
           <DataPanel>


### PR DESCRIPTION
# Code Review: IGVF-3038-file-graph-crash Branch

## Overview
This branch addresses a critical crash issue in the file association graph when attempting to create edges to files that failed to load due to incomplete indexing or access privileges. The fix implements filtering of unavailable files from `derived_from` arrays before graph processing.

## Files Modified
1. **`components/file-graph/file-graph.tsx`**

## Detailed Analysis

### ✅ **Strengths**

1. **Proactive Problem Prevention**: The fix addresses the issue at the source by filtering out problematic references before they can cause crashes in downstream functions like `trimIsolatedFiles`, `detectCycles`, or `generateGraphData`.

2. **Well-Documented Intent**: The comments clearly explain the purpose of the filtering - handling files that are "unavailable because of incomplete indexing or access privileges."

3. **Consistent Data Structure**: The solution maintains the same file object structure while safely removing only the problematic `derived_from` entries, preserving all other file properties.

4. **Performance Efficient**: Uses a `Set` for O(1) lookup performance when checking if a file path is available, which is optimal for filtering operations.

### 🔍 **Technical Implementation**

**The Fix Strategy:**
```tsx
// Create availability lookup
const availableFilePaths = new Set([
  ...files.map((file) => file["@id"]),
  ...derivedFromFiles.map((file) => file["@id"]),
]);

// Filter derived_from arrays
const filesWithFilteredDerived = files.map((file) => ({
  ...file,
  derived_from:
    file.derived_from?.filter((path) => availableFilePaths.has(path)) || [],
}));
```

### ✅ **Why This Approach Works**

1. **Comprehensive Coverage**: Creates a complete set of available files from both `files` and `derivedFromFiles` arrays.

2. **Safe Filtering**: Uses optional chaining (`?.`) and nullish coalescing (`||`) to handle cases where `derived_from` might be undefined.

3. **Immutable Updates**: Creates new file objects rather than mutating existing ones, following React best practices.

4. **Downstream Compatibility**: The existing `trimIsolatedFiles`, `detectCycles`, and `generateGraphData` functions work seamlessly with the filtered data.

### 🔍 **Code Quality Assessment**

**Comparison with Existing Pattern:**
Looking at the `trimIsolatedFiles` function in `lib.ts`, there's already similar logic:
```tsx
const loadedDerivedFromPaths = (file.derived_from || []).filter((path) =>
  allFilePaths.has(path)
);
```

This shows the fix aligns with established patterns in the codebase.

### ⚠️ **Potential Considerations**

1. **Duplication of Logic**: The filtering logic now exists in both places - this component and `trimIsolatedFiles`. Consider whether this should be consolidated.

2. **Error Logging**: No indication is given when files are filtered out. For debugging purposes, it might be helpful to log when `derived_from` entries are removed.

3. **Testing Coverage**: The change should be tested with scenarios where:
   - Some files in `derived_from` arrays don't exist in `derivedFromFiles`
   - Files have empty or undefined `derived_from` arrays
   - All `derived_from` files are available vs. none are available

### 📋 **Code Quality Metrics**

- **Readability**: ✅ Clear variable names and good comments
- **Maintainability**: ✅ Follows existing patterns in the codebase
- **Performance**: ✅ Efficient O(1) lookup with Set data structure
- **Type Safety**: ✅ Proper TypeScript usage with optional chaining
- **Error Handling**: ✅ Graceful handling of undefined `derived_from` arrays

### 🎯 **Recommendations**

1. **Consider Consolidation**: Since `trimIsolatedFiles` already has similar filtering logic, consider whether this filtering should be moved there to avoid duplication.

2. **Add Development Logging**: For debugging purposes:
   ```tsx
   const filteredPaths = file.derived_from?.filter((path) => !availableFilePaths.has(path)) || [];
   if (filteredPaths.length > 0 && process.env.NODE_ENV === 'development') {
     console.warn(`Filtered out unavailable files for ${file["@id"]}:`, filteredPaths);
   }
   ```

3. **Test Coverage**: Ensure tests cover the edge cases of missing files in `derived_from` arrays.

4. **Performance Monitoring**: If this becomes a performance bottleneck with large file sets, consider memoizing the `availableFilePaths` set.

## Verdict: ✅ **APPROVED**

This is a well-implemented defensive fix that:
- Solves a real crash scenario with unavailable files
- Uses efficient data structures and algorithms
- Follows established patterns in the codebase
- Maintains backward compatibility
- Has minimal performance impact
- Preserves data integrity while removing only problematic references

The fix is surgical and targeted, addressing the specific issue without over-engineering or breaking existing functionality. It demonstrates good understanding of the file graph system and implements a robust solution to handle real-world data inconsistencies.

## Commit Information

**Commit Hash**: `18b58c9dc6387e01b2e3161cb5effb4828b668b9`  
**Author**: forresttanaka <fytanaka@stanford.edu>  
**Date**: Thu Sep 25 13:26:43 2025 -0700  
**Message**: IGVF-3038-file-graph-crash - Filter out unavailable files from graph creation.

## Technical Context

### Problem Description
Files in the `files` array can contain a `derived_from` property that references other file objects by their `@id` paths. These referenced files should exist in either the `files` array or the `derivedFromFiles` array. However, some files might not be readable due to incomplete indexing or access privileges, causing them to be missing from `derivedFromFiles`. This creates broken references that could cause crashes in graph generation functions.

### Solution Approach
The fix preemptively filters out any `derived_from` paths that point to unavailable files by:
1. Creating a comprehensive set of all available file paths
2. Filtering each file's `derived_from` array to only include available paths
3. Using the filtered files throughout the graph generation pipeline

This approach prevents downstream crashes while maintaining data integrity for all available file relationships.