### PR TITLE
IGVF-3275 Add software versions display to all file pages

### DIFF
--- a/components/collapse-control.tsx
+++ b/components/collapse-control.tsx
@@ -39,23 +39,40 @@ import {
   ArrowDownIcon,
   ArrowUpIcon,
 } from "@heroicons/react/20/solid";
-import PropTypes from "prop-types";
 import { useState } from "react";
+
+/**
+ * Result returned by the `useCollapseControl` hook that contains the collapsed state, the setter
+ * for the collapsed state, a boolean indicating whether the collapse control should be visible,
+ * and the truncated list of items to display
+ *
+ * @property isCollapsed - True if the list appears collapsed; applies if `isCollapsible` is true
+ * @property setIsCollapsed - Function to set the collapsed state
+ * @property isCollapseControlVisible - True if the list has enough items to need a collapse control
+ * @property items - Truncated list of items to display
+ */
+export interface CollapseControlResult<T> {
+  isCollapsed: boolean;
+  setIsCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
+  isCollapseControlVisible: boolean;
+  items: T[];
+}
 
 /**
  * Hook to control the collapsed state of a list. It keeps the collapsed/expanded state and
  * handles the truncation of the list of items while collapsed.
- * @param {Array} items List of items to display
- * @param {number} maxItemsBeforeCollapse Max number of items before the list appears collapsed
- * @param {boolean} isCollapsible True if the list should be collapsible
- * @returns {Object} Object containing the collapsed state, the collapsed/expanded state setter,
- *   and the truncated list of items
+ *
+ * @param items - List of items to display
+ * @param maxItemsBeforeCollapse - Max number of items before the list appears collapsed
+ * @param isCollapsible - True if the list should be collapsible
+ * @returns Object containing the collapsed state, the collapsed/expanded state setter, a boolean
+ *   indicating whether the collapse control should be visible, and the truncated list of items
  */
-export function useCollapseControl(
-  items,
+export function useCollapseControl<T>(
+  items: T[],
   maxItemsBeforeCollapse = DEFAULT_MAX_COLLAPSE_ITEMS_INLINE,
   isCollapsible = true
-) {
+): CollapseControlResult<T> {
   // True if the list appears collapsed
   const [isCollapsed, setIsCollapsed] = useState(true);
 
@@ -92,8 +109,20 @@ export const DEFAULT_MAX_COLLAPSE_ITEMS_VERTICAL = 5;
 
 /**
  * Displays the expand/collapse control for a collapsible list.
+ *
+ * @param length - Total number of items in the list
+ * @param isCollapsed - True if the list appears collapsed
+ * @param setIsCollapsed - Function to set the collapsed state
  */
-export function CollapseControlInline({ length, isCollapsed, setIsCollapsed }) {
+export function CollapseControlInline({
+  length,
+  isCollapsed,
+  setIsCollapsed,
+}: {
+  length: number;
+  isCollapsed: boolean;
+  setIsCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
+}) {
   const label = isCollapsed
     ? `Show all ${length} items in list`
     : `Show fewer items in list`;
@@ -121,23 +150,24 @@ export function CollapseControlInline({ length, isCollapsed, setIsCollapsed }) {
   );
 }
 
-CollapseControlInline.propTypes = {
-  // Total length of the list
-  length: PropTypes.number.isRequired,
-  // True if the list appears collapsed
-  isCollapsed: PropTypes.bool.isRequired,
-  // Function to set the collapsed state
-  setIsCollapsed: PropTypes.func.isRequired,
-};
-
 /**
  * Displays the expand/collapse control for `<DataItemList>`.
+ *
+ * @param length - Total number of items in the list
+ * @param isCollapsed - True if the list appears collapsed
+ * @param setIsCollapsed - Function to set the collapsed state
+ * @param isFullBorder - True to have all four sides of the button have a border; false to have all but the top border
  */
 export function CollapseControlVertical({
   length,
   isCollapsed,
   setIsCollapsed,
   isFullBorder = false,
+}: {
+  length: number;
+  isCollapsed: boolean;
+  setIsCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
+  isFullBorder?: boolean;
 }) {
   const label = isCollapsed
     ? `Show all ${length} items in list`
@@ -168,14 +198,3 @@ export function CollapseControlVertical({
     </button>
   );
 }
-
-CollapseControlVertical.propTypes = {
-  // Total length of the list
-  length: PropTypes.number.isRequired,
-  // True if the list appears collapsed
-  isCollapsed: PropTypes.bool.isRequired,
-  // Function to set the collapsed state
-  setIsCollapsed: PropTypes.func.isRequired,
-  // True to have all four sides of the button have a border; false to have all but the top border
-  isFullBorder: PropTypes.bool,
-};

--- a/components/common-data-items.js
+++ b/components/common-data-items.js
@@ -12,6 +12,7 @@
 
 // node_modules
 import { QuestionMarkCircleIcon } from "@heroicons/react/20/solid";
+import _ from "lodash";
 import PropTypes from "prop-types";
 import { Fragment } from "react";
 // components
@@ -609,6 +610,18 @@ export function FileDataItems({ item, children = null }) {
       ? item.analysis_step_version
       : null;
 
+  // Extract the software versions from the analysis step version object.
+  const softwareVersions = (
+    analysisStepVersion?.software_versions || []
+  ).filter(
+    (version) =>
+      version && typeof version === "object" && !Array.isArray(version)
+  );
+  const sortedSoftwareVersions = _.sortBy(
+    softwareVersions,
+    (version) => version.summary?.toLowerCase() || "\uffff"
+  );
+
   return (
     <>
       {typeof item.file_set === "object" && (
@@ -643,6 +656,20 @@ export function FileDataItems({ item, children = null }) {
               {analysisStepVersion["@id"]}
             </Link>
           </DataItemValueUrl>
+        </>
+      )}
+      {sortedSoftwareVersions.length > 0 && (
+        <>
+          <DataItemLabel>Software Versions</DataItemLabel>
+          <DataItemValue>
+            <SeparatedList isCollapsible>
+              {sortedSoftwareVersions.map((version) => (
+                <Link href={version["@id"]} key={version["@id"]}>
+                  {version.summary}
+                </Link>
+              ))}
+            </SeparatedList>
+          </DataItemValue>
         </>
       )}
       <DataItemLabel>File Format</DataItemLabel>

--- a/components/section-directory.tsx
+++ b/components/section-directory.tsx
@@ -186,6 +186,11 @@ export function SecDir({ sections }: { sections: SectionList }) {
   // True if the user has the mouse in the section directory menu. Use ref to avoid closure issue.
   const isMouseHovered = useRef(false);
 
+  // Don't render the section directory if there are no sections to display.
+  if (sections.items.length === 0) {
+    return null;
+  }
+
   // Get the item renderer, either the default one or the custom one passed in the sections prop.
   const ItemRenderer = sections.renderer;
 

--- a/components/separated-list.tsx
+++ b/components/separated-list.tsx
@@ -65,7 +65,7 @@ export default function SeparatedList({
   maxItemsBeforeCollapse?: number;
   children: React.ReactNode;
 }) {
-  const childrenArray = Children.toArray(children);
+  const childrenArray = Children.toArray(children) as React.ReactElement[];
   const collapser = useCollapseControl(
     childrenArray,
     maxItemsBeforeCollapse,
@@ -76,14 +76,13 @@ export default function SeparatedList({
   if (items.length > 0) {
     return (
       <div className={className || ""} data-testid={testid}>
-        {items
-          .filter(Boolean)
-          .map((item) => <Fragment key={item.key}>{item}</Fragment>)
-          .reduce((combined, curr, index) => [
-            combined,
-            <Fragment key={`sep-${index}`}>{separator}</Fragment>,
-            <Fragment key={`sep-${index + 1}`}>
-              {curr}
+        {items.filter(Boolean).map((item, index) =>
+          index === 0 ? (
+            <Fragment key={item.key}>{item}</Fragment>
+          ) : (
+            <Fragment key={`sep-${index}`}>
+              {separator}
+              {item}
               {collapser.isCollapseControlVisible &&
               index === collapser.items.length - 1 ? (
                 <CollapseControlInline
@@ -92,8 +91,9 @@ export default function SeparatedList({
                   setIsCollapsed={collapser.setIsCollapsed}
                 />
               ) : null}
-            </Fragment>,
-          ])}
+            </Fragment>
+          )
+        )}
       </div>
     );
   }

--- a/cypress/e2e/app.cy.js
+++ b/cypress/e2e/app.cy.js
@@ -32,61 +32,70 @@ describe("Navigation", () => {
     cy.get("[data-testid=navigation-files]").click();
     cy.url().should("include", "/search/?type=File");
     cy.get("h1").should("exist"); // Actual title depends on data
-
-    // Test Resources and Standards submenus. Add to this once the pages these submenus link to exist.
-    cy.get("[data-testid=navigation-resources-standards]").click();
-
-    // Test About submenus. Add to this once the pages these submenus link to exist.
-    cy.get("[data-testid=navigation-about]").click();
-
-    // Test Help submenus. Add to this once the pages these submenus link to exist.
-    cy.get("[data-testid=navigation-help]").click();
   });
 
-  it("should load every schema's list and report page", () => {
-    cy.loginAuth0(Cypress.env("AUTH_USERNAME"), Cypress.env("AUTH_PASSWORD"));
-    cy.contains("Cypress Testing");
-    cy.wait(1000);
+  // Shared login helper using cy.session() to cache Auth0 cookies across the two schema tests,
+  // avoiding a full OAuth roundtrip for the second test while still giving Chrome a fresh context.
+  function loginWithSession() {
+    cy.session("auth0-session", () => {
+      cy.visit("/");
+      cy.loginAuth0(Cypress.env("AUTH_USERNAME"), Cypress.env("AUTH_PASSWORD"));
+      cy.contains("Cypress Testing");
+    });
+  }
 
-    // Go to the schemas page.
-    cy.get(`[data-testid="navigation-data-model"]`).click();
-    cy.get(`[data-testid="navigation-schemas"]`).click();
+  it("should load every schema's list page", () => {
+    loginWithSession();
+    cy.visit("/profiles/");
+
+    // Wait for the session context to finish loading so the links reflect the authenticated user's
+    // query params (status!=deleted) rather than the anonymous-user defaults (status=released).
+    cy.get(`[aria-label^="List view of all"]`)
+      .first()
+      .should("have.attr", "href")
+      .and("include", "status!=deleted");
 
     // Collect up all the list view links for every schema.
     const listHrefs = [];
-    cy.get(`[data-testid^="schema-"`).each(($schema) => {
+    cy.get(`[data-testid^="schema-"]`).each(($schema) => {
       const href = $schema
         .find(`[aria-label^="List view of all"]`)
         .attr("href");
       listHrefs.push(href);
     });
 
-    // Visit each list page to make sure it comes up, then go back to the schema page.
+    // Request each list page to make sure it returns a 200.
     cy.then(() => {
       listHrefs.forEach((href) => {
-        cy.get(`a[href="${href}"]`).click();
-        cy.wait(500);
-        cy.get("h1").should("exist");
-        cy.get(`[data-testid="navigation-schemas"]`).click();
+        cy.request(href).its("status").should("eq", 200);
       });
     });
+  });
+
+  it("should load every schema's report page", () => {
+    loginWithSession();
+    cy.visit("/profiles/");
+
+    // Wait for the session context to finish loading so the links reflect the authenticated user's
+    // query params (status!=deleted) rather than the anonymous-user defaults (status=released).
+    cy.get(`[aria-label^="Report view of all"]`)
+      .first()
+      .should("have.attr", "href")
+      .and("include", "status!=deleted");
 
     // Collect up all the report view links for every schema.
     const reportHrefs = [];
-    cy.get(`[data-testid^="schema-"`).each(($schema) => {
+    cy.get(`[data-testid^="schema-"]`).each(($schema) => {
       const href = $schema
         .find(`[aria-label^="Report view of all"]`)
         .attr("href");
       reportHrefs.push(href);
     });
 
-    // Visit each report page to make sure it comes up, then go back to the schema page.
+    // Request each report page to make sure it returns a 200.
     cy.then(() => {
       reportHrefs.forEach((href) => {
-        cy.get(`a[href="${href}"]`).click();
-        cy.wait(500);
-        cy.get("h1").should("exist");
-        cy.get(`[data-testid="navigation-schemas"]`).click();
+        cy.request(href).its("status").should("eq", 200);
       });
     });
   });

--- a/cypress/e2e/profiles.cy.js
+++ b/cypress/e2e/profiles.cy.js
@@ -12,7 +12,6 @@ describe("Test the profiles page and each individual profile page", () => {
       const href = $schema.attr("href");
       profileHrefs.push(href);
     });
-    cy.log(profileHrefs);
 
     // Visit each list page to make sure it comes up, then go back to the schema page.
     cy.then(() => {

--- a/pages/profiles/[...profile].js
+++ b/pages/profiles/[...profile].js
@@ -568,7 +568,7 @@ function SchemaProperties({
 
   return (
     <>
-      <section className="border-panel bg-schema-search sticky top-[37px] z-10 border-b px-4 py-2">
+      <section className="border-panel bg-schema-search sticky top-9.25 z-10 border-b px-4 py-2">
         <FormLabel>Search Schema Properties</FormLabel>
         <div className="mb-4">
           <SchemaSearchField


### PR DESCRIPTION
# Code Review — `IGVF-3275-file-software-version`

_Reviewed by GitHub Copilot using Claude Sonnet 4.6_

## Changed files

| Status | File |
|---|---|
| Renamed + converted | `components/collapse-control.js` → `collapse-control.tsx` |
| Modified | `components/common-data-items.js` |
| Modified | `components/section-directory.tsx` |
| Modified | `components/separated-list.tsx` |
| Modified | `cypress/e2e/app.cy.js` |
| Modified | `cypress/e2e/profiles.cy.js` |
| Modified | `pages/profiles/[...profile].js` |

---

## `collapse-control.tsx` — JS to TS conversion

Clean migration. Highlights:

- `CollapseControlResult<T>` and `useCollapseControl<T>` are correctly generic. Exporting the interface is useful for consumers who need to type-annotate the return value.
- `PropTypes` declarations replaced with inline TypeScript prop types throughout.
- `React.Dispatch<React.SetStateAction<boolean>>` used consistently, compatible with the project's implicit React namespace (via `next-env.d.ts`).

No issues.

---

## `common-data-items.js` — Software Versions display

New `softwareVersions` / `sortedSoftwareVersions` block in `FileDataItems`:

- **Sort safety** — `version.summary?.toLowerCase() || "\uffff"` correctly handles missing `summary` fields and sorts them to the end rather than crashing.
- **React key** — `key={version["@id"]}` is a stable, guaranteed-unique identifier. Good choice over `version.summary`.
- **Render gate** — `sortedSoftwareVersions.length > 0` is consistent with what is actually rendered.
- `lodash` is already a declared dependency (`^4.17.21`); the `_.sortBy` import is fine.

No issues.

---

## `section-directory.tsx` — Early return for empty sections

```tsx
if (sections.items.length === 0) {
  return null;
}
```

Both hooks called before this guard (`useTouchPointerType`, `useRef`) — no rules-of-hooks violation. Clean and correct.

No issues.

---

## `separated-list.tsx` — TypeScript fix + reduce refactor

The original `map` + `reduce` pipeline produced a nested array structure that TypeScript couldn't express without a `as unknown as React.ReactElement` double cast. Replaced with a single `map` where each callback returns one `Fragment`:

- Index 0: the item alone (no leading separator).
- Index > 0: a `Fragment` containing the separator, the item, and (for the last visible item) the collapse control.

Each callback returns exactly one element, the return type is correctly inferred as `React.ReactElement[]`, and no casts are needed. Behavior is identical to before.

The `Children.toArray(children) as React.ReactElement[]` cast is slightly broad (strings/numbers are technically valid children) but safe in practice given how `SeparatedList` is used throughout the codebase.

No issues.

---

## `cypress/e2e/app.cy.js` — Test refactoring

- `cy.session()` deduplicates the Auth0 login across the two schema tests, avoiding a full OAuth round-trip for the second test. Good performance improvement.
- Splitting list-page and report-page checks into separate `it` blocks improves isolation and failure readability.
- Switching from `cy.get(a).click()` + DOM assertions to `cy.request().its("status").should("eq", 200)` is significantly faster. It no longer verifies UI rendering, but for a schema coverage smoke test this tradeoff is reasonable.
- Adding `.should("have.attr", "href").and("include", "status!=deleted")` before gathering hrefs correctly ensures the session is authenticated before link collection begins.

**Note:** The navigation tests for the "Resources and Standards", "About", and "Help" submenus were removed and not relocated. Confirm this is intentional (e.g., those menu items are being removed or covered elsewhere).

---

## `cypress/e2e/profiles.cy.js`

Removed a stray `cy.log(profileHrefs)` debug statement. No issues.

---

## `pages/profiles/[...profile].js`

`top-[37px]` → `top-9.25`

Valid in Tailwind v4 (project uses `tailwindcss@^4.2.1`). The calculation $9.25 \times 0.25\text{rem} = 2.3125\text{rem} = 37\text{px}$ matches the original. Good cleanup from an arbitrary value to a standard utility class.

No issues.