### PR TITLE
IGVF-3546 Repair Cypress tests after test data change

### DIFF
--- a/cypress/e2e/facets.cy.js
+++ b/cypress/e2e/facets.cy.js
@@ -17,11 +17,13 @@ describe("Facet tests", () => {
     // Make sure we have some search results.
     cy.get(`[data-testid^="search-list-item-/"]`).should("have.length.gte", 5);
 
-    // Make sure we have some facets and open the Sample one. For some reason we need the delay or
-    // it ignores the click.
+    // Make sure we have some facets and open the Sample one.
     cy.get(`[data-testid^="facet-container-"]`).should("have.length.gte", 3);
-    cy.wait(1000);
-    cy.get(`[data-testid="facettrigger-sample_terms.term_name"]`).click();
+    cy.get(`[data-testid="facettrigger-sample_terms.term_name"]`, {
+      timeout: 20000,
+    })
+      .should("be.visible")
+      .click();
 
     // Make sure clicking a facet term in the Sample facet has an effect.
     cy.get(`label[id="facet-checkbox-sample_terms.term_name-hues8"]`).click();
@@ -34,8 +36,12 @@ describe("Facet tests", () => {
     );
 
     // Open the Lab facet, click a term, and make sure it has an effect.
-    cy.wait(1000);
-    cy.get(`[data-testid="facettrigger-lab.title"]`).click();
+    cy.get(`[data-testid="facettrigger-lab.title"]`, {
+      timeout: 20000,
+    }).scrollIntoView();
+    cy.get(`[data-testid="facettrigger-lab.title"]`)
+      .should("be.visible")
+      .click();
     cy.get(
       `label[id="facet-checkbox-lab.title-danwei-huangfu-2c-mskcc"]`
     ).click();
@@ -54,15 +60,27 @@ describe("Facet tests", () => {
     // Check we can transition to the report view with selected facets. Delay three seconds to make
     // sure opened facets get saved.
     cy.wait(3000);
+    cy.get(`[data-testid="facettrigger-lab.title"]`).then(($trigger) => {
+      if ($trigger.attr("aria-expanded") !== "true") {
+        cy.wrap($trigger).click();
+      }
+    });
+    cy.get(`[data-testid="facet-container-lab.title"]`)
+      .contains("label", /J\.? Michael Cherry, Stanford/i)
+      .click();
     cy.get(
-      `label[id="facet-checkbox-lab.title-j-michael-cherry-2c-stanford"]`
-    ).click();
-    cy.get(`[data-testid^="search-list-item-/"]`).should("have.length.gte", 5);
+      `[aria-label*="Clear Lab filter for"][aria-label*="Michael Cherry"]`
+    ).should("exist");
+    cy.get(`[data-testid^="search-list-item-/"]`)
+      .its("length")
+      .as("filteredSearchCount");
     cy.get(`[aria-label="Select report view"]`).click();
-    cy.get(`[data-testid="search-results-count"]`).should(
-      "have.text",
-      "8 items"
-    );
+    cy.get("@filteredSearchCount").then((filteredSearchCount) => {
+      cy.get(`[data-testid="search-results-count"]`).should(
+        "have.text",
+        `${filteredSearchCount} items`
+      );
+    });
 
     // Now we're in the report view. Make sure the Sample and Lab facets are still open.
     cy.get(`[data-testid="facettrigger-sample_terms.term_name"]`).should(
@@ -76,14 +94,26 @@ describe("Facet tests", () => {
       "true"
     );
 
-    // Uncheck the lab facet term and make sure the count updates.
+    // Uncheck the lab facet term and make sure the selected-filter chip clears.
+    cy.get(`[data-testid="facettrigger-lab.title"]`).then(($trigger) => {
+      if ($trigger.attr("aria-expanded") !== "true") {
+        cy.wrap($trigger).click();
+      }
+    });
+    cy.get(`[data-testid="facet-container-lab.title"]`)
+      .contains("label", /J\.? Michael Cherry, Stanford/i)
+      .click();
     cy.get(
-      `label[id="facet-checkbox-lab.title-j-michael-cherry-2c-stanford"]`
-    ).click();
-    cy.get(`[data-testid="search-results-count"]`).should(
-      "have.text",
-      "8 items"
-    );
+      `[aria-label*="Clear Lab filter for"][aria-label*="Michael Cherry"]`
+    ).should("not.exist");
+    cy.get("@filteredSearchCount").then((filteredSearchCount) => {
+      cy.get(`[data-testid="search-results-count"]`)
+        .invoke("text")
+        .then((text) => {
+          const unfilteredCount = Number.parseInt(text, 10);
+          cy.wrap(unfilteredCount).should("be.gte", filteredSearchCount);
+        });
+    });
 
     // Load the search view and make sure the Sample and Lab facets are still open.
     cy.visit("/search/?type=InVitroSystem");


### PR DESCRIPTION
# PR Review: IGVF-3546-update-cypress-test

## Model
GPT-5.3-Codex

## Summary
Verdict: Approve

This change improves Cypress test stability by replacing brittle fixed waits and hard-coded result counts with state-aware assertions. I found no functional regressions in the branch diff.

## Findings
No blocking issues found.

## Reviewed Changes
- [cypress/e2e/facets.cy.js](cypress/e2e/facets.cy.js)

## What Looks Good
1. Replaced fixed waits with visibility and timeout checks when opening facet controls, which should reduce flakiness in slower CI runs.
2. Replaced a hard-coded report-count assertion with a count captured from current filtered search results, making the test robust to data drift.
3. Updated the unfilter validation to assert non-decrease relative to filtered count, avoiding brittle fixed-number expectations.

## Residual Risks
1. Cypress tests were not executed as part of this review, so runtime behavior is not revalidated here.
2. The selector based on visible label text for Michael Cherry is more resilient than exact generated IDs, but can still break if display text changes.

## Ready-to-Paste PR Comment
I reviewed the branch changes in [cypress/e2e/facets.cy.js](cypress/e2e/facets.cy.js).

Summary verdict: Approve.

I found no functional regressions. The updates improve test reliability by replacing fixed waits with visibility checks and replacing hard-coded counts with dynamic assertions based on current search results.

Residual risk: I did not execute Cypress in this pass, so this is a static review only.

Model: GPT-5.3-Codex
