### PR TITLE
IGVF-3287 Display time post culture on in-vitro system pages

### DIFF
--- a/components/__tests__/react-utility.test.tsx
+++ b/components/__tests__/react-utility.test.tsx
@@ -1,0 +1,46 @@
+const originalWindow = globalThis.window;
+
+async function loadHookForWindowState(windowIsDefined: boolean) {
+  jest.resetModules();
+  Object.defineProperty(globalThis, "window", {
+    value: windowIsDefined ? originalWindow : undefined,
+    configurable: true,
+    writable: true,
+  });
+
+  // Import the file under test at this point because its behavior depends on the state of
+  // `window`. We need to do this after we set `window` to ensure we get the correct version of the
+  // hook.
+  const reactUtility = await import("../react-utility");
+  const react = await import("react");
+  return {
+    hook: reactUtility.useIsomorphicLayoutEffect,
+    useEffect: react.useEffect,
+    useLayoutEffect: react.useLayoutEffect,
+  };
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "window", {
+    value: originalWindow,
+    configurable: true,
+    writable: true,
+  });
+});
+
+describe("useIsomorphicLayoutEffect", () => {
+  it("should be defined", async () => {
+    const { hook } = await loadHookForWindowState(true);
+    expect(hook).toBeDefined();
+  });
+
+  it("should be useLayoutEffect on the client", async () => {
+    const { hook, useLayoutEffect } = await loadHookForWindowState(true);
+    expect(hook).toBe(useLayoutEffect);
+  });
+
+  it("should be useEffect on the server", async () => {
+    const { hook, useEffect } = await loadHookForWindowState(false);
+    expect(hook).toBe(useEffect);
+  });
+});

--- a/components/biomarker-table.js
+++ b/components/biomarker-table.js
@@ -40,7 +40,16 @@ const biomarkersColumns = [
 ];
 
 /**
- * Display a sortable table of the given treatments.
+ * Display a sortable table of the given biomarkers.
+ *
+ * @param {{
+ *   biomarkers: object[],
+ *   reportLink?: string | null,
+ *   reportLabel?: string | null,
+ *   title?: string,
+ *   isDeletedVisible?: boolean,
+ *   panelId?: string,
+ * }} props
  */
 export default function BiomarkerTable({
   biomarkers,

--- a/components/common-data-items.js
+++ b/components/common-data-items.js
@@ -367,6 +367,19 @@ function formatAge(item) {
 
 /**
  * Display data items common to all biosample-derived objects.
+ *
+ * @param {{
+ *   item: object,
+ *   classifications?: string[],
+ *   constructLibrarySets?: object[],
+ *   diseaseTerms?: object[],
+ *   annotatedFrom?: object | null,
+ *   partOf?: object | null,
+ *   sampleTerms?: object[],
+ *   sources?: object[] | null,
+ *   publications?: object[],
+ *   children?: import("react").ReactNode,
+ * }} props
  */
 export function BiosampleDataItems({
   item,

--- a/components/sample-table.js
+++ b/components/sample-table.js
@@ -108,6 +108,16 @@ const sampleColumns = [
 
 /**
  * Display a sortable table of the given sample objects.
+ *
+ * @param {{
+ *   samples: object[],
+ *   reportLink?: string | null,
+ *   reportLabel?: string | null,
+ *   title?: string,
+ *   panelId?: string,
+ *   isConstructLibraryColumnVisible?: boolean,
+ *   isDeletedVisible?: boolean,
+ * }} props
  */
 export default function SampleTable({
   samples,

--- a/components/treatment-table.js
+++ b/components/treatment-table.js
@@ -36,6 +36,15 @@ const treatmentColumns = [
 
 /**
  * Display a sortable table of the given treatments.
+ *
+ * @param {{
+ *   treatments: object[],
+ *   reportLink?: string | null,
+ *   reportLabel?: string | null,
+ *   title?: string,
+ *   isDeletedVisible?: boolean,
+ *   panelId?: string,
+ * }} props
  */
 export default function TreatmentTable({
   treatments,

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,5 +1,6 @@
-import { type InstitutionalCertificateObject } from "./lib/data-use-limitation";
+// lib
 import { type QualityMetricObject } from "./lib/quality-metric";
+import { type BiosampleObject, type SampleObject } from "./lib/samples";
 import { type WorkflowObject } from "./lib/workflow";
 
 /**
@@ -483,11 +484,14 @@ export type RelatedDonorObject = {
   relationship_type: string;
 };
 
-export interface HumanDonorObject extends DatabaseObject {
+export interface DonorObject extends DatabaseObject {
   aliases?: string[];
   dbxrefs?: string[];
   description?: string;
   documents: string[] | DocumentObject[];
+}
+
+export interface HumanDonorObject extends DonorObject {
   ethnicities?: string[];
   human_donor_identifiers?: string[];
   notes?: string;
@@ -500,23 +504,36 @@ export interface HumanDonorObject extends DatabaseObject {
   virtual?: boolean;
 }
 
-/**
- * Data structure common to all sample object types.
- */
-export interface SampleObject extends DatabaseObject {
+export interface SourceObject extends DatabaseObject {
   aliases?: string[];
-  collections?: string[];
-  barcode_map?: string | FileObject;
-  dbxrefs?: string[];
-  institutional_certificates?: string[] | InstitutionalCertificateObject[];
-  name?: string;
+  description?: string;
+  name: string;
   notes?: string;
-  study_sets?: string[];
-  submitter_comment?: string;
   summary?: string;
-  taxa?: string;
   title?: string;
-  transcriptome_annotation?: string;
+}
+
+export interface TreatmentObject extends DatabaseObject {
+  amount?: number;
+  amount_units?: string;
+  biosamples_treated?: string[] | BiosampleObject[];
+  depletion: boolean;
+  description?: string;
+  duration?: number;
+  duration_units?: string;
+  notes?: string;
+  pH?: number;
+  post_treatment_time?: number;
+  post_treatment_time_units?: string;
+  product_id?: string;
+  purpose: string;
+  sources?: string[] | (SourceObject | LabObject)[];
+  summary?: string;
+  temperature?: number;
+  temperature_units?: string;
+  treatment_term_id?: string;
+  treatment_term_name: string;
+  treatment_type: string;
 }
 
 export interface OntologyTermObject extends DatabaseObject {
@@ -693,4 +710,14 @@ export interface ApiObject extends DataProviderObject {
  */
 export interface ApiErrorObject {
   error: string;
+}
+
+export interface BiomarkerObject extends DatabaseObject {
+  aliases?: string[];
+  description?: string;
+  name: string;
+  name_quantification?: string;
+  notes?: string;
+  quantification: string;
+  summary?: string;
 }

--- a/lib/common-requests.ts
+++ b/lib/common-requests.ts
@@ -1,17 +1,24 @@
 // lib
+import { type InstitutionalCertificateObject } from "./data-use-limitation";
 import { trimDeprecatedFiles } from "./deprecated-files";
 import FetchRequest from "./fetch-request";
 import { type DatasetSummary } from "./home";
+import { type BiosampleObject, type SampleObject } from "./samples";
 // root
 import type {
   AnalysisStepVersionObject,
+  BiomarkerObject,
   DatabaseObject,
   DataProviderObject,
+  DocumentObject,
+  DonorObject,
   FileObject,
   FileSetObject,
   LabObject,
-  SampleObject,
+  OntologyTermObject,
+  PublicationObject,
   SessionPropertiesObject,
+  TreatmentObject,
   UserObject,
 } from "../globals";
 
@@ -86,16 +93,17 @@ export async function requestAwards(
 
 /**
  * Retrieve the biomarker objects for the given biosample paths from the data provider.
- * @param {Array<string>} paths Paths to the biomarker objects to request
- * @param {FetchRequest} request The request object to use to make the request
- * @returns {Array<object>} The biomarker objects requested
+ *
+ * @param paths - Paths to the biomarker objects to request
+ * @param request - The request object to use to make the request
+ * @returns The biomarker objects requested
  */
 export async function requestBiomarkers(
   paths: Array<string>,
   request: FetchRequest
-): Promise<Array<DataProviderObject>> {
+): Promise<BiomarkerObject[]> {
   return (
-    await request.getMultipleObjectsBulk(
+    await request.getMultipleObjectsBulk<BiomarkerObject>(
       paths,
       [
         "aliases",
@@ -119,9 +127,9 @@ export async function requestBiomarkers(
 export async function requestBiosamples(
   paths: Array<string>,
   request: FetchRequest
-): Promise<Array<DataProviderObject>> {
+): Promise<Array<BiosampleObject>> {
   return (
-    await request.getMultipleObjectsBulk(
+    await request.getMultipleObjectsBulk<BiosampleObject>(
       paths,
       ["accession", "disease_terms", "sample_terms", "status", "summary"],
       ["Biosample"]
@@ -250,9 +258,9 @@ export async function requestFileSets(
   paths: string[],
   request: FetchRequest,
   addedProperties: string[] = []
-): Promise<Array<DataProviderObject>> {
+): Promise<FileSetObject[]> {
   return (
-    await request.getMultipleObjectsBulk(
+    await request.getMultipleObjectsBulk<FileSetObject>(
       paths,
       [
         "@type",
@@ -279,9 +287,9 @@ export async function requestFileSets(
 export async function requestDocuments(
   paths: Array<string>,
   request: FetchRequest
-): Promise<Array<DataProviderObject>> {
+): Promise<Array<DocumentObject>> {
   return (
-    await request.getMultipleObjectsBulk(
+    await request.getMultipleObjectsBulk<DocumentObject>(
       paths,
       [
         "attachment",
@@ -299,14 +307,14 @@ export async function requestDocuments(
  * Retrieve the donor objects for the given donor paths from the data provider.
  * @param {Array<string>} paths Paths to the donor objects to request
  * @param {FetchRequest} request The request object to use to make the request
- * @returns {Array<object>} The donor objects requested
+ * @returns {Array<DonorObject>} The donor objects requested
  */
 export async function requestDonors(
   paths: Array<string>,
   request: FetchRequest
-): Promise<Array<DataProviderObject>> {
+): Promise<Array<DonorObject>> {
   return (
-    await request.getMultipleObjectsBulk(
+    await request.getMultipleObjectsBulk<DonorObject>(
       paths,
       [
         "accession",
@@ -339,16 +347,17 @@ export async function requestGenes(
 
 /**
  * Retrieves the institutional-certificate objects for the given paths from the data provider.
- * @param {string[]} paths Paths to the institutional-certificate objects to request
- * @param {FetchRequest} request The request object to use to make the request
- * @returns {DataProviderObject[]} The institutional-certificate objects requested
+ *
+ * @param paths - Paths to the institutional-certificate objects to request
+ * @param request - The request object to use to make the request
+ * @returns The institutional-certificate objects requested
  */
 export async function requestInstitutionalCertificates(
   paths: string[],
   request: FetchRequest
-): Promise<DataProviderObject[]> {
+): Promise<InstitutionalCertificateObject[]> {
   return (
-    await request.getMultipleObjectsBulk(
+    await request.getMultipleObjectsBulk<InstitutionalCertificateObject>(
       paths,
       [
         "certificate_identifier",
@@ -371,9 +380,9 @@ export async function requestInstitutionalCertificates(
 export async function requestOntologyTerms(
   paths: Array<string>,
   request: FetchRequest
-): Promise<Array<DataProviderObject>> {
+): Promise<Array<OntologyTermObject>> {
   return (
-    await request.getMultipleObjectsBulk(
+    await request.getMultipleObjectsBulk<OntologyTermObject>(
       paths,
       ["term_id", "term_name"],
       ["OntologyTerm"]
@@ -411,16 +420,17 @@ export async function requestPhenotypicFeatures(
 
 /**
  * Retrieve the samples objects for the given sample paths from the data provider.
- * @param {Array<string>} paths Paths to the samples objects to request
- * @param {FetchRequest} request The request object to use to make the request
- * @returns {Array<object>} The samples objects requested
+ *
+ * @param paths - Paths to the samples objects to request
+ * @param request - The request object to use to make the request
+ * @returns The samples objects requested
  */
 export async function requestSamples(
   paths: Array<string>,
   request: FetchRequest
-): Promise<Array<DataProviderObject>> {
+): Promise<SampleObject[]> {
   return (
-    await request.getMultipleObjectsBulk(
+    await request.getMultipleObjectsBulk<SampleObject>(
       paths,
       [
         "accession",
@@ -486,16 +496,17 @@ export async function requestSoftwareVersions(
 
 /**
  * Retrieve the treatments objects for the given paths from the data provider.
- * @param {Array<string>} paths Paths to the treatment objects to request
- * @param {FetchRequest} request The request object to use to make the request
- * @returns {Array<object>} The treatment objects requested
+ *
+ * @param paths - Paths to the treatment objects to request
+ * @param request - The request object to use to make the request
+ * @returns The treatment objects requested
  */
 export async function requestTreatments(
-  paths: Array<string>,
+  paths: string[],
   request: FetchRequest
-): Promise<Array<DataProviderObject>> {
+): Promise<TreatmentObject[]> {
   return (
-    await request.getMultipleObjectsBulk(
+    await request.getMultipleObjectsBulk<TreatmentObject>(
       paths,
       ["purpose", "status", "summary", "treatment_term_name", "treatment_type"],
       ["Treatment"]
@@ -581,16 +592,17 @@ export async function requestWorkflows(
 
 /**
  * Retrieve the publication objects for the given paths from the data provider.
- * @param paths Paths to the publication objects to request
- * @param request The request object to use to make the request
+ *
+ * @param paths - Paths to the publication objects to request
+ * @param request - The request object to use to make the request
  * @returns The publication objects requested, or an empty array if none found
  */
 export async function requestPublications(
   paths: string[],
   request: FetchRequest
-): Promise<DataProviderObject[]> {
+): Promise<PublicationObject[]> {
   return (
-    await request.getMultipleObjectsBulk(
+    await request.getMultipleObjectsBulk<PublicationObject>(
       paths,
       [
         "aliases",

--- a/lib/data-use-limitation.ts
+++ b/lib/data-use-limitation.ts
@@ -1,5 +1,7 @@
+// lib
+import { type SampleObject } from "./samples";
 // root
-import type { DatabaseObject, SampleObject } from "../globals";
+import type { DatabaseObject } from "../globals";
 
 /**
  * Institutional certificate object type.

--- a/lib/database-object.ts
+++ b/lib/database-object.ts
@@ -1,3 +1,5 @@
+// lib
+import { type SampleObject } from "./samples";
 // root
 import {
   AnalysisStepObject,
@@ -13,7 +15,6 @@ import {
   OntologyTermObject,
   PageObject,
   PublicationObject,
-  SampleObject,
   SoftwareObject,
   SoftwareVersionObject,
   UserObject,

--- a/lib/fetch-request.ts
+++ b/lib/fetch-request.ts
@@ -589,16 +589,17 @@ export default class FetchRequest {
 
   /**
    * Request the object with the given path.
-   * @param {string} path Path to requested resource
-   * @param {object} options? indicating request options
-   * @param {boolean} options.isDbRequest True to get data from database instead of search engine
-   * @returns {Promise<DataProviderObject|ErrorObject>} Requested object, error object, or
-   *  `defaultErrorValue` if given and the request fails
+   *
+   * @param path - Path to requested resource
+   * @param options? - indicating request options
+   * @param options.isDbRequest - True to get data from database instead of search engine
+   * @returns - Requested object, error object, or `defaultErrorValue` if given and the request
+   *            fails
    */
-  public async getObject(
+  public async getObject<T extends DataProviderObject = DataProviderObject>(
     path: string,
     options = { isDbRequest: false }
-  ): Promise<Result<DataProviderObject, ErrorObject>> {
+  ): Promise<Result<T, ErrorObject>> {
     const url = this.pathUrl(path, options.isDbRequest);
     const headerOptions = this.buildOptionsWithAgent(url, "GET", {
       accept: PAYLOAD_FORMAT.JSON,
@@ -613,7 +614,7 @@ export default class FetchRequest {
         } as ErrorObject;
         return err(error);
       }
-      const results = (await response.json()) as DataProviderObject;
+      const results = (await response.json()) as T;
       return ok(results);
     } catch (error) {
       console.log("NETWORK ERROR: ", error);
@@ -667,24 +668,27 @@ export default class FetchRequest {
    * Request a number of objects with the given paths, returning each path's resource in an array
    * in the same order as their paths in the given array. Any paths that result in an error
    * get placed that array entry.
-   * @param {array} paths Array of paths to requested resources
-   * @param {object} options? Options for these requests
-   * @param {boolean} options.filterErrors True to filter errored requests from the returned array
-   * @returns {Promise<Array<DataProviderObject|ErrorObject|T>>} Array of requested objects
+   *
+   * @param paths - Array of paths to requested resources
+   * @param options - Options for these requests
+   * @param options.filterErrors - True to filter errored requests from the returned array
+   * @returns Array of requested objects
    */
-  public async getMultipleObjects(
-    paths: Array<string>,
+  public async getMultipleObjects<
+    T extends DataProviderObject = DataProviderObject,
+  >(
+    paths: string[],
     options = { filterErrors: false }
-  ): Promise<Array<Result<DataProviderObject, ErrorObject>>> {
+  ): Promise<Array<Result<T, ErrorObject>>> {
     logRequest(
       "getMultipleObjects",
       `[${paths.join(", ")}]`,
       this.usingPersistentConnections
     );
-    const results =
+    const results: Array<Result<T, ErrorObject>> =
       paths.length > 0
-        ? await Promise.all(paths.map((path) => this.getObject(path)))
-        : await Promise.resolve([]);
+        ? await Promise.all(paths.map(async (path) => this.getObject<T>(path)))
+        : [];
 
     return options.filterErrors
       ? results.filter((result) => result.isOk())
@@ -699,16 +703,19 @@ export default class FetchRequest {
    * request. Unlike `getMultipleObjects()`, this method never returns an array that could contain
    * entries for failed requests. It instead either returns an array of successfully requested
    * objects, or a single error value.
-   * @param {Array<string>} paths Path of each object to request
-   * @param {Array<string>} fields Properties of each object to retrieve; if none; all properties
-   * @param {string} type? Type of objects to request; if given, adds `type=` to the query string
-   * @returns {Promise<Result<Array<DataProviderObject>, ErrorObject>>} Array of requested objects
+   *
+   * @param paths - Path of each object to request
+   * @param fields - Properties of each object to retrieve; if none; all properties
+   * @param types - Type of objects to request; if given, adds `type=` to the query string
+   * @returns {Promise<Result<Array<T>, ErrorObject>>} Array of requested objects
    */
-  async getMultipleObjectsBulk(
+  async getMultipleObjectsBulk<
+    T extends DataProviderObject = DataProviderObject,
+  >(
     paths: Array<string>,
     fields: Array<string>,
     types: string[] = []
-  ): Promise<Result<Array<DataProviderObject>, ErrorObject>> {
+  ): Promise<Result<T[], ErrorObject>> {
     logRequest(
       "getMultipleObjectsBulk",
       `types:${types.join()} [${paths.join(", ")}]`,
@@ -743,7 +750,7 @@ export default class FetchRequest {
         const response = await this.getObject(
           `/search-quick/?${typeQuery}${query}&limit=${group.length}`
         );
-        return response.map((g) => g["@graph"] as Array<DataProviderObject>);
+        return response.map((g) => g["@graph"] as T[]);
       })
     );
 
@@ -753,9 +760,8 @@ export default class FetchRequest {
       return firstError;
     }
 
-    // We know that all the Results in the results list are Ok
-    // so we can safely turn them all into Array<DataProviderObject>
-    // Return the the flattened list wrapped in an Ok
+    // We know that all the Results in the results list are Ok so we can safely turn them all into
+    // Array<T>. Return the the flattened list wrapped in an Ok
     return ok(Ok.all(results).flat());
   }
 

--- a/lib/files.ts
+++ b/lib/files.ts
@@ -12,12 +12,12 @@ import {
   type RowComponentProps,
 } from "./data-grid";
 import type FetchRequest from "./fetch-request";
+import { type SampleObject } from "./samples";
 // root
 import type {
   DatabaseObject,
   FileObject,
   FileSetObject,
-  SampleObject,
   UploadStatus,
 } from "../globals.d";
 
@@ -152,7 +152,7 @@ async function getFileDerivedFromFiles(
 
   // Collect all derived_from file paths from `files`.
   let derivedFromPaths = files.reduce((acc: string[], file) => {
-    return file.derived_from?.length > 0 ? acc.concat(file.derived_from) : acc;
+    return acc.concat(file.derived_from ?? []);
   }, []);
 
   // Deduplicate the paths.
@@ -250,9 +250,9 @@ export function checkFileDownloadable(
   file: FileObject,
   viewingGroups: string[] = []
 ): boolean {
-  const isDownloadDisabledByStatus = nonDownloadableStatuses.has(
-    file.upload_status
-  );
+  const isDownloadDisabledByStatus = file.upload_status
+    ? nonDownloadableStatuses.has(file.upload_status)
+    : false;
   const isDownloadDisabledByControlledAccess =
     file.controlled_access && !viewingGroups.includes("IGVF");
   return (
@@ -296,7 +296,7 @@ function checkSampleIsObjectArray(
 export function collectFileFileSetSamples(files: FileObject): SampleObject[] {
   // Collect all samples from the file set of the file.
   const samples: SampleObject[] = [];
-  if (checkFileSetIsObject(files.file_set)) {
+  if (checkFileSetIsObject(files.file_set) && files.file_set.samples) {
     if (checkSampleIsObjectArray(files.file_set.samples)) {
       samples.push(...files.file_set.samples);
     }
@@ -469,7 +469,7 @@ export function extractSeqspecsForFile(
   seqspecs: FileObject[]
 ): FileObject[] {
   let matchingSeqspecs: FileObject[] = [];
-  if (file.seqspecs?.length > 0) {
+  if (file.seqspecs && file.seqspecs.length > 0) {
     const fileSeqspecPaths =
       typeof file.seqspecs[0] === "string"
         ? (file.seqspecs as string[])

--- a/lib/modifications.ts
+++ b/lib/modifications.ts
@@ -1,0 +1,40 @@
+// lib
+// Note: circular import type with ./samples.ts. This is a deliberate, safe choice.
+import { type BiosampleObject } from "./samples";
+import { type LinkTo } from "./types";
+// root
+import type {
+  DatabaseObject,
+  DocumentObject,
+  GeneObject,
+  LabObject,
+  SourceObject,
+} from "../globals";
+
+export interface ModificationObject extends DatabaseObject {
+  activated?: boolean;
+  activating_agent_term_id?: string;
+  activating_agent_term_name?: string;
+  aliases?: string[];
+  biosamples_modified?: LinkTo<BiosampleObject>[];
+  description?: string;
+  documents?: LinkTo<DocumentObject>[];
+  lot_id?: string;
+  modality: string;
+  notes?: string;
+  product_id?: string;
+  sources?: LinkTo<SourceObject | LabObject>[];
+  summary?: string;
+}
+
+export interface DegronModificationObject extends ModificationObject {
+  degron_system: string;
+  tagged_proteins: LinkTo<GeneObject>[];
+}
+
+export interface CrisprModificationObject extends ModificationObject {
+  cas: string;
+  cas_species: string;
+  fused_domain?: string;
+  tagged_proteins?: LinkTo<GeneObject>[];
+}

--- a/lib/samples.ts
+++ b/lib/samples.ts
@@ -1,0 +1,73 @@
+// lib
+import { type InstitutionalCertificateObject } from "./data-use-limitation";
+// Note: circular import type with ./modifications.ts. This is a deliberate, safe choice.
+import { type ModificationObject } from "./modifications";
+import { type LinkTo } from "./types";
+
+// root
+import type {
+  BiomarkerObject,
+  DatabaseObject,
+  DocumentObject,
+  DonorObject,
+  FileObject,
+  FileSetObject,
+  LabObject,
+  OntologyTermObject,
+  PublicationObject,
+  SourceObject,
+  TreatmentObject,
+} from "../globals";
+
+export interface SampleObject extends DatabaseObject {
+  aliases?: string[];
+  barcode_map?: LinkTo<FileObject>;
+  biomarkers?: LinkTo<BiomarkerObject>[];
+  classifications?: string[];
+  collections?: string[];
+  construct_library_sets?: LinkTo<FileSetObject>[];
+  dbxrefs?: string[];
+  demultiplexed_to?: LinkTo<SampleObject>[];
+  disease_terms?: LinkTo<OntologyTermObject>[];
+  documents?: LinkTo<DocumentObject>[];
+  donors?: LinkTo<DonorObject>[];
+  file_sets?: LinkTo<FileSetObject>[];
+  institutional_certificates?: LinkTo<InstitutionalCertificateObject>[];
+  modifications?: LinkTo<ModificationObject>[];
+  multiplexed_in?: LinkTo<SampleObject>[];
+  name?: string;
+  notes?: string;
+  origin_of?: LinkTo<SampleObject>[];
+  part_of?: LinkTo<BiosampleObject>;
+  parts?: LinkTo<SampleObject>[];
+  publications?: LinkTo<PublicationObject>[];
+  sample_terms?: LinkTo<OntologyTermObject>[];
+  sorted_fractions?: LinkTo<SampleObject>[];
+  sources?: LinkTo<SourceObject | LabObject>[];
+  study_sets?: string[];
+  submitter_comment?: string;
+  summary?: string;
+  taxa?: string;
+  title?: string;
+  transcriptome_annotation?: string;
+  treatments?: LinkTo<TreatmentObject>[];
+}
+
+export interface BiosampleObject extends SampleObject {
+  annotated_from?: LinkTo<SampleObject>;
+  biosample_qualifiers?: string[];
+  pooled_from?: LinkTo<BiosampleObject>[];
+  pooled_in?: LinkTo<BiosampleObject>[];
+}
+
+export interface InVitroSystemObject extends BiosampleObject {
+  cell_fate_change_protocol?: LinkTo<DocumentObject>;
+  demultiplexed_from?: LinkTo<SampleObject>;
+  growth_medium?: string;
+  passage_number?: number;
+  targeted_sample_term?: LinkTo<OntologyTermObject>;
+  time_post_change?: number;
+  time_post_change_units?: string;
+  time_post_culture?: number;
+  time_post_culture_units?: string;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Use this type to represent a property that can either be a link to another object (represented
+ * as a string) or an embedded object itself (represented as a generic type T). This is useful for
+ * handling cases where an API might return either a reference to another resource or the full
+ * resource data.
+ */
+export type LinkTo<T> = string | T;
+
+/**
+ * Type guard to check if a LinkTo<T> value is a string (i.e., a link) or an embedded object (T).
+ *
+ * @param value - Object property to check if it is a link (string)
+ * @returns True if the property is a link (string), false if it is an embedded object (T).
+ */
+export function isPath<T>(value: LinkTo<T>): value is string {
+  return typeof value === "string";
+}
+
+/**
+ * Type guard to check if a LinkTo<T> value is an array of links (strings) rather than an array of
+ * embedded objects (T). This is useful for properties that can be arrays of either links or
+ * embedded objects.
+ *
+ * @param value - Object property to check if it's an array of links (string)
+ * @returns True if the property is an array of links (strings)
+ */
+export function isPathArray<T>(
+  value: LinkTo<T>[] | undefined | null
+): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+/**
+ * Type guard to check if a LinkTo<T> value is an embedded object (T) rather than a string (i.e., a
+ * link).
+ *
+ * @param value - Object property to check if it is an embedded object (T)
+ * @returns True if the property is an embedded object (T), false if it is a link (string).
+ */
+export function isEmbedded<T extends object>(value: LinkTo<T>): value is T {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Type guard to check if a LinkTo<T> value is an array of embedded objects (T) rather than an array of
+ * links (strings). This is useful for properties that can be arrays of either links or embedded objects.
+ *
+ * @param value - Object property to check if it's an array of embedded objects (T)
+ * @returns True if the property is an array of embedded objects (T)
+ */
+export function isEmbeddedArray<T extends object>(
+  value: LinkTo<T>[] | undefined | null
+): value is T[] {
+  return (
+    Array.isArray(value) &&
+    value.every((item) => typeof item === "object" && item !== null)
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tailwindcss/container-queries": "^0.1.1",
         "@types/diff": "^8.0.0",
         "@types/node": "^24.0.13",
+        "@types/pako": "^2.0.4",
         "@types/papaparse": "^5.3.15",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
@@ -168,6 +169,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -707,6 +709,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -728,6 +731,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1975,6 +1979,7 @@
       "version": "9.7.5",
       "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.5.tgz",
       "integrity": "sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==",
+      "peer": true,
       "dependencies": {
         "@react-spring/animated": "~9.7.5",
         "@react-spring/core": "~9.7.5",
@@ -2028,6 +2033,7 @@
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
       "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -2446,7 +2452,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2459,7 +2464,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -2473,8 +2477,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -2564,8 +2567,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2869,6 +2871,12 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/papaparse": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.2.tgz",
@@ -2977,6 +2985,7 @@
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.4.0.tgz",
       "integrity": "sha512-yHMQ/oFaM7HZdVrVm/M2WHaNPgyuJH4WelkSVEWSSsir34kxW2kDJCxlXRhhGWEsMN0WAW/vLpKfKVcm8k+MPw==",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
         "@typescript-eslint/scope-manager": "7.4.0",
@@ -3011,6 +3020,7 @@
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.4.0.tgz",
       "integrity": "sha512-ZvKHxHLusweEUVwrGRXXUVzFgnWhigo4JurEj0dGF1tbcGh6buL+ejDdjxOQxv6ytcY1uhun1p2sm8iWStlgLQ==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.4.0",
         "@typescript-eslint/types": "7.4.0",
@@ -4251,6 +4261,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4910,6 +4921,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6009,6 +6021,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6230,6 +6243,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -6432,8 +6446,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -6552,6 +6565,7 @@
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -6773,6 +6787,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
       "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7059,6 +7074,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9278,6 +9294,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10849,7 +10866,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11744,6 +11760,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11912,6 +11929,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -12031,6 +12049,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -12073,6 +12092,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -13250,7 +13270,8 @@
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -13337,6 +13358,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13622,6 +13644,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@tailwindcss/container-queries": "^0.1.1",
     "@types/diff": "^8.0.0",
     "@types/node": "^24.0.13",
+    "@types/pako": "^2.0.4",
     "@types/papaparse": "^5.3.15",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",

--- a/pages/in-vitro-systems/[id].tsx
+++ b/pages/in-vitro-systems/[id].tsx
@@ -1,5 +1,5 @@
-// node_modules
-import PropTypes from "prop-types";
+// root
+import { type GetServerSidePropsContext } from "next";
 // components
 import { AlternativeIdentifiers } from "../../components/alternative-identifiers";
 import Attribution from "../../components/attribution";
@@ -27,7 +27,7 @@ import { useSecDir } from "../../components/section-directory";
 import { StatusPreviewDetail } from "../../components/status";
 import TreatmentTable from "../../components/treatment-table";
 // lib
-import buildAttribution from "../../lib/attribution";
+import buildAttribution, { type AttributionData } from "../../lib/attribution";
 import { createCanonicalUrlRedirect } from "../../lib/canonical-redirect";
 import {
   requestBiomarkers,
@@ -43,11 +43,34 @@ import {
   requestTreatments,
 } from "../../lib/common-requests";
 import { UC } from "../../lib/constants";
+import { type InstitutionalCertificateObject } from "../../lib/data-use-limitation";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import { truthyOrZero } from "../../lib/general";
 import { isJsonFormat } from "../../lib/query-utils";
 import { Ok } from "../../lib/result";
+import type {
+  BiosampleObject,
+  InVitroSystemObject,
+  SampleObject,
+} from "../../lib/samples";
+import {
+  isEmbedded,
+  isEmbeddedArray,
+  isPath,
+  isPathArray,
+} from "../../lib/types";
+// root
+import type {
+  BiomarkerObject,
+  DocumentObject,
+  DonorObject,
+  FileSetObject,
+  LabObject,
+  OntologyTermObject,
+  PublicationObject,
+  SourceObject,
+  TreatmentObject,
+} from "../../globals";
 
 export default function InVitroSystem({
   inVitroSystem,
@@ -73,8 +96,34 @@ export default function InVitroSystem({
   institutionalCertificates,
   supersedes,
   supersededBy,
-  attribution = null,
+  attribution,
   isJson,
+}: {
+  inVitroSystem: InVitroSystemObject;
+  cellFateProtocol: DocumentObject | null;
+  constructLibrarySets: FileSetObject[];
+  demultiplexedFrom: SampleObject | null;
+  demultiplexedTo: SampleObject[];
+  diseaseTerms: OntologyTermObject[];
+  annotatedFrom: BiosampleObject | null;
+  documents: DocumentObject[];
+  donors: DonorObject[];
+  originOf: SampleObject[];
+  partOf: BiosampleObject | null;
+  parts: BiosampleObject[];
+  pooledFrom: BiosampleObject[];
+  pooledIn: BiosampleObject[];
+  publications: PublicationObject[];
+  sortedFractions: SampleObject[];
+  sources: (SourceObject | LabObject)[];
+  treatments: TreatmentObject[];
+  biomarkers: BiomarkerObject[];
+  multiplexedInSamples: SampleObject[];
+  institutionalCertificates: InstitutionalCertificateObject[];
+  supersedes: SampleObject[];
+  supersededBy: SampleObject[];
+  attribution?: AttributionData;
+  isJson: boolean;
 }) {
   const sections = useSecDir({ isJson });
 
@@ -99,16 +148,16 @@ export default function InVitroSystem({
                 constructLibrarySets={constructLibrarySets}
                 diseaseTerms={diseaseTerms}
                 annotatedFrom={annotatedFrom}
-                parts={parts}
                 partOf={partOf}
                 publications={publications}
-                sampleTerms={inVitroSystem.sample_terms}
+                sampleTerms={
+                  isEmbeddedArray(inVitroSystem.sample_terms)
+                    ? inVitroSystem.sample_terms
+                    : []
+                }
                 sources={sources}
-                options={{
-                  dateObtainedTitle: "Date Collected",
-                }}
               >
-                {inVitroSystem.targeted_sample_term && (
+                {isEmbedded(inVitroSystem.targeted_sample_term) && (
                   <>
                     <DataItemLabel>Targeted Sample Term</DataItemLabel>
                     <DataItemValue>
@@ -118,7 +167,7 @@ export default function InVitroSystem({
                     </DataItemValue>
                   </>
                 )}
-                {truthyOrZero(inVitroSystem.passage_number) && (
+                {inVitroSystem.passage_number !== undefined && (
                   <>
                     <DataItemLabel>Passage Number</DataItemLabel>
                     <DataItemValue>
@@ -126,14 +175,25 @@ export default function InVitroSystem({
                     </DataItemValue>
                   </>
                 )}
-                {truthyOrZero(inVitroSystem.time_post_change) && (
+                {inVitroSystem.time_post_change !== undefined && (
                   <>
                     <DataItemLabel>Time Post Change</DataItemLabel>
                     <DataItemValue>
                       {inVitroSystem.time_post_change}{" "}
-                      {inVitroSystem.time_post_change > 1
-                        ? `${inVitroSystem.time_post_change_units}s`
-                        : inVitroSystem.time_post_change_units}
+                      {inVitroSystem.time_post_change === 1
+                        ? inVitroSystem.time_post_change_units
+                        : `${inVitroSystem.time_post_change_units}s`}
+                    </DataItemValue>
+                  </>
+                )}
+                {inVitroSystem.time_post_culture !== undefined && (
+                  <>
+                    <DataItemLabel>Time Post Culture</DataItemLabel>
+                    <DataItemValue>
+                      {inVitroSystem.time_post_culture}{" "}
+                      {inVitroSystem.time_post_culture === 1
+                        ? inVitroSystem.time_post_culture_units
+                        : `${inVitroSystem.time_post_culture_units}s`}
                     </DataItemValue>
                   </>
                 )}
@@ -164,11 +224,11 @@ export default function InVitroSystem({
                   </>
                 )}
               </BiosampleDataItems>
-              <Attribution attribution={attribution} />
+              <Attribution attribution={attribution ?? null} />
             </DataArea>
           </DataPanel>
           {donors.length > 0 && <DonorTable donors={donors} />}
-          {inVitroSystem.file_sets?.length > 0 && (
+          {isEmbeddedArray(inVitroSystem.file_sets) && (
             <FileSetTable fileSets={inVitroSystem.file_sets} />
           )}
           {multiplexedInSamples.length > 0 && (
@@ -226,7 +286,7 @@ export default function InVitroSystem({
               panelId="origin-of"
             />
           )}
-          {inVitroSystem.modifications?.length > 0 && (
+          {isEmbeddedArray(inVitroSystem.modifications) && (
             <ModificationTable modifications={inVitroSystem.modifications} />
           )}
           {sortedFractions.length > 0 && (
@@ -268,66 +328,20 @@ export default function InVitroSystem({
   );
 }
 
-InVitroSystem.propTypes = {
-  // In Vitro System sample to display
-  inVitroSystem: PropTypes.object.isRequired,
-  // Biomarkers of the sample
-  biomarkers: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Cell Fate Change Protocols of the sample
-  cellFateProtocol: PropTypes.object,
-  // Construct libraries that link to this object
-  constructLibrarySets: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Demultiplexed from sample
-  demultiplexedFrom: PropTypes.object,
-  // Demultiplexed to sample
-  demultiplexedTo: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Disease ontology for this sample
-  diseaseTerms: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Annotated from sample
-  annotatedFrom: PropTypes.object,
-  // Documents associated with the sample
-  documents: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Donors associated with the sample
-  donors: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Origin of sample
-  originOf: PropTypes.arrayOf(PropTypes.object),
-  // Part of Sample
-  partOf: PropTypes.object,
-  // Sample parts
-  parts: PropTypes.arrayOf(PropTypes.object),
-  // Pooled from sample
-  pooledFrom: PropTypes.arrayOf(PropTypes.object),
-  // Pooled in sample
-  pooledIn: PropTypes.arrayOf(PropTypes.object),
-  // Publications associated with the sample
-  publications: PropTypes.arrayOf(PropTypes.object),
-  // Sorted fractions sample
-  sortedFractions: PropTypes.arrayOf(PropTypes.object),
-  // Source lab or source for this sample
-  sources: PropTypes.arrayOf(PropTypes.object),
-  // Treatments of the sample
-  treatments: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Multiplexed in samples
-  multiplexedInSamples: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Institutional certificates referencing this sample
-  institutionalCertificates: PropTypes.arrayOf(PropTypes.object),
-  // Samples that this sample supersedes
-  supersedes: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Samples that supersede this sample
-  supersededBy: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Attribution for this sample
-  attribution: PropTypes.object,
-  // Is the format JSON?
-  isJson: PropTypes.bool.isRequired,
-};
-
-export async function getServerSideProps({ params, req, query, resolvedUrl }) {
+export async function getServerSideProps({
+  params,
+  req,
+  query,
+  resolvedUrl,
+}: GetServerSidePropsContext) {
   const isJson = isJsonFormat(query);
   const request = new FetchRequest({ cookie: req.headers.cookie });
-  const inVitroSystem = (
+  const response = (
     await request.getObject(`/in-vitro-systems/${params.id}/`)
   ).union();
-  if (FetchRequest.isResponseSuccess(inVitroSystem)) {
+  if (FetchRequest.isResponseSuccess(response)) {
+    const inVitroSystem = response as InVitroSystemObject;
+
     const canonicalRedirect = createCanonicalUrlRedirect(
       inVitroSystem,
       resolvedUrl,
@@ -336,83 +350,87 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
     if (canonicalRedirect) {
       return canonicalRedirect;
     }
-
-    let biomarkers = [];
-    if (inVitroSystem.biomarkers?.length > 0) {
+    let biomarkers: BiomarkerObject[] = [];
+    if (isEmbeddedArray(inVitroSystem.biomarkers)) {
       const biomarkerPaths = inVitroSystem.biomarkers.map(
         (biomarker) => biomarker["@id"]
       );
       biomarkers = await requestBiomarkers(biomarkerPaths, request);
     }
-    let cellFateProtocol = null;
-    if (inVitroSystem.cell_fate_change_protocol) {
+    let cellFateProtocol: DocumentObject | null = null;
+    if (isPath(inVitroSystem.cell_fate_change_protocol)) {
       cellFateProtocol = (
-        await request.getObject(inVitroSystem.cell_fate_change_protocol)
+        await request.getObject<DocumentObject>(
+          inVitroSystem.cell_fate_change_protocol
+        )
       ).optional();
     }
-    const demultiplexedFrom = inVitroSystem.demultiplexed_from
-      ? (await request.getObject(inVitroSystem.demultiplexed_from)).optional()
+    const demultiplexedFrom = isPath(inVitroSystem.demultiplexed_from)
+      ? (
+          await request.getObject<SampleObject>(
+            inVitroSystem.demultiplexed_from
+          )
+        ).optional()
       : null;
-    const demultiplexedTo =
-      inVitroSystem.demultiplexed_to?.length > 0
-        ? await requestBiosamples(inVitroSystem.demultiplexed_to, request)
-        : [];
-    let diseaseTerms = [];
-    if (inVitroSystem.disease_terms) {
+    const demultiplexedTo = isPathArray(inVitroSystem.demultiplexed_to)
+      ? await requestBiosamples(inVitroSystem.demultiplexed_to, request)
+      : [];
+    let diseaseTerms: OntologyTermObject[] = [];
+    if (isEmbeddedArray(inVitroSystem.disease_terms)) {
       const diseaseTermPaths = inVitroSystem.disease_terms.map(
         (diseaseTerm) => diseaseTerm["@id"]
       );
       diseaseTerms = await requestOntologyTerms(diseaseTermPaths, request);
     }
-    const documents = inVitroSystem.documents
+    const documents = isPathArray(inVitroSystem.documents)
       ? await requestDocuments(inVitroSystem.documents, request)
       : [];
-    let donors = [];
-    if (inVitroSystem.donors?.length > 0) {
+    let donors: DonorObject[] = [];
+    if (isEmbeddedArray(inVitroSystem.donors)) {
       const donorPaths = inVitroSystem.donors.map((donor) => donor["@id"]);
       donors = await requestDonors(donorPaths, request);
     }
-    const partOf = inVitroSystem.part_of
-      ? (await request.getObject(inVitroSystem.part_of)).optional()
+    const partOf = isPath(inVitroSystem.part_of)
+      ? (
+          await request.getObject<BiosampleObject>(inVitroSystem.part_of)
+        ).optional()
       : null;
-    const parts =
-      inVitroSystem.parts?.length > 0
-        ? await requestBiosamples(inVitroSystem.parts, request)
-        : [];
-    const pooledFrom =
-      inVitroSystem.pooled_from?.length > 0
-        ? await requestBiosamples(inVitroSystem.pooled_from, request)
-        : [];
-    const pooledIn =
-      inVitroSystem.pooled_in?.length > 0
-        ? await requestBiosamples(inVitroSystem.pooled_in, request)
-        : [];
-    const originOf =
-      inVitroSystem.origin_of?.length > 0
-        ? await requestBiosamples(inVitroSystem.origin_of, request)
-        : [];
-    const sortedFractions =
-      inVitroSystem.sorted_fractions?.length > 0
-        ? await requestSamples(inVitroSystem.sorted_fractions, request)
-        : [];
-    let sources = [];
-    if (inVitroSystem.sources?.length > 0) {
+    const parts = isPathArray(inVitroSystem.parts)
+      ? await requestBiosamples(inVitroSystem.parts, request)
+      : [];
+    const pooledFrom = isPathArray(inVitroSystem.pooled_from)
+      ? await requestBiosamples(inVitroSystem.pooled_from, request)
+      : [];
+    const pooledIn = isPathArray(inVitroSystem.pooled_in)
+      ? await requestBiosamples(inVitroSystem.pooled_in, request)
+      : [];
+    const originOf = isPathArray(inVitroSystem.origin_of)
+      ? await requestBiosamples(inVitroSystem.origin_of, request)
+      : [];
+    const sortedFractions = isPathArray(inVitroSystem.sorted_fractions)
+      ? await requestSamples(inVitroSystem.sorted_fractions, request)
+      : [];
+    let sources: (SourceObject | LabObject)[] = [];
+    if (isEmbeddedArray(inVitroSystem.sources)) {
       const sourcePaths = inVitroSystem.sources.map((source) => source["@id"]);
       sources = Ok.all(
-        await request.getMultipleObjects(sourcePaths, {
-          filterErrors: true,
-        })
+        await request.getMultipleObjects<SourceObject | LabObject>(
+          sourcePaths,
+          {
+            filterErrors: true,
+          }
+        )
       );
     }
-    let treatments = [];
-    if (inVitroSystem.treatments?.length > 0) {
+    let treatments: TreatmentObject[] = [];
+    if (isEmbeddedArray(inVitroSystem.treatments)) {
       const treatmentPaths = inVitroSystem.treatments.map(
         (treatment) => treatment["@id"]
       );
       treatments = await requestTreatments(treatmentPaths, request);
     }
-    let constructLibrarySets = [];
-    if (inVitroSystem.construct_library_sets?.length > 0) {
+    let constructLibrarySets: FileSetObject[] = [];
+    if (isEmbeddedArray(inVitroSystem.construct_library_sets)) {
       const constructLibrarySetPaths = inVitroSystem.construct_library_sets.map(
         (constructLibrarySet) => constructLibrarySet["@id"]
       );
@@ -421,15 +439,15 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         request
       );
     }
-    let multiplexedInSamples = [];
-    if (inVitroSystem.multiplexed_in?.length > 0) {
+    let multiplexedInSamples: SampleObject[] = [];
+    if (isEmbeddedArray(inVitroSystem.multiplexed_in)) {
       const multiplexedInPaths = inVitroSystem.multiplexed_in.map(
         (sample) => sample["@id"]
       );
       multiplexedInSamples = await requestSamples(multiplexedInPaths, request);
     }
-    let institutionalCertificates = [];
-    if (inVitroSystem.institutional_certificates?.length > 0) {
+    let institutionalCertificates: InstitutionalCertificateObject[] = [];
+    if (isEmbeddedArray(inVitroSystem.institutional_certificates)) {
       const institutionalCertificatePaths =
         inVitroSystem.institutional_certificates.map(
           (institutionalCertificate) => institutionalCertificate["@id"]
@@ -439,11 +457,13 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         request
       );
     }
-    const annotatedFrom = inVitroSystem.annotated_from
-      ? (await request.getObject(inVitroSystem.annotated_from)).optional()
+    const annotatedFrom = isPath(inVitroSystem.annotated_from)
+      ? (
+          await request.getObject<BiosampleObject>(inVitroSystem.annotated_from)
+        ).optional()
       : null;
-    let publications = [];
-    if (inVitroSystem.publications?.length > 0) {
+    let publications: PublicationObject[] = [];
+    if (isEmbeddedArray(inVitroSystem.publications)) {
       const publicationPaths = inVitroSystem.publications.map(
         (publication) => publication["@id"]
       );
@@ -458,6 +478,13 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
       inVitroSystem,
       req.headers.cookie
     );
+
+    const sampleTermName =
+      isEmbeddedArray(inVitroSystem.sample_terms) &&
+      inVitroSystem.sample_terms.length > 0
+        ? (inVitroSystem.sample_terms[0].term_name ?? "no sample term")
+        : "no sample term";
+
     return {
       props: {
         inVitroSystem,
@@ -484,12 +511,12 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         supersedes,
         supersededBy,
         pageContext: {
-          title: `${inVitroSystem.accession} ${UC.mdash} ${inVitroSystem.sample_terms[0].term_name}`,
+          title: `${inVitroSystem.accession} ${UC.mdash} ${sampleTermName}`,
         },
         attribution,
         isJson,
       },
     };
   }
-  return errorObjectToProps(inVitroSystem);
+  return errorObjectToProps(response);
 }

--- a/pages/institutional-certificates/[...id].tsx
+++ b/pages/institutional-certificates/[...id].tsx
@@ -29,8 +29,9 @@ import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest, { type ErrorObject } from "../../lib/fetch-request";
 import PagePreamble from "../../components/page-preamble";
 import { isJsonFormat } from "../../lib/query-utils";
+import { type SampleObject } from "../../lib/samples";
 // root
-import type { LabObject, SampleObject, UserObject } from "../../globals";
+import type { LabObject, UserObject } from "../../globals";
 
 export default function InstitutionalCertificate({
   institutionalCertificate,
@@ -138,6 +139,14 @@ export async function getServerSideProps(
   context: GetServerSidePropsContext<Params>
 ) {
   const { req, query, params, resolvedUrl } = context;
+
+  // 404 if params or params.id is missing or empty
+  if (!params || !params.id || params.id.length === 0) {
+    return {
+      notFound: true,
+    };
+  }
+
   const isJson = isJsonFormat(query);
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const item = (
@@ -157,7 +166,8 @@ export async function getServerSideProps(
       item as unknown as InstitutionalCertificateObject;
 
     const samples =
-      institutionalCertificate.samples?.length > 0
+      institutionalCertificate.samples &&
+      institutionalCertificate.samples.length > 0
         ? await requestSamples(institutionalCertificate.samples, request)
         : [];
 
@@ -167,7 +177,7 @@ export async function getServerSideProps(
 
     const attribution = await buildAttribution(
       institutionalCertificate,
-      req.headers.cookie
+      req.headers.cookie || ""
     );
 
     return {


### PR DESCRIPTION
# Code Review — IGVF-3287-time-post-culture

_Reviewed by: GitHub Copilot (Claude Sonnet 4.6)_

---

## Summary

This branch adds `time_post_culture` / `time_post_culture_units` display to the In Vitro System page and, in doing so, converts `pages/in-vitro-systems/[id].js` from JavaScript (with PropTypes) to TypeScript. The type work is the larger part of the change: it introduces `lib/types.ts` (the `LinkTo<T>` utility type and four type guards), `lib/samples.ts` (typed `SampleObject`, `BiosampleObject`, `InVitroSystemObject`), and `lib/modifications.ts` (typed modification objects). It also adds proper generic type parameters to `FetchRequest.getObject`, `getMultipleObjects`, and `getMultipleObjectsBulk`, and tightens the return types of all `requestXxx` functions in `lib/common-requests.ts`.

---

## Issues

No issues found.

---

## Positive Notes

- The `LinkTo<T>` type and its four type guards (`isPath`, `isPathArray`, `isEmbedded`, `isEmbeddedArray`) in `lib/types.ts` are well-designed and well-documented. Using them consistently throughout `getServerSideProps` to distinguish path strings from embedded objects is a significant improvement over the previous `?.length > 0` pattern, which was both imprecise and unsafe for TypeScript narrowing.
- Adding generic type parameters to `getObject`, `getMultipleObjects`, and `getMultipleObjectsBulk` in `lib/fetch-request.ts` is a clean improvement — callers no longer receive bare `DataProviderObject` and have to cast at every use site.
- Splitting `DonorObject` from `HumanDonorObject` in `globals.d.ts` is the right structural move.
- Moving `SampleObject` to `lib/samples.ts` with the `LinkTo<T>` typing is strictly more accurate than the old `string | T` union spelling in `globals.d.ts`.
- `lib/samples.ts` and `lib/modifications.ts` have a circular `import type` dependency (`SampleObject` references `ModificationObject` and vice versa). This is intentional and safe — TypeScript erases all type imports before emit, so there is no runtime module cycle. Both files carry a comment explaining this.
- The component props type in `pages/in-vitro-systems/[id].tsx` correctly marks `cellFateProtocol`, `demultiplexedFrom`, `annotatedFrom`, and `partOf` as `T | null`, matching what `getServerSideProps` can actually return.
- The `time_post_culture` singular/plural units logic (`=== 1` rather than the original `> 1`) is correct. The original condition was backwards for the singular case.
- All numeric/optional fields on `InVitroSystemObject` (`passage_number`, `targeted_sample_term`, `time_post_change`, `time_post_change_units`, `time_post_culture`, `time_post_culture_units`) are typed as optional (`?`), matching the conditional rendering in the component.
- `sampleTermName` correctly guards against both a non-embedded `sample_terms` and an empty array before accessing `[0]`, with a `?? "no sample term"` fallback for a missing `term_name`.
- The defensive fixes in `lib/files.ts` (`upload_status` guard, `file_set.samples` guard, `seqspecs &&`) are correct narrowing improvements.
- `getServerSideProps` uses `import type { GetServerSidePropsContext }` from Next.js, consistent with the rest of the file.
- The `params` null guard added to `pages/institutional-certificates/[...id].tsx` is a proper defensive fix.
- `req.headers.cookie || ""` in `pages/institutional-certificates/[...id].tsx` correctly handles the case where the `cookie` header is absent.