### PR TITLE
IGVF-3526 File association graph downloads include groups

### DIFF
--- a/components/file-graph/__tests__/lib.test.ts
+++ b/components/file-graph/__tests__/lib.test.ts
@@ -1584,6 +1584,10 @@ describe("generateSVGContent", () => {
     };
   }
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("should return undefined when ReactFlow renderer is not found", () => {
     const consoleSpy = jest
       .spyOn(console, "error")
@@ -1795,7 +1799,11 @@ describe("generateSVGContent", () => {
 
   it("should include file set nodes with rounded corners", () => {
     const mockFileSetNode = createMockElement("div");
-    mockFileSetNode.style = { transform: "translate(50px, 100px)" };
+    mockFileSetNode.style = {
+      transform: "translate(50px, 100px)",
+      width: "156px",
+      height: "60px",
+    };
 
     const mockFileSetSvg = createMockElement("svg");
     mockFileSetSvg.getAttribute = jest.fn().mockImplementation((attr) => {
@@ -1849,9 +1857,74 @@ describe("generateSVGContent", () => {
     expect(result).toContain(`rx="${NODE_HEIGHT / 2}"`);
   });
 
+  it("should use rendered dimensions for file set nodes", () => {
+    const mockFileSetNode = createMockElement("div");
+    mockFileSetNode.style = {
+      transform: "translate(50px, 100px)",
+      width: "156px",
+      height: "60px",
+    };
+
+    const mockFileSetSvg = createMockElement("svg");
+    mockFileSetSvg.getAttribute = jest.fn().mockImplementation((attr) => {
+      if (attr === "data-fileset-type") {
+        return "measurement";
+      }
+      return null;
+    });
+    mockFileSetSvg.hasAttribute = jest.fn().mockImplementation((attr) => {
+      return attr === "data-fileset-type";
+    });
+    mockFileSetSvg.innerHTML = "<text>Measurement FileSet</text>";
+
+    mockFileSetNode.querySelector = jest.fn().mockImplementation((selector) => {
+      if (selector === "svg") {
+        return mockFileSetSvg;
+      }
+      return null;
+    });
+
+    const mockRenderer = createMockElement("div");
+    mockRenderer.querySelectorAll = jest.fn().mockImplementation((selector) => {
+      if (selector === "[data-id]") {
+        return [mockFileSetNode];
+      }
+      if (selector === ".react-flow__edge path") {
+        return [];
+      }
+      if (selector === ".react-flow__edge polygon") {
+        return [];
+      }
+      return [];
+    });
+    mockRenderer.querySelector = jest.fn().mockImplementation((selector) => {
+      if (selector === ".react-flow__viewport") {
+        return createMockElement("div");
+      }
+      return null;
+    });
+
+    const mockContainer = createMockElement("div");
+    mockContainer.querySelector = jest.fn().mockReturnValue(mockRenderer);
+
+    jest
+      .spyOn(document, "getElementById")
+      .mockReturnValue(mockContainer as any);
+
+    const result = generateSVGContent("test-graph-id");
+
+    expect(result).toContain('width="156"');
+    expect(result).toContain('height="60"');
+    expect(result).toContain('rx="30"');
+  });
+
   it("should handle file set nodes with unknown type", () => {
     const mockFileSetNode = createMockElement("div");
-    mockFileSetNode.style = { transform: "translate(0px, 0px)" };
+    mockFileSetNode.style = {
+      transform: "translate(0px, 0px)",
+      width: "156px",
+      height: "60px",
+    };
 
     const mockFileSetSvg = createMockElement("svg");
     mockFileSetSvg.getAttribute = jest.fn().mockImplementation((attr) => {
@@ -1907,7 +1980,11 @@ describe("generateSVGContent", () => {
 
   it("should handle file set nodes without data-fileset-type attribute", () => {
     const mockFileSetNode = createMockElement("div");
-    mockFileSetNode.style = { transform: "translate(0px, 0px)" };
+    mockFileSetNode.style = {
+      transform: "translate(0px, 0px)",
+      width: "156px",
+      height: "60px",
+    };
 
     const mockFileSetSvg = createMockElement("svg");
     mockFileSetSvg.getAttribute = jest.fn().mockReturnValue(""); // Empty data-fileset-type
@@ -2200,6 +2277,261 @@ describe("generateSVGContent", () => {
 
     // Unknown variable falls back to the original when colorVariableToColorHex returns falsy.
     expect(result).toContain('fill="var(--color-unknown-variable)"');
+  });
+
+  it("should render group nodes behind edges and regular nodes in SVG output", () => {
+    const mockGroupNode = createMockElement("div");
+    mockGroupNode.style = {
+      transform: "translate(5px, 10px)",
+      width: "300px",
+      height: "180px",
+    };
+
+    const mockGroupSvg = createMockElement("svg");
+    mockGroupSvg.hasAttribute = jest.fn().mockImplementation((attr) => {
+      return attr === "data-group-node";
+    });
+    mockGroupSvg.innerHTML = "";
+    mockGroupNode.querySelector = jest.fn().mockImplementation((selector) => {
+      if (selector === "svg") {
+        return mockGroupSvg;
+      }
+      return null;
+    });
+
+    const mockFileNode = createMockElement("div");
+    mockFileNode.style = { transform: "translate(50px, 60px)" };
+    const mockFileSvg = createMockElement("svg");
+    mockFileSvg.innerHTML = "<text>Regular Node</text>";
+    mockFileNode.querySelector = jest.fn().mockImplementation((selector) => {
+      if (selector === "svg") {
+        return mockFileSvg;
+      }
+      return null;
+    });
+
+    const mockPath = createMockElement("path");
+    mockPath.getAttribute = jest.fn().mockImplementation((attr) => {
+      if (attr === "d") {
+        return "M0,0 L100,100";
+      }
+      if (attr === "stroke") {
+        return "#000000";
+      }
+      return null;
+    });
+
+    const mockRenderer = createMockElement("div");
+    mockRenderer.querySelectorAll = jest.fn().mockImplementation((selector) => {
+      if (selector === "[data-id]") {
+        return [mockGroupNode, mockFileNode];
+      }
+      if (selector === ".react-flow__edge path") {
+        return [mockPath];
+      }
+      if (selector === ".react-flow__edge polygon") {
+        return [];
+      }
+      return [];
+    });
+    mockRenderer.querySelector = jest.fn().mockImplementation((selector) => {
+      if (selector === ".react-flow__viewport") {
+        return createMockElement("div");
+      }
+      return null;
+    });
+
+    const mockContainer = createMockElement("div");
+    mockContainer.querySelector = jest.fn().mockReturnValue(mockRenderer);
+
+    jest
+      .spyOn(document, "getElementById")
+      .mockReturnValue(mockContainer as any);
+
+    const result = generateSVGContent("test-graph-id") as string;
+
+    const groupIndex = result.indexOf('transform="translate(5, 10)"');
+    const edgeIndex = result.indexOf('<path d="M0,0 L100,100"');
+    const regularNodeIndex = result.indexOf("Regular Node");
+
+    expect(groupIndex).toBeGreaterThan(-1);
+    expect(edgeIndex).toBeGreaterThan(-1);
+    expect(regularNodeIndex).toBeGreaterThan(-1);
+    expect(groupIndex).toBeLessThan(edgeIndex);
+    expect(edgeIndex).toBeLessThan(regularNodeIndex);
+    expect(result).toContain('width="300"');
+    expect(result).toContain('height="180"');
+  });
+
+  it("should use computedStyle size for real group node elements", () => {
+    const realGroupNode = document.createElement("div");
+    realGroupNode.style.transform = "translate(1px, 2px)";
+
+    const realGroupSvg = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "svg"
+    );
+    realGroupSvg.setAttribute("data-group-node", "true");
+    realGroupNode.appendChild(realGroupSvg);
+
+    const computedStyleSpy = jest
+      .spyOn(window, "getComputedStyle")
+      .mockReturnValue({
+        width: "321px",
+        height: "123px",
+      } as CSSStyleDeclaration);
+
+    const mockRenderer = createMockElement("div");
+    mockRenderer.querySelectorAll = jest.fn().mockImplementation((selector) => {
+      if (selector === "[data-id]") {
+        return [realGroupNode];
+      }
+      if (selector === ".react-flow__edge path") {
+        return [];
+      }
+      if (selector === ".react-flow__edge polygon") {
+        return [];
+      }
+      return [];
+    });
+    mockRenderer.querySelector = jest.fn().mockImplementation((selector) => {
+      if (selector === ".react-flow__viewport") {
+        return createMockElement("div");
+      }
+      return null;
+    });
+
+    const mockContainer = createMockElement("div");
+    mockContainer.querySelector = jest.fn().mockReturnValue(mockRenderer);
+
+    jest
+      .spyOn(document, "getElementById")
+      .mockReturnValue(mockContainer as any);
+
+    const result = generateSVGContent("test-graph-id");
+
+    expect(result).toContain('width="321"');
+    expect(result).toContain('height="123"');
+    computedStyleSpy.mockRestore();
+  });
+
+  it("should fall back to boundingClientRect size for group nodes", () => {
+    const realGroupNode = document.createElement("div");
+    realGroupNode.style.transform = "translate(3px, 4px)";
+    jest.spyOn(realGroupNode, "getBoundingClientRect").mockReturnValue({
+      width: 444,
+      height: 222,
+      x: 0,
+      y: 0,
+      top: 0,
+      right: 444,
+      bottom: 222,
+      left: 0,
+      toJSON: () => ({}),
+    });
+
+    const realGroupSvg = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "svg"
+    );
+    realGroupSvg.setAttribute("data-group-node", "true");
+    realGroupNode.appendChild(realGroupSvg);
+
+    const computedStyleSpy = jest
+      .spyOn(window, "getComputedStyle")
+      .mockReturnValue({ width: "", height: "" } as CSSStyleDeclaration);
+
+    const mockRenderer = createMockElement("div");
+    mockRenderer.querySelectorAll = jest.fn().mockImplementation((selector) => {
+      if (selector === "[data-id]") {
+        return [realGroupNode];
+      }
+      if (selector === ".react-flow__edge path") {
+        return [];
+      }
+      if (selector === ".react-flow__edge polygon") {
+        return [];
+      }
+      return [];
+    });
+    mockRenderer.querySelector = jest.fn().mockImplementation((selector) => {
+      if (selector === ".react-flow__viewport") {
+        return createMockElement("div");
+      }
+      return null;
+    });
+
+    const mockContainer = createMockElement("div");
+    mockContainer.querySelector = jest.fn().mockReturnValue(mockRenderer);
+
+    jest
+      .spyOn(document, "getElementById")
+      .mockReturnValue(mockContainer as any);
+
+    const result = generateSVGContent("test-graph-id");
+
+    expect(result).toContain('width="444"');
+    expect(result).toContain('height="222"');
+    computedStyleSpy.mockRestore();
+  });
+
+  it("should fall back to default group size when style, computedStyle, and rect dimensions are zero", () => {
+    const mockGroupNode = createMockElement("div");
+    mockGroupNode.style = { transform: "translate(7px, 8px)" };
+    mockGroupNode.getBoundingClientRect = jest.fn().mockReturnValue({
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      toJSON: () => ({}),
+    });
+
+    const mockGroupSvg = createMockElement("svg");
+    mockGroupSvg.hasAttribute = jest.fn().mockImplementation((attr) => {
+      return attr === "data-group-node";
+    });
+    mockGroupNode.querySelector = jest.fn().mockImplementation((selector) => {
+      if (selector === "svg") {
+        return mockGroupSvg;
+      }
+      return null;
+    });
+
+    const mockRenderer = createMockElement("div");
+    mockRenderer.querySelectorAll = jest.fn().mockImplementation((selector) => {
+      if (selector === "[data-id]") {
+        return [mockGroupNode];
+      }
+      if (selector === ".react-flow__edge path") {
+        return [];
+      }
+      if (selector === ".react-flow__edge polygon") {
+        return [];
+      }
+      return [];
+    });
+    mockRenderer.querySelector = jest.fn().mockImplementation((selector) => {
+      if (selector === ".react-flow__viewport") {
+        return createMockElement("div");
+      }
+      return null;
+    });
+
+    const mockContainer = createMockElement("div");
+    mockContainer.querySelector = jest.fn().mockReturnValue(mockRenderer);
+
+    jest
+      .spyOn(document, "getElementById")
+      .mockReturnValue(mockContainer as any);
+
+    const result = generateSVGContent("test-graph-id");
+
+    expect(result).toContain(`width="${NODE_WIDTH - 2}"`);
+    expect(result).toContain(`height="${NODE_HEIGHT - 2}"`);
   });
 });
 

--- a/components/file-graph/file-graph.tsx
+++ b/components/file-graph/file-graph.tsx
@@ -321,9 +321,16 @@ function FileSetNodeContent(props: NodeProps) {
  */
 function GroupNodeContent() {
   return (
-    <div
-      className={`relative h-full w-full border ${groupTypeColorMap.bg} ${groupTypeColorMap.border}`}
-    />
+    <svg width="100%" height="100%" data-group-node>
+      <rect
+        x="0"
+        y="0"
+        width="100%"
+        height="100%"
+        className={`${groupTypeColorMap.bg} ${groupTypeColorMap.border}`}
+        strokeWidth="1"
+      />
+    </svg>
   );
 }
 
@@ -358,6 +365,9 @@ function CustomArrowEdge({
     targetY,
     targetPosition,
   });
+  const edgeStroke =
+    (style as (CSSProperties & { stroke?: string }) | undefined)?.stroke ||
+    "#6b7280";
 
   return (
     <g>
@@ -370,7 +380,7 @@ function CustomArrowEdge({
       />
       <polygon
         points={`${targetX},${targetY} ${targetX - 5},${targetY - 5} ${targetX - 5},${targetY + 5}`}
-        fill={style?.stroke || "#6b7280"}
+        fill={edgeStroke}
         className="react-flow__edge-arrowhead"
       />
     </g>
@@ -765,7 +775,6 @@ export function FileGraph({
           qualityMetrics
         )
       : null;
-  console.log("Graph data:", JSON.stringify(graphData, (key, value) => key === "metadata" ? undefined : value, 2));
 
   if (graphData || cycles.length > 0 || isEmptyGraphAfterFiltering) {
     return (

--- a/components/file-graph/lib.ts
+++ b/components/file-graph/lib.ts
@@ -13,6 +13,7 @@ import { groupingPipelineRunner, type GroupNodeMap } from "./grouping-pipeline";
 import {
   fileSetTypeColorMap,
   fileTypeColorMap,
+  groupTypeColorMap,
   isFileSetNodeMetadata,
   isGroupNodeMetadata,
   NODE_KINDS,
@@ -50,6 +51,48 @@ const HASH_SEED = 0xe8c0f852;
  * Padding (in pixels) added around SVG export content for visual spacing.
  */
 const SVG_CONTENT_PADDING = 5;
+
+/**
+ * Resolve rendered node dimensions so exported geometry matches the browser rendering.
+ *
+ * @param nodeElement - The HTML element of the node to get dimensions for
+ * @param fallbackWidth - Fallback width to use if rendered dimensions resolve to 0
+ * @param fallbackHeight - Fallback height to use if rendered dimensions resolve to 0
+ * @return Object containing the resolved width and height for the node
+ */
+function getRenderedNodeSize(
+  nodeElement: HTMLElement,
+  fallbackWidth: number,
+  fallbackHeight: number
+): { width: number; height: number } {
+  // Try to get dimensions from the node's inline styles first, as these are most likely to reflect
+  // the actual rendered size.
+  const styleWidth = parseFloat(nodeElement.style?.width || "");
+  const styleHeight = parseFloat(nodeElement.style?.height || "");
+  if (styleWidth && styleHeight) {
+    return { width: styleWidth, height: styleHeight };
+  }
+
+  // If inline styles don't provide valid dimensions, try to get computed styles. This is a more
+  // expensive operation, but it can capture dimensions set by CSS classes.
+  if (nodeElement instanceof Element) {
+    const computedStyle = getComputedStyle(nodeElement);
+    const computedWidth = parseFloat(computedStyle.width) || 0;
+    const computedHeight = parseFloat(computedStyle.height) || 0;
+    if (computedWidth && computedHeight) {
+      return { width: computedWidth, height: computedHeight };
+    }
+  }
+
+  // If computed styles don't provide valid dimensions, use the bounding client rect. This is a
+  // last resort because it can be affected by transforms.
+  const rect = nodeElement.getBoundingClientRect();
+  if (rect.width && rect.height) {
+    return { width: rect.width, height: rect.height };
+  }
+
+  return { width: fallbackWidth, height: fallbackHeight };
+}
 
 /**
  * Static root node of ELK graph.
@@ -728,34 +771,11 @@ export function generateSVGContent(graphId: string): string | undefined {
   const height = contentHeight + SVG_CONTENT_PADDING * 2;
 
   // Generate SVG header with calculated dimensions and viewBox starting at negative padding.
-  let svgContent = `<?xml version="1.0" encoding="UTF-8"?><svg width="${width}px" height="${height}px" viewBox="${-SVG_CONTENT_PADDING} ${-SVG_CONTENT_PADDING} ${width} ${height}" xmlns="http://www.w3.org/2000/svg">`;
+  const svgHeader = `<?xml version="1.0" encoding="UTF-8"?><svg width="${width}px" height="${height}px" viewBox="${-SVG_CONTENT_PADDING} ${-SVG_CONTENT_PADDING} ${width} ${height}" xmlns="http://www.w3.org/2000/svg">`;
 
-  // Add edge paths to the accumulating SVG text.
-  const edgePathElements = reactFlowRenderer.querySelectorAll(
-    ".react-flow__edge path"
-  );
-  const edgePathElementArray = Array.from(edgePathElements);
-  svgContent += edgePathElementArray.reduce((acc, pathElement) => {
-    const d = pathElement.getAttribute("d");
-    const stroke = pathElement.getAttribute("stroke") || "#6b7280";
-    const strokeWidth = pathElement.getAttribute("stroke-width") || "1";
-    return d
-      ? `${acc} <path d="${d}" stroke="${stroke}" stroke-width="${strokeWidth}" fill="none"/>\n`
-      : acc;
-  }, "");
-
-  // Add arrowheads to the accumulating SVG text.
-  const edgeArrowheadElements = reactFlowRenderer.querySelectorAll(
-    ".react-flow__edge polygon"
-  );
-  const edgeArrowheadElementArray = Array.from(edgeArrowheadElements);
-  svgContent += edgeArrowheadElementArray.reduce((acc, polygonElement) => {
-    const points = polygonElement.getAttribute("points");
-    const fill = "#6b7280";
-    return points
-      ? `${acc}  <polygon points="${points}" fill="${fill}"/>\n`
-      : acc;
-  }, "");
+  // Build node layers separately so group nodes can be painted behind edges and regular nodes.
+  let groupNodeLayer = "";
+  let regularNodeLayer = "";
 
   // Add nodes by copying the rendered SVG node elements from the DOM.
   const nodeElements = reactFlowRenderer.querySelectorAll("[data-id]");
@@ -771,8 +791,10 @@ export function generateSVGContent(graphId: string): string | undefined {
     const x = match ? parseFloat(match[1]) : 0;
     const y = match ? parseFloat(match[2]) : 0;
 
-    // Check if this is a file set node by looking for the data attribute.
+    // Check node kind markers on rendered SVG roots.
     const isFileSetNode = svgElement.hasAttribute("data-fileset-type");
+    const isGroupNode =
+      !isFileSetNode && svgElement.hasAttribute("data-group-node");
 
     // Determine colors based on node type.
     let nodeColors;
@@ -780,6 +802,8 @@ export function generateSVGContent(graphId: string): string | undefined {
       const fileSetType = svgElement.getAttribute("data-fileset-type") || "";
       nodeColors =
         fileSetTypeColorMap[fileSetType] || fileSetTypeColorMap.unknown;
+    } else if (isGroupNode) {
+      nodeColors = groupTypeColorMap;
     } else {
       nodeColors = fileTypeColorMap;
     }
@@ -798,13 +822,64 @@ export function generateSVGContent(graphId: string): string | undefined {
       return colorVariableToColorHex(colorVar) || colorVar;
     });
 
-    // Add background rect and content.
-    const cleanSvg = isFileSetNode
-      ? `<rect x="0" y="0" width="${NODE_WIDTH - 2}" height="${NODE_HEIGHT - 2}" rx="${NODE_HEIGHT / 2}" fill="${nodeColors.bgColor}" stroke="${nodeColors.borderColor}" stroke-width="1"/>${svgContentInner}`
-      : `<rect x="0" y="0" width="${NODE_WIDTH - 2}" height="${NODE_HEIGHT - 2}" fill="${nodeColors.bgColor}" stroke="${nodeColors.borderColor}" stroke-width="1"/>${svgContentInner}`;
+    const nodeElementAsHtml = nodeElement as HTMLElement;
+    const { width: renderedNodeWidth, height: renderedNodeHeight } =
+      getRenderedNodeSize(nodeElementAsHtml, NODE_WIDTH - 2, NODE_HEIGHT - 2);
 
-    svgContent += `  <g transform="translate(${x}, ${y})">${cleanSvg}</g>\n`;
+    // Add background rect and content.
+    let cleanSvg = "";
+    if (isGroupNode) {
+      cleanSvg = `<rect x="0" y="0" width="${renderedNodeWidth}" height="${renderedNodeHeight}" fill="${nodeColors.bgColor}" stroke="${nodeColors.borderColor}" stroke-width="1"/>`;
+    } else if (isFileSetNode) {
+      cleanSvg = `<rect x="0" y="0" width="${renderedNodeWidth}" height="${renderedNodeHeight}" rx="${renderedNodeHeight / 2}" fill="${nodeColors.bgColor}" stroke="${nodeColors.borderColor}" stroke-width="1"/>${svgContentInner}`;
+    } else {
+      cleanSvg = `<rect x="0" y="0" width="${renderedNodeWidth}" height="${renderedNodeHeight}" fill="${nodeColors.bgColor}" stroke="${nodeColors.borderColor}" stroke-width="1"/>${svgContentInner}`;
+    }
+
+    const nodeSvg = `  <g transform="translate(${x}, ${y})">${cleanSvg}</g>\n`;
+    if (isGroupNode) {
+      groupNodeLayer += nodeSvg;
+    } else {
+      regularNodeLayer += nodeSvg;
+    }
   });
+
+  // Add edge paths.
+  const edgePathElements = reactFlowRenderer.querySelectorAll(
+    ".react-flow__edge path"
+  );
+  const edgePathElementArray = Array.from(edgePathElements);
+  const edgePathLayer = edgePathElementArray.reduce((acc, pathElement) => {
+    const d = pathElement.getAttribute("d");
+    const stroke = pathElement.getAttribute("stroke") || "#6b7280";
+    const strokeWidth = pathElement.getAttribute("stroke-width") || "1";
+    return d
+      ? `${acc} <path d="${d}" stroke="${stroke}" stroke-width="${strokeWidth}" fill="none"/>\n`
+      : acc;
+  }, "");
+
+  // Add arrowheads.
+  const edgeArrowheadElements = reactFlowRenderer.querySelectorAll(
+    ".react-flow__edge polygon"
+  );
+  const edgeArrowheadElementArray = Array.from(edgeArrowheadElements);
+  const edgeArrowheadLayer = edgeArrowheadElementArray.reduce(
+    (acc, polygonElement) => {
+      const points = polygonElement.getAttribute("points");
+      const fill = "#6b7280";
+      return points
+        ? `${acc}  <polygon points="${points}" fill="${fill}"/>\n`
+        : acc;
+    },
+    ""
+  );
+
+  let svgContent =
+    svgHeader +
+    groupNodeLayer +
+    edgePathLayer +
+    edgeArrowheadLayer +
+    regularNodeLayer;
 
   // Close the SVG element. We now have the entire SVG to download as a string.
   svgContent += "</svg>";

--- a/components/file-graph/types.ts
+++ b/components/file-graph/types.ts
@@ -210,11 +210,11 @@ export const fileTypeColorMap: ColorMapSpec = {
  * Tailwind CSS classes have names we can use directly.
  */
 export const groupTypeColorMap: ColorMapSpec = {
-  bg: "bg-file-graph-group",
+  bg: "fill-file-graph-group",
   bgCount: "",
-  border: "border-file-graph-group",
-  bgColor: "#d0d0d0",
-  borderColor: "#505050",
+  border: "stroke-file-graph-node",
+  bgColor: "#F8F8F8",
+  borderColor: "#212938",
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -11118,15 +11118,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -11752,9 +11753,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -11772,7 +11773,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -400,7 +400,6 @@
   --color-file-graph-file-count: oklch(0.5 0 0);
   --color-file-graph-file-border: oklch(0.4891 0 0);
   --color-file-graph-group: oklch(0.9791 0 0);
-  --color-file-graph-group-border: oklch(0.5999 0 0);
 
   /** Modal */
   --color-modal-border: #cecfd3;
@@ -697,7 +696,6 @@
   --color-file-graph-file: oklch(0.3092 0 0);
   --color-file-graph-file-border: oklch(0.5999 0 0);
   --color-file-graph-group: oklch(0.1703 0 0);
-  --color-file-graph-group-border: oklch(0.4891 0 0);
 
   --color-modal-border: #68799c;
   --color-modal-backdrop: oklch(0 0 0 / 60%);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -161,7 +161,6 @@ const tailwindConfig: Config = {
         "file-graph-file-count": "var(--color-file-graph-file-count)",
         "file-graph-qc-trigger": "var(--color-file-graph-qc-trigger-bg)",
         "file-graph-qc-trigger-text": "var(--color-file-graph-qc-trigger-text)",
-        "file-graph-group": "var(--color-file-graph-group)",
 
         "tissue-matrix-data-homo-sapiens":
           "var(--color-tissue-matrix-data-homo-sapiens)",
@@ -334,7 +333,6 @@ const tailwindConfig: Config = {
         "file-graph-prediction": "var(--color-file-graph-prediction-border)",
         "file-graph-unknown": "var(--color-file-graph-unknown-border)",
         "file-graph-file": "var(--color-file-graph-file-border)",
-        "file-graph-group": "var(--color-file-graph-group-border)",
       },
       fontSize: {
         xxs: "0.7rem",
@@ -468,6 +466,9 @@ const tailwindConfig: Config = {
         "audit-not-compliant": "var(--color-audit-not-compliant-fill)",
         "audit-internal-action": "var(--color-audit-internal-action-fill)",
         "audit-facet": "var(--color-audit-facet-fill)",
+
+        // File graph
+        "file-graph-group": "var(--color-file-graph-group)",
       },
       gridTemplateColumns: {
         "min-2": "repeat(2, minmax(0, min-content))",


### PR DESCRIPTION
# PR Review: IGVF-3526-graph-dl-groups

## Reviewer
- Model: GPT-5.3-Codex

## Summary
- Reviewed all branch changes against dev.
- Focus areas: file graph rendering, SVG export behavior, styling/token updates for group nodes, and test coverage for new export logic.

## Files Reviewed
- components/file-graph/__tests__/lib.test.ts
- components/file-graph/file-graph.tsx
- components/file-graph/lib.ts
- components/file-graph/types.ts
- styles/globals.css
- tailwind.config.ts
- package-lock.json

## Findings
- No blocking issues found.
- The edge color behavior difference between in-app rendering and downloaded SVG is intentional and appropriate for requirements:
  - In-app graph remains CSS/theme driven, including dark mode.
  - Downloaded SVG uses self-contained colors so it renders correctly outside the app where CSS variables and theme context are unavailable.

## Validation
- Targeted test run passed:
  - npm test -- --runInBand components/file-graph/__tests__/lib.test.ts -t generateSVGContent
- Full workspace typecheck/build was not re-run as part of this review note.

## Final Verdict
- Approve.
- The PR is ready to merge from a code review perspective.
 No newline at end of file