### PR TITLE
IGVF-3423 Tooltips for preferred assay title facet terms

### DIFF
--- a/components/__tests__/annotated-value.test.tsx
+++ b/components/__tests__/annotated-value.test.tsx
@@ -279,6 +279,54 @@ describe("AnnotatedValue", () => {
     expect(el).toHaveClass("underline");
     expect(el).toHaveClass("decoration-help-underline");
   });
+
+  it("renders a span by default when no as prop is given and there is no annotation", () => {
+    renderWithSession(
+      <AnnotatedValue objectType="File" propertyName="content_type">
+        fastq
+      </AnnotatedValue>,
+      null
+    );
+
+    const el = screen.getByText("fastq");
+    expect(el.tagName.toLowerCase()).toBe("span");
+  });
+
+  it("renders the element specified by as when there is no annotation", () => {
+    renderWithSession(
+      <AnnotatedValue as="div" objectType="File" propertyName="content_type">
+        fastq
+      </AnnotatedValue>,
+      null
+    );
+
+    const el = screen.getByText("fastq");
+    expect(el.tagName.toLowerCase()).toBe("div");
+  });
+
+  it("renders the element specified by as when there is an annotation", () => {
+    const profiles = {
+      File: {
+        properties: {
+          content_type: {
+            type: "string",
+            enum_descriptions: { fastq: "FASTQ sequence reads." },
+          },
+        },
+      },
+    };
+
+    renderWithSession(
+      <AnnotatedValue as="div" objectType="File" propertyName="content_type">
+        fastq
+      </AnnotatedValue>,
+      profiles
+    );
+
+    const el = screen.getByText("fastq");
+    expect(el.tagName.toLowerCase()).toBe("div");
+    expect(el).toHaveClass("underline");
+  });
 });
 
 describe("AnnotatedItem", () => {
@@ -327,5 +375,46 @@ describe("AnnotatedItem", () => {
     const el = screen.getByText("test value");
     expect(el).toHaveClass("underline");
     expect(el).toHaveClass("custom-class");
+  });
+
+  it("renders a span by default when no as prop is given", () => {
+    render(
+      <>
+        <TooltipPortalRoot />
+        <AnnotatedItem tooltipKey="test-key">test value</AnnotatedItem>
+      </>
+    );
+
+    const el = screen.getByText("test value");
+    expect(el.tagName.toLowerCase()).toBe("span");
+  });
+
+  it("renders the element specified by the as prop when there is no annotation", () => {
+    render(
+      <>
+        <TooltipPortalRoot />
+        <AnnotatedItem as="div" tooltipKey="test-key">
+          test value
+        </AnnotatedItem>
+      </>
+    );
+
+    const el = screen.getByText("test value");
+    expect(el.tagName.toLowerCase()).toBe("div");
+  });
+
+  it("renders the element specified by the as prop when there is an annotation", () => {
+    render(
+      <>
+        <TooltipPortalRoot />
+        <AnnotatedItem as="div" tooltipKey="test-key" annotation="A tooltip">
+          test value
+        </AnnotatedItem>
+      </>
+    );
+
+    const el = screen.getByText("test value");
+    expect(el.tagName.toLowerCase()).toBe("div");
+    expect(el).toHaveClass("underline");
   });
 });

--- a/components/annotated-value.tsx
+++ b/components/annotated-value.tsx
@@ -1,5 +1,5 @@
 // node_modules
-import { useContext } from "react";
+import { ElementType, useContext } from "react";
 import { twMerge } from "tailwind-merge";
 // components
 import MarkdownSection from "./markdown-section";
@@ -13,35 +13,39 @@ import { extractSchema } from "../lib/profiles";
  * Display a single data-item value with an annotation that appears in a tooltip. If no annotation
  * is provided, this renders the children without any underline nor tooltip.
  *
+ * @param as - HTML element or React component to render as; defaults to "span"
  * @param tooltipKey - Unique key for the tooltip reference
  * @param annotation - The annotation text to show in the tooltip
- * @param className - Additional class names to apply to the span wrapping the children
+ * @param className - Additional class names to apply to the element wrapping the children
  */
 export function AnnotatedItem({
+  as,
   tooltipKey,
   annotation = "",
   className = "",
   children,
 }: {
+  as?: ElementType;
   tooltipKey: string;
   annotation?: string;
   className?: string;
   children: React.ReactNode;
 }) {
+  const Tag = as ?? "span";
   const tooltipRef = useTooltip(tooltipKey);
 
   if (annotation) {
     return (
       <>
         <TooltipRef tooltipAttr={tooltipRef}>
-          <span
+          <Tag
             className={twMerge(
               "decoration-help-underline underline decoration-dotted underline-offset-2",
               className
             )}
           >
             {children}
-          </span>
+          </Tag>
         </TooltipRef>
         <Tooltip tooltipAttr={tooltipRef}>
           <MarkdownSection className="text-xs text-white dark:text-black">
@@ -51,7 +55,7 @@ export function AnnotatedItem({
       </>
     );
   }
-  return <span>{children}</span>;
+  return <Tag>{children}</Tag>;
 }
 
 /**
@@ -66,16 +70,19 @@ export function AnnotatedItem({
  * annotations, the `externalAnnotations` property provides the mappings of values to annotations.
  * `objectType` and `propertyName` do not get used for this case.
  *
+ * @param as - HTML element or React component to render as; defaults to "span"
  * @param objectType - `@type` of object this property belongs to
  * @param propertyName - Name of the object property being displayed
  * @param externalAnnotations - Map of values to descriptions if not using the schema
  */
 export function AnnotatedValue({
+  as,
   objectType = "",
   propertyName = "",
   externalAnnotations = {},
   children,
 }: {
+  as?: ElementType;
   objectType?: string;
   propertyName?: string;
   externalAnnotations?: Record<string, string>;
@@ -92,11 +99,13 @@ export function AnnotatedValue({
 
   // Check that we either have an object type and property name, or external annotations, and check
   // that we don't have both.
+  const Tag = as ?? "span";
+
   if (hasSchema && hasExternal) {
     console.error(
       "AnnotatedValue cannot have both objectType/propertyName and externalAnnotations"
     );
-    return <span>{children}</span>;
+    return <Tag>{children}</Tag>;
   }
 
   // Get the annotation for the given value from the schema, if available, or from the external
@@ -120,12 +129,16 @@ export function AnnotatedValue({
   // If we got an annotation, display the value with the annotation in a tooltip.
   if (annotation) {
     return (
-      <AnnotatedItem annotation={annotation} tooltipKey={uniqueTooltipKey}>
+      <AnnotatedItem
+        as={as}
+        annotation={annotation}
+        tooltipKey={uniqueTooltipKey}
+      >
         {children}
       </AnnotatedItem>
     );
   }
 
   // Could not find an annotation, so just display the value without a tooltip.
-  return <span>{children}</span>;
+  return <Tag>{children}</Tag>;
 }

--- a/components/data-use-limitation-status.tsx
+++ b/components/data-use-limitation-status.tsx
@@ -26,7 +26,7 @@ const limitationConfigs = {
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 20 20"
         fill="white"
-        className="ml-[-4px] h-full"
+        className="-ml-1 h-full"
         data-testid="icon-limitation-ds"
       >
         <path d="M17,10.5v-1h-2.1c-.1-1-.5-1.9-1.1-2.6l1.4-1.4-.7-.7-1.4,1.4c-.7-.6-1.6-1-2.6-1.1v-2.1h-1v2.1c-1,.1-1.9.5-2.6,1.1l-1.4-1.4-.7.7,1.4,1.4c-.6.7-1,1.6-1.1,2.6h-2.1v1h2.1c.1,1,.5,1.9,1.1,2.6l-1.4,1.4.7.7,1.4-1.4c.7.6,1.6,1,2.6,1.1v2.1h1v-2.1c1-.1,1.9-.5,2.6-1.1l1.4,1.4.7-.7-1.4-1.4c.6-.7,1-1.6,1.1-2.6h2.1ZM8.6,9.5c-.5,0-1-.4-1-1s.4-1,1-1,1,.4,1,1-.4,1-1,1ZM11.4,12.4c-.5,0-1-.4-1-1s.4-1,1-1,1,.4,1,1-.4,1-1,1Z" />
@@ -47,7 +47,7 @@ const limitationConfigs = {
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 20 20"
         fill="white"
-        className="ml-[-4px] h-full"
+        className="-ml-1 h-full"
         data-testid="icon-limitation-gru"
       >
         <path d="M10,17c-3.9,0-7-3.1-7-7s3.1-7,7-7,7,3.1,7,7-3.1,7-7,7ZM10,5.6c-2.4,0-4.4,2-4.4,4.4s2,4.4,4.4,4.4,4.4-2,4.4-4.4-2-4.4-4.4-4.4Z" />
@@ -68,7 +68,7 @@ const limitationConfigs = {
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 20 20"
         fill="white"
-        className="ml-[-4px] h-full"
+        className="-ml-1 h-full"
         data-testid="icon-limitation-hmb"
       >
         <polygon points="17 8 12 8 12 3 8 3 8 8 3 8 3 12 8 12 8 17 12 17 12 12 17 12 17 8" />
@@ -83,7 +83,7 @@ const limitationConfigs = {
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 20 20"
         fill="white"
-        className="ml-[-4px] h-full"
+        className="-ml-1 h-full"
         data-testid="icon-limitation-other"
       >
         <path d="M5.6,8.6c.2-.7.5-1.3,1-1.8l-1.4-2.4c-1.2,1.1-2.1,2.5-2.4,4.2h2.8Z" />
@@ -103,7 +103,7 @@ const limitationConfigs = {
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 20 20"
         fill="white"
-        className="ml-[-4px] h-full"
+        className="-ml-1 h-full"
         data-testid="icon-limitation-multiple"
       >
         <path d="M10.1,3c-3.9,0-7.1,3-7.1,6.9,0,3.9,3,7.1,6.9,7.1,3.9,0,7.1-3,7.1-6.9,0-3.9-3-7.1-6.9-7.1ZM8.9,5.5c0-.6.5-1.1,1.1-1.1s1.1.5,1.1,1.1v5.3c0,.6-.5,1.1-1.1,1.1s-1.1-.5-1.1-1.1v-5.3ZM10,15.6c-.7,0-1.2-.6-1.2-1.2s.6-1.2,1.2-1.2,1.2.6,1.2,1.2-.6,1.2-1.2,1.2Z" />
@@ -118,7 +118,7 @@ const limitationConfigs = {
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 20 20"
         fill="white"
-        className="ml-[-4px] h-full"
+        className="-ml-1 h-full"
         data-testid="icon-limitation-none"
       >
         <path d="M16.3,12.8c0,.4-.1.7-.4,1-.3.3-.6.4-1,.4s-.8-.1-1.1-.3c-.3-.2-.8-.7-1.5-1.4-.8-.8-1.3-1.3-1.7-1.5,0,.4.2,1.2.5,2.2.3,1,.5,1.8.5,2.2s-.1.9-.4,1.2-.6.5-1.1.5-.8-.2-1.1-.5c-.3-.3-.4-.7-.4-1.2s.2-1.2.5-2.2c.3-1,.5-1.8.5-2.2-.4.2-1,.7-1.7,1.5-.7.7-1.2,1.2-1.5,1.4-.3.2-.7.3-1.1.3s-.7-.1-1-.4c-.3-.3-.4-.6-.4-1s.2-.8.5-1.1c.3-.3,1.2-.7,2.5-1,1.1-.3,1.8-.5,2.1-.7-.4-.2-1.1-.4-2.1-.7-1.3-.3-2.2-.6-2.5-1-.4-.3-.6-.7-.6-1.1s.1-.7.4-1c.3-.3.6-.4,1-.4s.7.1,1,.3c.4.2.9.7,1.6,1.4.8.8,1.3,1.3,1.7,1.5,0-.4-.2-1.1-.5-2.2-.3-1-.5-1.8-.5-2.2s.1-.9.4-1.2c.3-.3.6-.5,1.1-.5s.8.2,1.1.5.4.7.4,1.2-.2,1.2-.5,2.2c-.3,1-.5,1.8-.5,2.2.4-.2.9-.7,1.7-1.5.7-.7,1.3-1.2,1.6-1.4s.7-.3,1-.3.7.1,1,.4.4.6.4,1-.2.8-.6,1.1c-.4.3-1.2.6-2.5,1-1.1.3-1.8.5-2.1.7.4.2,1.1.4,2.1.7,1.3.3,2.2.7,2.5,1,.3.3.5.7.5,1.1Z" />
@@ -231,7 +231,7 @@ export function DataUseLimitationStatus({
               className="bg-stone-700 text-white ring-stone-800"
               testid={`dul-badge-${toShishkebabCase(localLimitation)}`}
             >
-              <Icon className="ml-[-4px]" />
+              <Icon className="-ml-1" />
               <div
                 data-testid={`limitation-${toShishkebabCase(localLimitation)}`}
                 className={localModifiers.length > 0 ? "pr-1" : ""}
@@ -244,7 +244,7 @@ export function DataUseLimitationStatus({
                     return (
                       <div
                         key={modifier}
-                        className="border-l border-white px-0.5 last:mr-[-5px] last:rounded-r-full last:pr-1.5"
+                        className="border-l border-white px-0.5 last:-mr-1.25 last:rounded-r-full last:pr-1.5"
                         data-testid={`modifier-${toShishkebabCase(modifier)}`}
                       >
                         {modifier}

--- a/components/facets/__tests__/preferred-assay-terms-label.test.tsx
+++ b/components/facets/__tests__/preferred-assay-terms-label.test.tsx
@@ -1,0 +1,146 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import PreferredAssayTermsLabel from "../custom-facets/preferred-assay-terms-label";
+import SessionContext from "../../session-context";
+import { TooltipPortalRoot } from "../../tooltip";
+import type { SearchResultsFacetTerm } from "../../../globals";
+
+function renderWithSession(ui: React.ReactElement, profiles: any = null) {
+  const providerValue: any = {
+    session: null,
+    sessionProperties: null,
+    profiles,
+    collectionTitles: null,
+    dataProviderUrl: null,
+  };
+  return render(
+    <SessionContext.Provider value={providerValue}>
+      <TooltipPortalRoot />
+      {ui}
+    </SessionContext.Provider>
+  );
+}
+
+const baseTerm: SearchResultsFacetTerm = {
+  key: "STARR-seq",
+  doc_count: 42,
+};
+
+describe("PreferredAssayTermsLabel", () => {
+  it("renders the term key and doc_count when not negated and not a child term", () => {
+    renderWithSession(
+      <PreferredAssayTermsLabel
+        term={baseTerm}
+        isNegative={false}
+        isChildTerm={false}
+      />
+    );
+    expect(screen.getByText("STARR-seq")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
+  it("applies text-sm font-normal class when not a child term", () => {
+    renderWithSession(
+      <PreferredAssayTermsLabel
+        term={baseTerm}
+        isNegative={false}
+        isChildTerm={false}
+      />
+    );
+    const outerDiv = screen.getByText("STARR-seq").parentElement as HTMLElement;
+    expect(outerDiv.className).toContain("text-sm");
+    expect(outerDiv.className).toContain("font-normal");
+  });
+
+  it("applies text-xs font-light class when it is a child term", () => {
+    renderWithSession(
+      <PreferredAssayTermsLabel
+        term={baseTerm}
+        isNegative={false}
+        isChildTerm={true}
+      />
+    );
+    const outerDiv = screen.getByText("STARR-seq").parentElement as HTMLElement;
+    expect(outerDiv.className).toContain("text-xs");
+    expect(outerDiv.className).toContain("font-light");
+  });
+
+  it("does not render doc_count when isNegative is true", () => {
+    renderWithSession(
+      <PreferredAssayTermsLabel
+        term={baseTerm}
+        isNegative={true}
+        isChildTerm={false}
+      />
+    );
+    expect(screen.getByText("STARR-seq")).toBeInTheDocument();
+    expect(screen.queryByText("42")).not.toBeInTheDocument();
+  });
+
+  it("converts a numeric term key to a string", () => {
+    const numericTerm: SearchResultsFacetTerm = { key: 7, doc_count: 3 };
+    renderWithSession(
+      <PreferredAssayTermsLabel
+        term={numericTerm}
+        isNegative={false}
+        isChildTerm={false}
+      />
+    );
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("annotates the term key when profiles contain a matching enum_description", () => {
+    const profiles = {
+      MeasurementSet: {
+        properties: {
+          preferred_assay_titles: {
+            items: {
+              enum_descriptions: {
+                "STARR-seq": "A high-throughput assay for regulatory regions.",
+              },
+            },
+          },
+        },
+      },
+    };
+    renderWithSession(
+      <PreferredAssayTermsLabel
+        term={baseTerm}
+        isNegative={false}
+        isChildTerm={false}
+      />,
+      profiles
+    );
+    const el = screen.getByText("STARR-seq");
+    expect(el).toHaveClass("underline");
+    expect(el).toHaveAttribute("aria-describedby");
+  });
+
+  it("renders the term key without annotation when the profiles have no matching description", () => {
+    const profiles = {
+      MeasurementSet: {
+        properties: {
+          preferred_assay_titles: {
+            items: {
+              enum_descriptions: {
+                "Other-assay": "Some other description.",
+              },
+            },
+          },
+        },
+      },
+    };
+    renderWithSession(
+      <PreferredAssayTermsLabel
+        term={baseTerm}
+        isNegative={false}
+        isChildTerm={false}
+      />,
+      profiles
+    );
+    const el = screen.getByText("STARR-seq");
+    expect(el.tagName.toLowerCase()).toBe("span");
+    expect(el).not.toHaveClass("underline");
+  });
+});

--- a/components/facets/custom-facets/preferred-assay-terms-label.tsx
+++ b/components/facets/custom-facets/preferred-assay-terms-label.tsx
@@ -1,0 +1,45 @@
+// node_modules
+import { useContext } from "react";
+// components
+import { AnnotatedValue } from "../../annotated-value";
+import SessionContext from "../../session-context";
+// lib
+import { getPreferredAssayTitleDescriptionMap } from "../../../lib/ontology-terms";
+// root
+import type { SearchResultsFacetTerm } from "../../../globals";
+
+/**
+ * Displays the term labels for the preferred assay title facet terms. It behaves nearly
+ * identically to the standard facet term labels, except it uses the preferred assay title
+ * ontology term map to annotate the term labels.
+ *
+ * @param term - Single term from a facet from the search results
+ * @param isNegative - True if the term is negated
+ * @param isChildTerm - True if the term is a child term within a sub facet
+ */
+export default function PreferredAssayTermsLabel({
+  term,
+  isNegative,
+  isChildTerm,
+}: {
+  term: SearchResultsFacetTerm;
+  isNegative: boolean;
+  isChildTerm: boolean;
+}) {
+  const { profiles } = useContext(SessionContext);
+  const preferredAssayTitleDescriptionMap =
+    getPreferredAssayTitleDescriptionMap(profiles);
+
+  return (
+    <div
+      className={`flex grow items-center justify-between gap-2 leading-[1.1] [&>*:first-child]:wrap-anywhere ${
+        isChildTerm ? "text-xs font-light" : "text-sm font-normal"
+      }`}
+    >
+      <AnnotatedValue externalAnnotations={preferredAssayTitleDescriptionMap}>
+        {typeof term.key === "string" ? term.key : String(term.key)}
+      </AnnotatedValue>
+      {!isNegative && <div>{term.doc_count}</div>}
+    </div>
+  );
+}

--- a/components/facets/facet-registry.tsx
+++ b/components/facets/facet-registry.tsx
@@ -8,17 +8,18 @@ import type {
   SearchResultsFilter,
 } from "../../globals";
 // components/facets/custom-facets
+import InternalActionAuditTerms from "./custom-facets/audit-internal-action-terms";
 import AuditTitle from "./custom-facets/audit-title";
 import DateRangeTagLabel from "./custom-facets/date-range-tag-label";
 import DateRangeTerms from "./custom-facets/date-range-terms";
+import FileSizeTagLabel from "./custom-facets/file-size-tag-label";
 import FileSizeTerms from "./custom-facets/file-size-terms";
-import InternalActionAuditTerms from "./custom-facets/audit-internal-action-terms";
 import NoTermCountTitle from "./custom-facets/no-term-count-title";
+import PreferredAssayTermsLabel from "./custom-facets/preferred-assay-terms-label";
 import StandardTagLabel from "./custom-facets/standard-tag-label";
 import StandardTermLabel from "./custom-facets/standard-term-label";
 import StandardTerms from "./custom-facets/standard-terms";
 import StandardTitle from "./custom-facets/standard-title";
-import FileSizeTagLabel from "./custom-facets/file-size-tag-label";
 import TaxaTagLabel from "./custom-facets/taxa-tag-label";
 import TaxaTermLabel from "./custom-facets/taxa-term-label";
 
@@ -128,6 +129,8 @@ const tagLabel: FacetRegistrySection<TagComponent> = {
 const termLabel: FacetRegistrySection<TermLabelComponent> = {
   components: {
     "donors.taxa": TaxaTermLabel,
+    "file_sets.preferred_assay_titles": PreferredAssayTermsLabel,
+    preferred_assay_titles: PreferredAssayTermsLabel,
     taxa: TaxaTermLabel,
   },
   standard: StandardTermLabel,

--- a/components/search/list-renderer/open-reading-frame.js
+++ b/components/search/list-renderer/open-reading-frame.js
@@ -29,7 +29,9 @@ export default function OpenReadingFrame({ item: openReadingFrame }) {
         </SearchListItemUniqueId>
         <SearchListItemTitle>{openReadingFrame.orf_id}</SearchListItemTitle>
         {isMetaVisible && (
-          <SearchListItemMeta>{openReadingFrame.protein_id}</SearchListItemMeta>
+          <SearchListItemMeta>
+            <span key="protein_id">{openReadingFrame.protein_id}</span>
+          </SearchListItemMeta>
         )}
         <SearchListItemSupplement>
           <SearchListItemSupplementSection>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2868,9 +2868,10 @@
       "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="
     },
     "node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -6406,9 +6407,10 @@
       }
     },
     "node_modules/diff": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
-      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -10730,9 +10732,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",


### PR DESCRIPTION
# Code Review — `IGVF-3354-manually-derived`

*Reviewed by GitHub Copilot (Claude Sonnet 4.6)*

---

## `components/data-use-limitation-status.tsx`

The six `ml-[-4px]` → `-ml-1` changes are correct Tailwind v4 idiom cleanup; both compile to `−0.25rem`.

**Note:** `last:mr-[-5px]` → `last:-mr-1.25` is arithmetically accurate (`1.25 × 0.25rem = 0.3125rem ≈ 5px`), but the original was a fixed-pixel value, whereas the new class is rem-based and will scale with root font size. This is consistent with the other changes in this PR but is a subtle semantic shift worth being aware of.

---

## `components/facets/custom-facets/preferred-assay-terms-label.tsx` *(new)*

The component is a clean, well-structured specialisation of `StandardTermLabel` and the JSDoc is complete.

**Import paths.** ✅ Imports use `../../annotated-value` and `../../session-context`, consistent with other files in the same directory.

---

## `components/facets/__tests__/preferred-assay-terms-label.test.tsx` *(new)*

Good coverage: standard render, child vs. parent term styling, `doc_count` hidden when negated, numeric key stringification, and annotation present/absent based on profile data. No issues.

---

## `components/facets/facet-registry.tsx`

Imports are now alphabetically ordered by filename. The two new `termLabel` entries for `preferred_assay_titles` and `file_sets.preferred_assay_titles` follow the same dual-registration pattern used by `TaxaTermLabel`. Clean.

---

## `components/search/list-renderer/open-reading-frame.js`

`SearchListItemMeta` was receiving a raw string (`openReadingFrame.protein_id`) as its direct child. `SearchListItemMeta` renders its children inside `SeparatedList`, which calls `Children.toArray()` and then uses each child's `.key` for React reconciliation. A plain string has no `.key`, so React emits a missing-key warning at runtime and in tests. The fix wraps the value in a keyed `<span>`:

```jsx
<SearchListItemMeta>
  <span key="protein_id">{openReadingFrame.protein_id}</span>
</SearchListItemMeta>
```

This is exactly the pattern used by every other caller of `SearchListItemMeta` in the codebase (`technical-sample.js`, `rodent-donor.js`, `document.js`, `award.js`, etc.).

---

## Summary

| File | Verdict |
|---|---|
| `data-use-limitation-status.tsx` | ✅ Approve (note rem vs. px tradeoff) |
| `preferred-assay-terms-label.tsx` | ✅ Approve |
| `preferred-assay-terms-label.test.tsx` | ✅ Approve |
| `facet-registry.tsx` | ✅ Approve |
| `open-reading-frame.js` | ✅ Approve |