### PR TITLE
IGVF-3280 Work around Safari bug that scrolls tables out of place when the user changes table pages

### DIFF
--- a/components/react-utility.tsx
+++ b/components/react-utility.tsx
@@ -1,0 +1,8 @@
+import { useEffect, useLayoutEffect } from "react";
+
+/**
+ * A hook that behaves like `useLayoutEffect` on the client and `useEffect` on the server.
+ * This is useful for avoiding warnings about using `useLayoutEffect` on the server.
+ */
+export const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;

--- a/components/sequencing-file-table.tsx
+++ b/components/sequencing-file-table.tsx
@@ -1,7 +1,7 @@
 // node_modules
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import _ from "lodash";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 // components
 import { AnnotatedValue } from "./annotated-value";
 import { BatchDownloadActuator } from "./batch-download";
@@ -12,6 +12,7 @@ import { FileAccessionAndDownload } from "./file-download";
 import { HostedFilePreview } from "./hosted-file-preview";
 import Link from "./link-no-prefetch";
 import Pager, { TablePagerContainer } from "./pager";
+import { useIsomorphicLayoutEffect } from "./react-utility";
 import { SeqspecDocumentLink } from "./seqspec-document";
 import TableCount from "./table-count";
 // lib
@@ -445,8 +446,11 @@ export default function SequencingFileTable({
   // Create a batch-download controller if a file set is provided.
   const controller = fileSet ? new FileTableController(fileSet) : null;
 
-  // Called when the user selects a new page of sequence files to view.
-  function setCurrentPageIndex(newIndex: number) {
+  // Called when the user selects a new page in the pager. Capture the scroll position before
+  // changing the page index to trigger the useIsomorphicLayoutEffect that restores the scroll
+  // position after the re-render.
+  function handlePageChange(newIndex: number) {
+    savedScrollY.current = window.scrollY;
     setPageIndex(newIndex);
   }
 
@@ -454,6 +458,17 @@ export default function SequencingFileTable({
     // Reset to the first page whenever the number of data items changes.
     setPageIndex(0);
   }, [files.length]);
+
+  // Restore the scroll position after a page change. This is needed to prevent Safari from
+  // erratically adjusting the scroll position after a page change when the table height changes
+  // between pages.
+  const savedScrollY = useRef<number | null>(null);
+  useIsomorphicLayoutEffect(() => {
+    if (savedScrollY.current !== null) {
+      window.scrollTo(0, savedScrollY.current);
+      savedScrollY.current = null;
+    }
+  }, [pageIndex]);
 
   return (
     <>
@@ -496,9 +511,7 @@ export default function SequencingFileTable({
             <Pager
               currentPage={pageIndex + 1}
               totalPages={paginatedSequenceFileGroups.length}
-              onClick={(newCurrentPage) =>
-                setCurrentPageIndex(newCurrentPage - 1)
-              }
+              onClick={(newCurrentPage) => handlePageChange(newCurrentPage - 1)}
             />
           </TablePagerContainer>
         )}

--- a/components/sortable-grid.tsx
+++ b/components/sortable-grid.tsx
@@ -21,6 +21,7 @@ import {
 import DataGrid, { DataGridContainer } from "./data-grid";
 import Pager, { TablePagerContainer } from "./pager";
 import GridScrollIndicators from "./grid-scroll-indicators";
+import { useIsomorphicLayoutEffect } from "./react-utility";
 import TableCount from "./table-count";
 // lib
 import {
@@ -423,6 +424,25 @@ export default function SortableGrid<
     setPageIndex(0);
   }, [data.length]);
 
+  // Restore the scroll position after a page change. This is needed to prevent Safari from
+  // erratically adjusting the scroll position after a page change when the table height changes
+  // between pages.
+  const savedScrollY = useRef<number | null>(null);
+  useIsomorphicLayoutEffect(() => {
+    if (savedScrollY.current !== null) {
+      window.scrollTo(0, savedScrollY.current);
+      savedScrollY.current = null;
+    }
+  }, [pageIndex]);
+
+  // Called when the user selects a new page in the pager. Capture the scroll position before
+  // changing the page index to trigger the useIsomorphicLayoutEffect that restores the scroll
+  // position after the re-render.
+  function handlePageChange(newPageIndex: number) {
+    savedScrollY.current = window.scrollY;
+    setPageIndex(newPageIndex);
+  }
+
   // Generate the cells within the header row. The column title can contain a string or a React
   // component.
   const headerCells = visibleColumns.map((column) => {
@@ -468,7 +488,7 @@ export default function SortableGrid<
         <TablePager
           data={data}
           currentPageIndex={pageIndex}
-          setCurrentPageIndex={setPageIndex}
+          setCurrentPageIndex={handlePageChange}
           maxItemsPerPage={MAX_ITEMS_PER_PAGE}
         />
       )}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -48,6 +48,9 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   disconnect: jest.fn(),
 }));
 
+// Mock window.scrollTo, which is not implemented in jsdom.
+global.scrollTo = jest.fn();
+
 // Mock navigator.clipboard for copy-to-clipboard tests.
 Object.assign(navigator, {
   clipboard: {


### PR DESCRIPTION
# Code Review — IGVF-3280: Safari Table Scroll Bug

*Review generated by GitHub Copilot (Claude Sonnet 4.6)*

## Summary

This branch fixes a Safari-specific bug where the browser erratically adjusts the scroll position after a paginated table changes pages, likely because the table height changes between pages with different row counts. The fix saves the scroll position before a page change and restores it synchronously via `useLayoutEffect` after re-render.

---

## `components/sortable-grid.tsx` and `components/sequencing-file-table.tsx`

Both files apply the same pattern, so the feedback applies to both.

### What's correct

- **`useLayoutEffect` is the right hook.** It fires synchronously after DOM mutations but before the browser paints, which is exactly what's needed to prevent the visual scroll jump. `useEffect` would be too late and would cause a flicker.
- **`window.scrollTo({ behavior: "instant" })` is correct.** Avoids introducing a scroll animation that would itself be visually jarring.
- **`useRef` for `savedScrollY` is correct.** It doesn't trigger a re-render, and persists across renders safely.
- **The `null` sentinel pattern is correct.** Checking for `null` before restoring and clearing it after prevents the effect from firing on the initial render or on any re-render not triggered by a pager click.

### Minor suggestions

**1. Naming inconsistency between the two files**

In `sortable-grid.tsx`, the page-change handler is named `handlePageChange`. In `sequencing-file-table.tsx`, it's named `setCurrentPageIndex`. The latter name implies it only sets state, but it now also captures the scroll position. Renaming it to `handlePageChange` (or similar) would better reflect what the function does and make the two files consistent.

**2. Duplicated logic**

The scroll save/restore pattern is duplicated across two components. If this needs to be applied to additional tables in the future, extracting a small custom hook (e.g., `useScrollRestoreOnPageChange`) would be worth considering. Not required now, but worth noting as the pattern spreads.

---

## Overall

The fix is correct, minimal, and uses the right React primitives. The two points above are minor — the naming inconsistency is the most worth addressing before merge.