### PR TITLE
IGVF-3358-checkfiles-timestamp

### DIFF
--- a/components/common-data-items.js
+++ b/components/common-data-items.js
@@ -781,6 +781,14 @@ export function FileDataItems({ item, children = null }) {
           </DataItemValue>
         </>
       )}
+      {item.checkfiles_timestamp && (
+        <>
+          <DataItemLabel>Checkfiles Timestamp</DataItemLabel>
+          <DataItemValue>
+            {formatDate(item.checkfiles_timestamp, "show-time")}
+          </DataItemValue>
+        </>
+      )}
       {item.validation_error_detail && (
         <>
           <DataItemLabel>Validation Error Detail</DataItemLabel>
@@ -813,6 +821,8 @@ FileDataItems.propTypes = {
 
 FileDataItems.commonProperties = [
   "aliases",
+  "checkfiles_timestamp",
+  "checkfiles_version",
   "content_md5sum",
   "content_type",
   "content_summary",

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -378,6 +378,7 @@ export type UploadStatus =
 export interface FileObject extends DatabaseObject {
   accession?: string;
   aliases?: string[];
+  checkfiles_timestamp?: string;
   checkfiles_version?: string;
   content_summary?: string;
   content_type: string;


### PR DESCRIPTION
# Code Review

*Reviewed by GitHub Copilot (Claude Sonnet 4.6)*

## Summary

This PR adds a "Checkfiles Timestamp" display field to the `FileDataItems` component in `components/common-data-items.js`, and registers `checkfiles_timestamp` (along with the pre-existing but previously unregistered `checkfiles_version`) in the component's `commonProperties` list. It also adds `checkfiles_timestamp` to the `FileObject` TypeScript interface in `globals.d.ts`.

---

## `components/common-data-items.js`

### New timestamp row

```jsx
{item.checkfiles_timestamp && (
  <>
    <DataItemLabel>Checkfiles Timestamp</DataItemLabel>
    <DataItemValue>
      {formatDate(item.checkfiles_timestamp, "show-time")}
    </DataItemValue>
  </>
)}
```

- The conditional guard and JSX fragment pattern are consistent with every other field in `FileDataItems`.
- Placement between "Checkfiles Version" and "Validation Error Detail" is logical.
- `formatDate(..., "show-time")` is the correct call for a datetime string — it's the same pattern used for `entry.timestamp` in `pages/history.tsx`.

### `commonProperties` additions

```js
FileDataItems.commonProperties = [
  "aliases",
  "checkfiles_timestamp",  // new
  "checkfiles_version",    // new (pre-existing gap, fixed here)
  "content_md5sum",
  ...
```

`commonProperties` tells `UnknownTypePanel` which fields `FileDataItems` already handles, so they aren't double-rendered in the generic property list for unknown file subtypes. Both `checkfiles_timestamp` and `checkfiles_version` are now registered correctly. The `checkfiles_version` addition fixes a pre-existing omission.

---

## `globals.d.ts`

```ts
export interface FileObject extends DatabaseObject {
  accession?: string;
  aliases?: string[];
+ checkfiles_timestamp?: string;
  checkfiles_version?: string;
```

`checkfiles_timestamp` is added as an optional `string`, alphabetically ordered relative to its neighbors. This keeps `FileObject` consistent with the property actually being rendered.

---

## Overall

No issues. The change is correct and complete: the new field is rendered, typed, and registered so it won't be double-rendered in edge cases. The pre-existing `checkfiles_version` gap in `commonProperties` is also cleaned up as part of this PR.