### PR TITLE
IGVF-3434 Pseudobulk set parent tables include cell type and qualifier

### DIFF
--- a/components/file-set-table.tsx
+++ b/components/file-set-table.tsx
@@ -2,13 +2,6 @@
 import { TableCellsIcon } from "@heroicons/react/20/solid";
 import _ from "lodash";
 import { useContext } from "react";
-// root
-import type {
-  CollectionTitles,
-  FileObject,
-  FileSetObject,
-  LabObject,
-} from "../globals";
 // components
 import { DataAreaTitle, DataAreaTitleLink } from "./data-area";
 import Link from "./link-no-prefetch";
@@ -19,18 +12,27 @@ import SortableGrid, { type SortableGridConfig } from "./sortable-grid";
 import { AliasesCell } from "./table-cells";
 // lib
 import { isFileObjectArray } from "../lib/files";
+import { isEmbedded } from "../lib/types";
+// root
+import type {
+  CollectionTitles,
+  FileObject,
+  FileSetObject,
+  LabObject,
+} from "../globals";
 
 /**
  * Used to pass metadata to the sortable grid for file set table rendering. `options` comes from
  * FileSetTable props. `collectionTitles` comes from session context.
  */
-interface FileSetMeta {
+type FileSetMeta = {
   options: {
-    showFileSetFiles: boolean;
+    showFileSetFiles?: boolean;
+    showCellColumns?: boolean;
     fileFilter?: (files: FileObject[]) => FileObject[];
   } | null;
   collectionTitles: CollectionTitles;
-}
+};
 
 /**
  * Columns configuration for the file set sortable grid.
@@ -62,6 +64,51 @@ const fileSetColumns: SortableGridConfig<FileSetObject, FileSetMeta>[] = [
       return null;
     },
     isSortable: false,
+  },
+  {
+    id: "cell_type",
+    title: "Cell Type",
+    display: ({ source }) => {
+      const cellType = isEmbedded(source.cell_type) ? source.cell_type : null;
+      return cellType ? (
+        <Link href={cellType["@id"]}>{cellType.term_name}</Link>
+      ) : null;
+    },
+    sorter: (item) => {
+      const cellType = isEmbedded(item.cell_type) ? item.cell_type : null;
+      return cellType?.term_name.toLowerCase() || "\uffff";
+    },
+    hide: (data, columns, meta) => {
+      // Hide the column if the client didn't request it, or if they did but there are no cell
+      // types to display.
+      if (meta.options?.showCellColumns) {
+        const hasCellTypes = data.some((fileSet) => {
+          const cellType = isEmbedded(fileSet.cell_type)
+            ? fileSet.cell_type
+            : null;
+          return Boolean(cellType);
+        });
+        return !hasCellTypes;
+      }
+      return true;
+    },
+  },
+  {
+    id: "cell_qualifier",
+    title: "Cell Qualifier",
+    sorter: (item) => item.cell_qualifier?.toLowerCase() || "\uffff",
+    hide: (data, columns, meta) => {
+      // Hide the column if the client didn't request it, or if they did but there are no cell
+      // qualifiers to display.
+      if (meta.options?.showCellColumns) {
+        const hasCellQualifiers = data.some(
+          (fileSet) =>
+            fileSet.cell_qualifier && fileSet.cell_qualifier.trim() !== ""
+        );
+        return !hasCellQualifiers;
+      }
+      return true;
+    },
   },
   {
     id: "files",
@@ -168,10 +215,7 @@ export default function FileSetTable({
   reportLink?: string;
   reportLabel?: string;
   title?: string;
-  fileSetMeta?: {
-    showFileSetFiles: boolean;
-    fileFilter?: (files: FileObject[]) => FileObject[];
-  } | null;
+  fileSetMeta?: FileSetMeta["options"] | null;
   isDeletedVisible?: boolean;
   panelId?: string;
 }) {
@@ -196,7 +240,9 @@ export default function FileSetTable({
           data={fileSets}
           columns={fileSetColumns}
           keyProp="@id"
-          meta={{ options: fileSetMeta, collectionTitles }}
+          meta={
+            { options: fileSetMeta, collectionTitles } satisfies FileSetMeta
+          }
         />
       </div>
     </>

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -419,6 +419,8 @@ export interface FileSetObject extends DatabaseObject {
   construct_library_sets?: string[] | FileSetObject[];
   assay_term?: string | OntologyTermObject;
   assay_titles?: string[];
+  cell_qualifier?: string;
+  cell_type?: string | OntologyTermObject;
   external_image_urls?: string[];
   file_set_type?: string;
   files: string[] | FileObject[];

--- a/lib/__tests__/common-requests.test.ts
+++ b/lib/__tests__/common-requests.test.ts
@@ -681,7 +681,7 @@ describe("Test all the common requests", () => {
       request
     );
     expect(mockFetch).toHaveBeenCalledWith(
-      "/search-quick/?type=FileSet&field=@type&field=accession&field=aliases&field=file_set_type&field=lab.title&field=preferred_assay_titles&field=samples&field=status&field=summary&@id=/auxiliary-sets/IGVFDS0001AUXI/&@id=/measurement-sets/IGVFDS4649TBFS/&limit=2",
+      "/search-quick/?type=FileSet&field=@type&field=accession&field=aliases&field=cell_qualifier&field=cell_type&field=file_set_type&field=lab.title&field=preferred_assay_titles&field=samples&field=status&field=summary&@id=/auxiliary-sets/IGVFDS0001AUXI/&@id=/measurement-sets/IGVFDS4649TBFS/&limit=2",
       expect.anything()
     );
     expect(result).toHaveLength(2);

--- a/lib/common-requests.ts
+++ b/lib/common-requests.ts
@@ -267,6 +267,8 @@ export async function requestFileSets(
         "@type",
         "accession",
         "aliases",
+        "cell_qualifier",
+        "cell_type",
         "file_set_type",
         "lab.title",
         "preferred_assay_titles",

--- a/pages/analysis-sets/[id].js
+++ b/pages/analysis-sets/[id].js
@@ -403,6 +403,7 @@ export default function AnalysisSet({
               reportLabel="Report of file sets that this analysis set is an input for"
               title="File Sets Using This Analysis Set as an Input"
               panelId="input-file-set-for"
+              fileSetMeta={{ showCellColumns: true }}
             />
           )}
 

--- a/pages/curated-sets/[id].js
+++ b/pages/curated-sets/[id].js
@@ -128,6 +128,7 @@ export default function CuratedSet({
               fileSets={inputFileSetFor}
               reportLink={`/multireport/?type=FileSet&input_file_sets.@id=${curatedSet["@id"]}`}
               reportLabel="Report of file sets that this curated set is an input for"
+              fileSetMeta={{ showCellColumns: true }}
               title="File Sets Using This Curated Set as an Input"
               panelId="input-file-set-for"
             />


### PR DESCRIPTION
# Code Review: IGVF-3434-pseudobulk-annotations

**Reviewer model:** Claude Sonnet 4.6 (GitHub Copilot)  
**Branch:** `IGVF-3434-pseudobulk-annotations` → `dev`  
**Date:** 2026-04-13

---

## Summary

This branch adds `cell_type` and `cell_qualifier` columns to `FileSetTable`, exposes them on the Analysis Set and Curated Set detail pages, and plumbs the two new fields through the type system and data-fetching layer. The changes are focused and self-consistent.

---

## File-by-file Review

### `globals.d.ts`

```diff
+  cell_qualifier?: string;
+  cell_type?: string | OntologyTermObject;
```

**No issues.** The union `string | OntologyTermObject` correctly models the IGVF API's embed/no-embed behavior. Both fields are optional, matching the schema.

---

### `lib/common-requests.ts`

Added `"cell_qualifier"` and `"cell_type"` to the `requestFileSets` field list. Both are inserted at the correct alphabetical position, consistent with the surrounding list.

**No issues.**

---

### `lib/__tests__/common-requests.test.ts`

The test URL expectation is updated to match the new field list. The test still validates all fields in the correct order.

**No issues.**

---

### `components/file-set-table.tsx`

This is the bulk of the change.

#### Import ordering

Imports are reorganized so the `// root` block (global type declarations) comes after `// lib`.  The previous order (`root` → `components` → `lib`) appeared inverted; the new ordering (`components` → `lib` → `root`) is more conventional.

#### `interface` → `type`

```diff
-interface FileSetMeta {
+type FileSetMeta = {
```

No functional difference. Minor style preference. Verify it's consistent with the rest of the file's style; either is fine here.

#### `showFileSetFiles` made optional

```diff
-    showFileSetFiles: boolean;
+    showFileSetFiles?: boolean;
```

Correct. The field was already optional in practice; making it explicitly optional aligns with the new `showCellColumns?: boolean` sibling and removes a potential footgun for callers that don't need it.

#### `fileSetMeta` prop type deduplication

```diff
-  fileSetMeta?: {
-    showFileSetFiles: boolean;
-    fileFilter?: (files: FileObject[]) => FileObject[];
-  } | null;
+  fileSetMeta?: FileSetMeta["options"] | null;
```

Good refactoring. Deriving the prop type from `FileSetMeta["options"]` ensures the component prop and the internal meta object stay in sync automatically.

#### `satisfies FileSetMeta`

```tsx
meta={
  { options: fileSetMeta, collectionTitles } satisfies FileSetMeta
}
```

Good practice. Using `satisfies` validates the shape at the callsite without widening the type, giving a better error location than a downstream type mismatch.

#### `cell_type` column

```tsx
const cellType =
  source.cell_type && typeof source.cell_type === "object"
    ? source.cell_type
    : null;
```

**Correctness:** `typeof null === "object"` in JavaScript, but this is safe because the leading `source.cell_type &&` short-circuits on falsy values (including `null`).

**Minor observation — repeated extraction logic:** The same `cell_type && typeof ... === "object"` expression appears three times: in `display`, `sorter`, and `hide`. This keeps each callback self-contained, which is consistent with how other columns in this file are written, so it's acceptable. If it becomes more complex in the future a small helper would improve readability.

**`hide` behavior:** The column is suppressed unless `showCellColumns: true` *and* at least one row has an embedded `cell_type` object. If `cell_type` is present but not embedded (i.e., it is a string path), the column will also be hidden. This is likely intentional — a link requires the embedded `term_name` — but worth confirming with the product spec.

#### `cell_qualifier` column

```tsx
{
  id: "cell_qualifier",
  title: "Cell Qualifier",
  sorter: (item) => item.cell_qualifier?.toLowerCase() || "\uffff",
  hide: (data, columns, meta) => { ... },
}
```

No `display` function is provided. SortableGrid will fall back to rendering `source[id]` directly, which is `source.cell_qualifier` (a plain string). This is correct and intentional, but worth noting as the asymmetry with `cell_type` (which does need a custom display) is non-obvious to future readers. A brief comment like `// No display needed; renders the string value directly` would clarify intent.

**`hide` extra guard:**

```tsx
fileSet.cell_qualifier && fileSet.cell_qualifier.trim() !== ""
```

The `.trim() !== ""` guard handles whitespace-only strings, which is more defensive than the corresponding check in `cell_type`. The inconsistency is harmless but could be normalized in a follow-up.

**Sentinel value `"\uffff"`:** Both columns use `"\uffff"` (U+FFFF, the highest BMP code point) to sort rows with no value to the end of the list. This is the existing pattern in this codebase and is consistent.

---

### `pages/analysis-sets/[id].js` and `pages/curated-sets/[id].js`

Both pages add `fileSetMeta={{ showCellColumns: true }}` to the `FileSetTable` for the "File Sets Using This … as an Input" sections. The placement is correct and the prop is properly typed via the updated `FileSetMeta["options"]` type.

**Note:** Neither page passes `showFileSetFiles`, which is now optional, so no action needed.

---

## Issues

| Severity | Location | Issue |
|----------|----------|-------|
| Low | `file-set-table.tsx` – `cell_qualifier` column | Missing `display` function; add a comment confirming the default rendering is intentional. |
| Low | `file-set-table.tsx` – `cell_type` `hide` | Column stays hidden when `cell_type` is a non-embedded string. Confirm this is the desired behavior. |
| Low | `file-set-table.tsx` – `cell_type` column | The `cellType` extraction is duplicated in three callbacks. Not blocking; extract a helper if complexity grows. |
| Info | `file-set-table.tsx` – `cell_qualifier` `hide` vs `cell_type` `hide` | `.trim()` check in `cell_qualifier` not mirrored in `cell_type`. Harmless but inconsistent. |

---

## Verdict

**Approve with minor notes.** The logic is correct, the types are sound, the test is updated, and the feature is properly gated behind `showCellColumns`. The low-severity observations above are non-blocking and can be addressed in a follow-up if desired.