### PR TITLE
IGVF-3333 Display analysis-step version on all file pages

### DIFF
--- a/components/common-data-items.js
+++ b/components/common-data-items.js
@@ -602,12 +602,12 @@ OntologyTermDataItems.commonProperties = [
 /**
  * Display data items common to all file-derived objects.
  */
-export function FileDataItems({
-  item,
-  analysisStepVersion = null,
-  children = null,
-}) {
+export function FileDataItems({ item, children = null }) {
   const tooltipAttr = useTooltip("external-host-url");
+  const analysisStepVersion =
+    typeof item.analysis_step_version === "object"
+      ? item.analysis_step_version
+      : null;
 
   return (
     <>
@@ -780,8 +780,6 @@ export function FileDataItems({
 FileDataItems.propTypes = {
   // file object common for all file types
   item: PropTypes.object.isRequired,
-  // Analysis step version for this file
-  analysisStepVersion: PropTypes.object,
   // Children elements to render
   children: PropTypes.node,
 };

--- a/pages/alignment-files/[...id].js
+++ b/pages/alignment-files/[...id].js
@@ -1,5 +1,4 @@
 // node_modules
-import _ from "lodash";
 import PropTypes from "prop-types";
 // components
 import { AlternativeIdentifiers } from "../../components/alternative-identifiers";
@@ -57,7 +56,6 @@ export default function AlignmentFile({
   workflows,
   referenceFiles,
   qualityMetrics,
-  analysisStepVersion,
   supersedes,
   supersededBy,
   isJson,
@@ -65,9 +63,9 @@ export default function AlignmentFile({
   const sections = useSecDir({ isJson });
   const isAlignmentDetailsVisible = Boolean(
     alignmentFile.redacted ||
-      alignmentFile.filtered ||
-      alignmentFile.assembly ||
-      alignmentFile.transcriptome_annotation
+    alignmentFile.filtered ||
+    alignmentFile.assembly ||
+    alignmentFile.transcriptome_annotation
   );
 
   return (
@@ -90,10 +88,7 @@ export default function AlignmentFile({
           <StatusPreviewDetail item={alignmentFile} />
           <DataPanel>
             <DataArea>
-              <FileDataItems
-                item={alignmentFile}
-                analysisStepVersion={analysisStepVersion}
-              />
+              <FileDataItems item={alignmentFile} />
               <Attribution attribution={attribution} />
             </DataArea>
           </DataPanel>
@@ -189,8 +184,6 @@ AlignmentFile.propTypes = {
   workflows: PropTypes.arrayOf(PropTypes.object),
   // Quality metrics associated with this file
   qualityMetrics: PropTypes.arrayOf(PropTypes.object),
-  // Analysis step version associated with this file
-  analysisStepVersion: PropTypes.object,
   // Files that this file supersedes
   supersedes: PropTypes.array.isRequired,
   // Files that supersede this file
@@ -266,13 +259,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
       alignmentFile.quality_metrics?.length > 0
         ? await requestQualityMetrics(alignmentFile.quality_metrics, request)
         : [];
-    const analysisStepVersionId = _.get(
-      alignmentFile,
-      "analysis_step_version.@id"
-    );
-    const analysisStepVersion = analysisStepVersionId
-      ? (await request.getObject(analysisStepVersionId)).optional()
-      : null;
     const { supersedes, supersededBy } = await requestSupersedes(
       alignmentFile,
       "File",
@@ -291,7 +277,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         fileFormatSpecifications,
         workflows,
         qualityMetrics,
-        analysisStepVersion,
         pageContext: { title: alignmentFile.accession },
         supersedes,
         supersededBy,

--- a/pages/configuration-files/[...id].js
+++ b/pages/configuration-files/[...id].js
@@ -1,5 +1,4 @@
 // node_modules
-import _ from "lodash";
 import PropTypes from "prop-types";
 // components
 import { AlternativeIdentifiers } from "../../components/alternative-identifiers";
@@ -50,7 +49,6 @@ export default function ConfigurationFile({
   fileFormatSpecifications,
   workflows,
   qualityMetrics,
-  analysisStepVersion,
   supersedes,
   supersededBy,
   isJson,
@@ -76,10 +74,7 @@ export default function ConfigurationFile({
           <StatusPreviewDetail item={configurationFile} />
           <DataPanel>
             <DataArea>
-              <FileDataItems
-                item={configurationFile}
-                analysisStepVersion={analysisStepVersion}
-              />
+              <FileDataItems item={configurationFile} />
               <Attribution attribution={attribution} />
             </DataArea>
           </DataPanel>
@@ -146,8 +141,6 @@ ConfigurationFile.propTypes = {
   workflows: PropTypes.arrayOf(PropTypes.object),
   // Quality metrics for this file
   qualityMetrics: PropTypes.arrayOf(PropTypes.object),
-  // Analysis step version for this file
-  analysisStepVersion: PropTypes.object,
   // Files that this file supersedes
   supersedes: PropTypes.arrayOf(PropTypes.object).isRequired,
   // Files that supersede this file
@@ -226,13 +219,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
             request
           )
         : [];
-    const analysisStepVersionId = _.get(
-      configurationFile,
-      "analysis_step_version.@id"
-    );
-    const analysisStepVersion = analysisStepVersionId
-      ? (await request.getObject(analysisStepVersionId)).optional()
-      : null;
     const { supersedes, supersededBy } = await requestSupersedes(
       configurationFile,
       "File",
@@ -252,7 +238,6 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         fileFormatSpecifications,
         workflows,
         qualityMetrics,
-        analysisStepVersion,
         supersedes,
         supersededBy,
         pageContext: { title: configurationFile.accession },


### PR DESCRIPTION
# Code Review: IGVF-3333-file-analysis-step-version

_Reviewed by GitHub Copilot using Claude Sonnet 4.6_

## Summary

Refactors `analysis_step_version` handling so `FileDataItems` reads it directly from the embedded `item` object, instead of accepting it as a separate prop fetched server-side. Aligns `alignment-files` and `configuration-files` with the existing pattern used by all other file page types.

## Changed Files

### `components/common-data-items.js`

Removes the `analysisStepVersion` prop from `FileDataItems` and derives it internally:

```js
const analysisStepVersion =
  typeof item.analysis_step_version === "object"
    ? item.analysis_step_version
    : null;
```

The `typeof` check correctly filters out string `@id` values (when the sub-object isn't embedded by the API) and `undefined`. The `typeof null === "object"` edge case is safe here — if `item.analysis_step_version` is `null`, the ternary assigns `null`, which the render guard (`{analysisStepVersion && ...}`) handles correctly.

### `pages/alignment-files/[...id].js` and `pages/configuration-files/[...id].js`

- Removes the `_.get()` / server-side `getObject` fetch of `analysis_step_version`
- Removes prop threading into `FileDataItems`
- Removes the now-unused `lodash` import
- Removes the corresponding `propTypes` entry

## Verdict

No issues. The changes are correct and consistent. Moving the `analysis_step_version` derivation into `FileDataItems` simplifies both page files and eliminates a redundant network request on each page load.