### PR TITLE
IGVF-3512 Display pseudobulk-set cell annotation with tooltips

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 clean:
 	rm -rf node_modules
 	rm -rf .next
+	rm -rf out
 	rm -rf coverage
 	rm -rf cypress/videos
 	rm -rf cypress/screenshots

--- a/components/__tests__/sample-annotated-summary.test.tsx
+++ b/components/__tests__/sample-annotated-summary.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { type OntologyTermObject } from "../../lib/ontology-terms";
+import { SampleAnnotatedSummary } from "../sample-annotated-summary";
+
+describe("SampleAnnotatedSummary", () => {
+  it("renders summary with annotated terms", async () => {
+    const summary = "This is a sample summary with term1 and term2.";
+    const terms: OntologyTermObject[] = [
+      {
+        "@id": "/ontology-terms/TERM_1",
+        "@type": ["OntologyTerm", "Item"],
+        term_id: "TERM_1",
+        term_name: "term1",
+        definition: "Definition of term1",
+        status: "released",
+      },
+      {
+        "@id": "/ontology-terms/TERM_2",
+        "@type": ["OntologyTerm", "Item"],
+        term_id: "TERM_2",
+        term_name: "term2",
+        definition: "Definition of term2",
+        status: "released",
+      },
+    ];
+
+    const { container } = render(
+      <SampleAnnotatedSummary summary={summary} terms={terms} />
+    );
+
+    // Check that the summary text is rendered
+    expect(
+      screen.getByText(/This is a sample summary with/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/and/)).toBeInTheDocument();
+
+    // Find the element with `aria-describedby="tooltip-term1-1"` and hover the mouse over it.
+    const term1Element = container.querySelector(
+      '[aria-describedby="tooltip-term1-1"]'
+    );
+    expect(term1Element).toBeInTheDocument();
+    fireEvent.mouseEnter(term1Element);
+
+    // Check that the tooltip for term1 is displayed with the correct definition.
+    const tooltip1 = await screen.findByTestId("tooltip-term1-1");
+    expect(tooltip1).toBeInTheDocument();
+    expect(tooltip1).toHaveTextContent("Definition of term1");
+
+    // Find the element with `aria-describedby="tooltip-term2-1"` and hover the mouse over it.
+    const term2Element = container.querySelector(
+      '[aria-describedby="tooltip-term2-3"]'
+    );
+    expect(term2Element).toBeInTheDocument();
+    fireEvent.mouseEnter(term2Element);
+
+    // Check that the tooltip for term2 is displayed with the correct definition.
+    const tooltip2 = await screen.findByTestId("tooltip-term2-3");
+    expect(tooltip2).toBeInTheDocument();
+    expect(tooltip2).toHaveTextContent("Definition of term2");
+  });
+
+  it("renders summary without annotations when no terms are provided", () => {
+    const summary = "This is a sample summary without terms.";
+    const terms: OntologyTermObject[] = [];
+
+    const { container } = render(
+      <SampleAnnotatedSummary summary={summary} terms={terms} />
+    );
+
+    // Check that the summary text is rendered as a single node without annotations.
+    expect(screen.getByText(summary)).toBeInTheDocument();
+
+    const describedElements = container.querySelectorAll("[aria-describedby]");
+    expect(describedElements.length).toBe(0);
+  });
+
+  it("renders summary without annotating terms that are parts of other words", () => {
+    const summary = "This is a sample summary with term1 and term12.";
+    const terms: OntologyTermObject[] = [
+      {
+        "@id": "/ontology-terms/TERM_1",
+        "@type": ["OntologyTerm", "Item"],
+        term_id: "TERM_1",
+        term_name: "term1",
+        definition: "Definition of term1",
+        status: "released",
+      },
+    ];
+
+    const { container } = render(
+      <SampleAnnotatedSummary summary={summary} terms={terms} />
+    );
+
+    // Check that only the exact match "term1" is annotated, and "term12" is not.
+    const term1Element = container.querySelector(
+      '[aria-describedby="tooltip-term1-1"]'
+    );
+    expect(term1Element).toBeInTheDocument();
+    expect(term1Element).toHaveTextContent("term1");
+
+    const term12Element = container.querySelector(
+      '[aria-describedby="tooltip-term1-2"]'
+    );
+    expect(term12Element).not.toBeInTheDocument();
+  });
+});

--- a/components/report/generate-columns.tsx
+++ b/components/report/generate-columns.tsx
@@ -16,6 +16,7 @@ import { API_URL } from "../../lib/constants";
 import { type FileSetObject } from "../../lib/file-sets";
 import { dataSize } from "../../lib/general";
 import { type GeneLocation } from "../../lib/genes";
+import { type OntologyTermObject } from "../../lib/ontology-terms";
 import { type ColumnSpec } from "../../lib/report";
 // root
 import type {
@@ -23,7 +24,6 @@ import type {
   DocumentObject,
   FileObject,
   HumanDonorObject,
-  OntologyTermObject,
   PageObject,
 } from "../../globals";
 

--- a/components/sample-annotated-summary.tsx
+++ b/components/sample-annotated-summary.tsx
@@ -1,0 +1,109 @@
+// node_modules
+import _ from "lodash";
+// components
+import { AnnotatedItem } from "./annotated-value";
+// lib
+import { type OntologyTermObject } from "../lib/ontology-terms";
+
+/**
+ * Regex pattern that matches a single word character, which includes letters, numbers, underscores,
+ * and hyphens. This is used to identify term names in the summary string that may contain these
+ * characters.
+ */
+const WORD_CHAR = String.raw`[\p{L}\p{N}_-]`;
+
+/**
+ * Display a summary string with annotated terms. The summary string may contain multiple terms that
+ * we want to annotate with tooltips. The terms to annotate and their corresponding annotations are
+ * provided in the `terms` array. Each term in the summary that matches a term name in the `terms`
+ * array will be wrapped with an `AnnotatedItem` that shows the term's definition in a tooltip on
+ * hover.
+ *
+ * @param summary - Summary string that may contain terms to annotate
+ * @param terms - Ontology term objects that provide the term names and their annotations
+ */
+export function SampleAnnotatedSummary({
+  summary,
+  terms,
+}: {
+  summary: string;
+  terms: OntologyTermObject[];
+}) {
+  const annotatedParts = renderAnnotatedSummary(summary, terms);
+  return <>{annotatedParts}</>;
+}
+
+/**
+ * Generate React nodes for a summary string that contains annotated terms. The function identifies
+ * terms in the summary that match the term names in the provided `terms` array and wraps those
+ * terms with `AnnotatedItem` components that display the term's definition in a tooltip. Non-term
+ * parts of the summary are returned as plain text nodes. This lets you display one summary string
+ * with multiple annotated terms, where each term's annotation is shown on hover.
+ *
+ * @param summary - Potentially contains term names needing annotation
+ * @param terms - Ontology term objects that provide the term names and their annotations
+ * @returns React nodes with annotated terms wrapped in `AnnotatedItem` components, and non-term
+ *          parts as plain text
+ */
+function renderAnnotatedSummary(
+  summary: string,
+  terms: OntologyTermObject[]
+): React.ReactNode {
+  // Map term names to their corresponding term objects for quick lookup.
+  const termByName = new Map(terms.map((term) => [term.term_name, term]));
+
+  // Get a list of term names sorted by length in descending order to ensure longer matches are
+  // found first, avoiding partial matches.
+  const termNames = _.sortBy(terms, (term) => -term.term_name.length).map(
+    (term) => term.term_name
+  );
+
+  // Generate a regex pattern that matches any of the term names, escaping special characters to
+  // avoid regex errors. The "|" is the regex "or" operator, allowing us to match any of the term
+  // names. Example: ["term.1", "abc|def", "44+55"] becomes "term\.1|abc\|def|44\+55".
+  const pattern = termNames
+    .map((termName) => {
+      const escaped = escapeRegExp(termName);
+      return String.raw`(?<!${WORD_CHAR})${escaped}(?!${WORD_CHAR})`;
+    })
+    .join("|");
+  if (!pattern) {
+    // No terms to annotate, return the original summary as a single React node.
+    return summary;
+  }
+
+  // Make a regex that matches any of the term names in the summary, with a capture group so that
+  // the non-matching parts of the summary are preserved when we split the string.
+  const regex = new RegExp(`(${pattern})`, "gu");
+
+  // Split the summary into parts based on the composed regex. Each part is either a term name that
+  // we annotate or a non-term string that we leave as is.
+  return summary.split(regex).map((part, index) => {
+    const term = termByName.get(part);
+
+    // Handle the case where the part is not a given term name.
+    if (!term) {
+      return part;
+    }
+
+    // Handle the case where the part is a term name that we want to annotate.
+    const key = `${part}-${index}`;
+    return (
+      <AnnotatedItem key={key} tooltipKey={key} annotation={term.definition}>
+        {part}
+      </AnnotatedItem>
+    );
+  });
+}
+
+/**
+ * To build a regex pattern that matches any of the term names in the summary, special characters
+ * in the term names that could interfere with the regex syntax need escaping. This function takes
+ * a term name and escapes those characters.
+ *
+ * @param termName - Term name to escape for use in a regular expression
+ * @returns Escaped string, safe for use in a regular expression
+ */
+function escapeRegExp(termName: string) {
+  return termName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/components/search/__tests__/list-renderer.test.js
+++ b/components/search/__tests__/list-renderer.test.js
@@ -3679,6 +3679,41 @@ describe("Test IndexFile component", () => {
 });
 
 describe("Test the PseudobulkSet component", () => {
+  it("renders a PseudobulkSet item with non-embedded lab", () => {
+    const item = {
+      "@id": "/pseudobulk-sets/IGVFDS1111PBST/",
+      "@type": ["PseudobulkSet", "FileSet", "Item"],
+      accession: "IGVFDS1111PBST",
+      aliases: ["igvf:basic_pseudobulk_set"],
+      award: "/awards/HG012012/",
+      files: [],
+      file_set_type: "pseudobulk analysis",
+      lab: "/labs/j-michael-cherry-stanford/",
+      status: "released",
+      summary: "pseudobulk set of data",
+      uuid: "609869e7-cbd9-4d06-9569-d3fdb4604ccd",
+    };
+
+    render(
+      <SessionContext.Provider value={{ profiles }}>
+        <PseudobulkSet item={item} />
+      </SessionContext.Provider>
+    );
+
+    expect(screen.getByTestId("search-list-item-unique-id")).toHaveTextContent(
+      /^Pseudobulk Set IGVFDS1111PBST$/
+    );
+    expect(screen.getByTestId("search-list-item-title")).toHaveTextContent(
+      /^pseudobulk set of data$/
+    );
+    expect(screen.getByTestId("search-list-item-meta")).toHaveTextContent(
+      "/labs/j-michael-cherry-stanford/"
+    );
+    expect(screen.getByTestId("search-list-item-quality")).toHaveTextContent(
+      "released"
+    );
+  });
+
   it("renders a PseudobulkSet item with alternate accession", () => {
     const item = {
       "@id": "/pseudobulk-sets/IGVFDS1111PBST/",
@@ -3687,6 +3722,7 @@ describe("Test the PseudobulkSet component", () => {
       alternate_accessions: ["IGVFDS1111PBSU"],
       aliases: ["igvf:basic_pseudobulk_set"],
       award: "/awards/HG012012/",
+      cell_type: "/sample-terms/CL_0000000/",
       files: [],
       file_set_type: "pseudobulk analysis",
       lab: {
@@ -3697,9 +3733,26 @@ describe("Test the PseudobulkSet component", () => {
       uuid: "609869e7-cbd9-4d06-9569-d3fdb4604ccd",
     };
 
+    const accessoryData = {
+      "/pseudobulk-sets/IGVFDS1111PBST/": {
+        "@id": "/sample-terms/CL_0000000/",
+        "@type": ["SampleTerm", "Item"],
+        cell_annotation: "H9 cell type",
+        cell_type: {
+          "@id": "/sample-terms/UBERON_0002048/",
+          definition:
+            "Respiration organ that develops as an outpocketing of the esophagus.",
+          status: "released",
+          term_id: "UBERON:0002048",
+          term_name: "lung",
+        },
+        workflows: [],
+      },
+    };
+
     render(
       <SessionContext.Provider value={{ profiles }}>
-        <PseudobulkSet item={item} />
+        <PseudobulkSet item={item} accessoryData={accessoryData} />
       </SessionContext.Provider>
     );
 
@@ -3727,6 +3780,7 @@ describe("Test the PseudobulkSet component", () => {
       accession: "IGVFDS1111PBST",
       aliases: ["igvf:basic_pseudobulk_set"],
       award: "/awards/HG012012/",
+      cell_type: { term_name: "H9" },
       description: "This is my description",
       files: [],
       file_set_type: "pseudobulk analysis",
@@ -3738,9 +3792,26 @@ describe("Test the PseudobulkSet component", () => {
       uuid: "609869e7-cbd9-4d06-9569-d3fdb4604ccd",
     };
 
+    const accessoryData = {
+      "/pseudobulk-sets/IGVFDS1111PBST/": {
+        "@id": "/sample-terms/CL_0000000/",
+        "@type": ["SampleTerm", "Item"],
+        cell_annotation: "H9 cell type",
+        cell_type: {
+          "@id": "/sample-terms/UBERON_0002048/",
+          definition:
+            "Respiration organ that develops as an outpocketing of the esophagus.",
+          status: "released",
+          term_id: "UBERON:0002048",
+          term_name: "lung",
+        },
+        workflows: [],
+      },
+    };
+
     render(
       <SessionContext.Provider value={{ profiles }}>
-        <PseudobulkSet item={item} />
+        <PseudobulkSet item={item} accessoryData={accessoryData} />
       </SessionContext.Provider>
     );
 
@@ -3757,9 +3828,7 @@ describe("Test the PseudobulkSet component", () => {
     expect(screen.getByTestId("search-list-item-supplement")).toHaveTextContent(
       "Description"
     );
-    expect(
-      screen.getByTestId("search-list-item-supplement-content")
-    ).toHaveTextContent("This is my description");
+    expect(screen.getByText("This is my description")).toBeInTheDocument();
 
     expect(screen.getByTestId("search-list-item-quality")).toHaveTextContent(
       "released"
@@ -3773,6 +3842,7 @@ describe("Test the PseudobulkSet component", () => {
       accession: "IGVFDS1111PBST",
       aliases: ["igvf:basic_pseudobulk_set"],
       award: "/awards/HG012012/",
+      cell_annotation: "H9 cell type",
       files: [],
       cell_type: { term_name: "H9" },
       file_set_type: "pseudobulk analysis",
@@ -3784,9 +3854,26 @@ describe("Test the PseudobulkSet component", () => {
       uuid: "609869e7-cbd9-4d06-9569-d3fdb4604ccd",
     };
 
+    const accessoryData = {
+      "/pseudobulk-sets/IGVFDS1111PBST/": {
+        "@id": "/sample-terms/CL_0000000/",
+        "@type": ["SampleTerm", "Item"],
+        cell_annotation: "H9 cell type",
+        cell_type: {
+          "@id": "/sample-terms/UBERON_0002048/",
+          definition:
+            "Respiration organ that develops as an outpocketing of the esophagus.",
+          status: "released",
+          term_id: "UBERON:0002048",
+          term_name: "H9",
+        },
+        workflows: [],
+      },
+    };
+
     render(
       <SessionContext.Provider value={{ profiles }}>
-        <PseudobulkSet item={item} />
+        <PseudobulkSet item={item} accessoryData={accessoryData} />
       </SessionContext.Provider>
     );
 
@@ -3803,9 +3890,9 @@ describe("Test the PseudobulkSet component", () => {
     expect(screen.getByTestId("search-list-item-supplement")).toHaveTextContent(
       "Cell Annotation"
     );
-    expect(
-      screen.getByTestId("search-list-item-supplement-content")
-    ).toHaveTextContent("H9");
+    expect(screen.getByTestId("search-list-item-supplement")).toHaveTextContent(
+      "H9 cell type"
+    );
 
     expect(screen.getByTestId("search-list-item-quality")).toHaveTextContent(
       "released"
@@ -3819,9 +3906,17 @@ describe("Test the PseudobulkSet component", () => {
       accession: "IGVFDS1111PBST",
       aliases: ["igvf:basic_pseudobulk_set"],
       award: "/awards/HG012012/",
+      cell_type: { term_name: "H9" },
+      cell_annotation: "H9 cell type",
       files: [],
       file_set_type: "pseudobulk analysis",
-      samples: [{ summary: "test samples.summary" }],
+      samples: [
+        {
+          "@id": "/samples/IGVFSM0000TEST/",
+          "@type": ["Sample", "Item"],
+          summary: "test samples.summary",
+        },
+      ],
       lab: {
         title: "J. Michael Cherry, Stanford",
       },
@@ -3887,6 +3982,7 @@ describe("Test the PseudobulkSet component", () => {
         workflows: [
           {
             "@id": "/workflows/IGVFWF0000WORK/",
+            "@type": ["Workflow", "Item"],
             accession: "IGVFWF0000WORK",
             name: "Perturb-seq Pipeline",
             uniform_pipeline: true,
@@ -3926,7 +4022,7 @@ describe("Test the PseudobulkSet component", () => {
       {
         type: "PseudobulkSet",
         paths: ["/pseudobulk-sets/IGVFDS1111PBST/"],
-        fields: ["workflows"],
+        fields: ["cell_annotation", "cell_type", "workflows"],
       },
     ]);
   });

--- a/components/search/list-renderer/pseudobulk-set.tsx
+++ b/components/search/list-renderer/pseudobulk-set.tsx
@@ -1,6 +1,5 @@
 // node_modules
 import _ from "lodash";
-import PropTypes from "prop-types";
 // components/search/list-renderer
 import {
   SearchListItemContent,
@@ -20,34 +19,71 @@ import {
 import { UniformlyProcessedBadge } from "../../common-pill-badges";
 import { ControlledAccessIndicator } from "../../controlled-access";
 import { DataUseLimitationSummaries } from "../../data-use-limitation-status";
+import { SampleAnnotatedSummary } from "../../sample-annotated-summary";
 // lib
+import { isDatabaseObjectArrayOfType } from "../../../lib/database-object";
+import { type PseudobulkSetObject } from "../../../lib/file-sets";
 import { truncateText } from "../../../lib/general";
+import { isEmbedded } from "../../../lib/types";
 
+/**
+ * A subset of the `PseudobulkSetObject` fields that appears in accessory data for the pseudobulk
+ * set list renderer.
+ */
+type PseudobulkSetSubset = Pick<
+  PseudobulkSetObject,
+  "@id" | "@type" | "cell_annotation" | "cell_type" | "workflows"
+>;
+
+/**
+ * List renderer for pseudobulk sets.
+ *
+ * @param item - A pseudobulk set search-result object to display on a search-result list page.
+ * @param accessoryData - Accessory data to display for all search-result objects, which may include
+ *                        additional fields not present in the main search result object.
+ */
 export default function PseudobulkSet({
   item: pseudobulkSet,
   accessoryData = null,
+}: {
+  item: PseudobulkSetObject;
+  accessoryData?: Record<string, PseudobulkSetSubset> | null;
 }) {
-  const samplesSummary =
-    pseudobulkSet.samples?.length > 0
-      ? _.sortBy(
-          [...new Set(pseudobulkSet.samples.map((sample) => sample.summary))],
-          (item) => item.toLowerCase()
-        )
-      : [];
+  const samplesSummary = isDatabaseObjectArrayOfType(
+    pseudobulkSet.samples,
+    "Sample"
+  )
+    ? _.sortBy(
+        [...new Set(pseudobulkSet.samples.map((sample) => sample.summary))],
+        (item) => item.toLowerCase()
+      )
+    : [];
 
   // Determine if at least one workflow in the analysis set has `uniform_pipeline` set.
-  const accessoryAnalysisSet = accessoryData?.[pseudobulkSet["@id"]];
-  const workflows = accessoryAnalysisSet?.workflows || [];
+  const accessoryPseudobulkSet = accessoryData?.[pseudobulkSet["@id"]];
+  const workflows =
+    accessoryPseudobulkSet &&
+    isDatabaseObjectArrayOfType(accessoryPseudobulkSet.workflows, "Workflow")
+      ? accessoryPseudobulkSet.workflows
+      : [];
   const isUniformPipeline = workflows.some(
     (workflow) => workflow.uniform_pipeline
   );
 
-  const isSupplementsVisible =
+  // If the accessory data has a `cell_type` property, use it to get definitions for tooltips on
+  // `cell_annotation` summary. We eventually need to also retrieve sample terms to get more
+  // complete tooltips.
+  const allSampleTerms = isEmbedded(accessoryPseudobulkSet?.cell_type)
+    ? [accessoryPseudobulkSet.cell_type]
+    : [];
+
+  const isSupplementsVisible = Boolean(
     pseudobulkSet.alternate_accessions ||
     pseudobulkSet.description ||
-    pseudobulkSet.cell_type ||
+    pseudobulkSet.cell_annotation ||
     samplesSummary.length > 0 ||
-    isUniformPipeline;
+    isUniformPipeline
+  );
 
   return (
     <SearchListItemContent>
@@ -58,7 +94,11 @@ export default function PseudobulkSet({
         </SearchListItemUniqueId>
         <SearchListItemTitle>{pseudobulkSet.summary}</SearchListItemTitle>
         <SearchListItemMeta>
-          <span key="lab">{pseudobulkSet.lab.title}</span>
+          <span key="lab">
+            {isEmbedded(pseudobulkSet.lab)
+              ? pseudobulkSet.lab.title
+              : pseudobulkSet.lab}
+          </span>
         </SearchListItemMeta>
         {isSupplementsVisible && (
           <SearchListItemSupplement>
@@ -73,18 +113,16 @@ export default function PseudobulkSet({
                 </SearchListItemSupplementContent>
               </SearchListItemSupplementSection>
             )}
-            {pseudobulkSet.cell_type && (
+            {accessoryPseudobulkSet?.cell_annotation && (
               <SearchListItemSupplementSection>
                 <SearchListItemSupplementLabel>
                   Cell Annotation
                 </SearchListItemSupplementLabel>
                 <SearchListItemSupplementContent>
-                  {[
-                    pseudobulkSet.cell_qualifier,
-                    pseudobulkSet.cell_type.term_name,
-                  ]
-                    .filter(Boolean)
-                    .join(" ")}
+                  <SampleAnnotatedSummary
+                    summary={accessoryPseudobulkSet.cell_annotation}
+                    terms={allSampleTerms}
+                  />
                 </SearchListItemSupplementContent>
               </SearchListItemSupplementSection>
             )}
@@ -112,20 +150,12 @@ export default function PseudobulkSet({
   );
 }
 
-PseudobulkSet.propTypes = {
-  // Single pseudobulk set search-result object to display on a search-result list page
-  item: PropTypes.object.isRequired,
-  // Accessory data to display for all search-result objects
-  accessoryData: PropTypes.object,
-};
-
 PseudobulkSet.getAccessoryDataPaths = (items) => {
-  // Get the `workflows` arrays for all analysis sets in the results.
   return [
     {
       type: "PseudobulkSet",
       paths: items.map((item) => item["@id"]),
-      fields: ["workflows"],
+      fields: ["cell_annotation", "cell_type", "workflows"],
     },
   ];
 };

--- a/components/sequencing-file-table.tsx
+++ b/components/sequencing-file-table.tsx
@@ -29,13 +29,9 @@ import {
   generateSequenceFileGroups,
   paginateSequenceFileGroups,
 } from "../lib/files";
+import { type OntologyTermObject } from "../lib/ontology-terms";
 // root
-import type {
-  DocumentObject,
-  FileObject,
-  LabObject,
-  OntologyTermObject,
-} from "../globals";
+import type { DocumentObject, FileObject, LabObject } from "../globals";
 import { UC } from "../lib/constants";
 
 /**

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,6 +1,7 @@
 import { type AttachmentObject } from "./lib/attachment";
 import { type FileSetObject } from "./lib/file-sets";
 import { type GeneLocation } from "./lib/genes";
+import { type OntologyTermObject } from "./lib/ontology-terms";
 import { type QualityMetricObject } from "./lib/quality-metric";
 import { type BiosampleObject } from "./lib/samples";
 import { type LinkTo, LinkToArray } from "./lib/types";
@@ -73,7 +74,7 @@ export interface DatabaseObject {
   collections?: string[];
   creation_timestamp?: string;
   description?: string;
-  documents?: LinkTo<DocumentObject>[];
+  documents?: LinkToArray<DocumentObject>;
   lab?: LinkTo<LabObject>;
   name?: string;
   release_timestamp?: string;
@@ -508,32 +509,6 @@ export interface TreatmentObject extends DatabaseObject {
   treatment_term_id?: string;
   treatment_term_name: string;
   treatment_type: string;
-}
-
-export interface OntologyTermObject extends DatabaseObject {
-  aliases?: string[];
-  ancestors?: string[];
-  assay_slims?: string[];
-  category_slims?: string[];
-  cell_slims?: string[];
-  comments?: string[];
-  company?: string;
-  definition?: string;
-  deprecated_ntr_terms?: string[];
-  description?: string;
-  is_a?: LinkToArray<OntologyTermObject>;
-  name?: string;
-  notes?: string;
-  objective_slims?: string[];
-  ontology?: string;
-  organ_slims?: string[];
-  preferred_assay_titles?: string[];
-  sequencing_kits?: string[];
-  summary?: string;
-  synonyms?: string[];
-  system_slims?: string[];
-  term_id: string;
-  term_name: string;
 }
 
 export interface PageObject extends DatabaseObject {

--- a/lib/__tests__/common-requests.test.ts
+++ b/lib/__tests__/common-requests.test.ts
@@ -1,6 +1,6 @@
 import type { DatabaseObject, FileObject } from "../../globals";
 import { ConstructLibrarySetObject, type FileSetObject } from "../file-sets";
-import { type SampleObject } from "../samples";
+import { type MultiplexedSampleObject, type SampleObject } from "../samples";
 import {
   requestAnalysisSteps,
   requestAnalysisStepVersions,
@@ -867,7 +867,7 @@ describe("Test all the common requests", () => {
       request
     );
     expect(mockFetch).toHaveBeenCalledWith(
-      "/search-quick/?type=OntologyTerm&field=term_id&field=term_name&@id=/phenotype-terms/NCIT_C92648/&@id=/sample-terms/UBERON_0005439/&limit=2",
+      "/search-quick/?type=OntologyTerm&field=definition&field=term_id&field=term_name&@id=/phenotype-terms/NCIT_C92648/&@id=/sample-terms/UBERON_0005439/&limit=2",
       expect.anything()
     );
     expect(result).toHaveLength(2);
@@ -2003,7 +2003,7 @@ describe("requestSampleBarcodeMaps", () => {
   });
 
   it("returns empty array when no samples have a barcode_map", async () => {
-    const samples: SampleObject[] = [
+    const samples: MultiplexedSampleObject[] = [
       {
         "@id": "/primary-cells/IGVFSM1111AAAA/",
         "@type": ["PrimaryCell", "Sample", "Item"],
@@ -2028,7 +2028,7 @@ describe("requestSampleBarcodeMaps", () => {
   });
 
   it("requests barcode map when barcode_map is a string path", async () => {
-    const samples: SampleObject[] = [
+    const samples: MultiplexedSampleObject[] = [
       {
         "@id": "/primary-cells/IGVFSM1111AAAA/",
         "@type": ["PrimaryCell", "Sample", "Item"],
@@ -2037,7 +2037,7 @@ describe("requestSampleBarcodeMaps", () => {
         status: "released",
         summary: "A sample of primary cells.",
       },
-    ] as SampleObject[];
+    ] as MultiplexedSampleObject[];
 
     const mockResult = { "@graph": [mockBarcodeMapFile] };
     mockFetch.mockResolvedValueOnce(createMockResponse(mockResult));
@@ -2059,7 +2059,7 @@ describe("requestSampleBarcodeMaps", () => {
   });
 
   it("requests barcode map when barcode_map is an embedded FileObject", async () => {
-    const samples: SampleObject[] = [
+    const samples: MultiplexedSampleObject[] = [
       {
         "@id": "/primary-cells/IGVFSM1111AAAA/",
         "@type": ["PrimaryCell", "Sample", "Item"],
@@ -2073,7 +2073,7 @@ describe("requestSampleBarcodeMaps", () => {
         status: "released",
         summary: "A sample of primary cells.",
       },
-    ] as SampleObject[];
+    ] as MultiplexedSampleObject[];
 
     const mockResult = { "@graph": [mockBarcodeMapFile] };
     mockFetch.mockResolvedValueOnce(createMockResponse(mockResult));
@@ -2091,7 +2091,7 @@ describe("requestSampleBarcodeMaps", () => {
   });
 
   it("deduplicates barcode map paths across multiple samples", async () => {
-    const samples: SampleObject[] = [
+    const samples: MultiplexedSampleObject[] = [
       {
         "@id": "/primary-cells/IGVFSM1111AAAA/",
         "@type": ["PrimaryCell", "Sample", "Item"],
@@ -2108,7 +2108,7 @@ describe("requestSampleBarcodeMaps", () => {
         status: "released",
         summary: "Another sample of primary cells.",
       },
-    ] as SampleObject[];
+    ] as MultiplexedSampleObject[];
 
     const mockResult = { "@graph": [mockBarcodeMapFile] };
     mockFetch.mockResolvedValueOnce(createMockResponse(mockResult));
@@ -2135,7 +2135,7 @@ describe("requestSampleBarcodeMaps", () => {
       upload_status: "validated",
     };
 
-    const samples: SampleObject[] = [
+    const samples: MultiplexedSampleObject[] = [
       {
         "@id": "/primary-cells/IGVFSM1111AAAA/",
         "@type": ["PrimaryCell", "Sample", "Item"],
@@ -2152,7 +2152,7 @@ describe("requestSampleBarcodeMaps", () => {
         status: "released",
         summary: "Another sample of primary cells.",
       },
-    ] as SampleObject[];
+    ] as MultiplexedSampleObject[];
 
     const mockResult = { "@graph": [mockBarcodeMapFile, mockBarcodeMapFile2] };
     mockFetch.mockResolvedValueOnce(createMockResponse(mockResult));
@@ -2173,7 +2173,7 @@ describe("requestSampleBarcodeMaps", () => {
   });
 
   it("skips samples without barcode_map while collecting from those that have one", async () => {
-    const samples: SampleObject[] = [
+    const samples: MultiplexedSampleObject[] = [
       {
         "@id": "/primary-cells/IGVFSM1111AAAA/",
         "@type": ["PrimaryCell", "Sample", "Item"],
@@ -2189,7 +2189,7 @@ describe("requestSampleBarcodeMaps", () => {
         status: "released",
         summary: "Another sample of primary cells.",
       },
-    ] as SampleObject[];
+    ] as MultiplexedSampleObject[];
 
     const mockResult = { "@graph": [mockBarcodeMapFile] };
     mockFetch.mockResolvedValueOnce(createMockResponse(mockResult));
@@ -2203,7 +2203,7 @@ describe("requestSampleBarcodeMaps", () => {
   });
 
   it("returns empty array when API request fails", async () => {
-    const samples: SampleObject[] = [
+    const samples: MultiplexedSampleObject[] = [
       {
         "@id": "/primary-cells/IGVFSM1111AAAA/",
         "@type": ["PrimaryCell", "Sample", "Item"],
@@ -2212,7 +2212,7 @@ describe("requestSampleBarcodeMaps", () => {
         status: "released",
         summary: "A sample of primary cells.",
       },
-    ] as SampleObject[];
+    ] as MultiplexedSampleObject[];
 
     mockFetch.mockResolvedValueOnce({
       ok: false,
@@ -2240,7 +2240,7 @@ describe("requestSampleBarcodeMaps", () => {
       upload_status: "validated",
     };
 
-    const samples: SampleObject[] = [
+    const samples: MultiplexedSampleObject[] = [
       {
         "@id": "/primary-cells/IGVFSM1111AAAA/",
         "@type": ["PrimaryCell", "Sample", "Item"],
@@ -2257,7 +2257,7 @@ describe("requestSampleBarcodeMaps", () => {
         status: "released",
         summary: "Another sample of primary cells.",
       },
-    ] as SampleObject[];
+    ] as MultiplexedSampleObject[];
 
     const mockResult = { "@graph": [mockBarcodeMapFile, deletedFile] };
     mockFetch.mockResolvedValueOnce(createMockResponse(mockResult));
@@ -2283,7 +2283,7 @@ describe("requestSampleBarcodeMaps", () => {
       upload_status: "validated",
     };
 
-    const samples: SampleObject[] = [
+    const samples: MultiplexedSampleObject[] = [
       {
         "@id": "/primary-cells/IGVFSM1111AAAA/",
         "@type": ["PrimaryCell", "Sample", "Item"],
@@ -2300,7 +2300,7 @@ describe("requestSampleBarcodeMaps", () => {
         status: "released",
         summary: "Another sample of primary cells.",
       },
-    ] as SampleObject[];
+    ] as MultiplexedSampleObject[];
 
     const mockResult = { "@graph": [mockBarcodeMapFile, deletedFile] };
     mockFetch.mockResolvedValueOnce(createMockResponse(mockResult));
@@ -2336,7 +2336,7 @@ describe("requestSampleBarcodeMaps", () => {
       upload_status: "validated",
     };
 
-    const samples: SampleObject[] = [
+    const samples: MultiplexedSampleObject[] = [
       {
         "@id": "/primary-cells/IGVFSM1111AAAA/",
         "@type": ["PrimaryCell", "Sample", "Item"],
@@ -2361,7 +2361,7 @@ describe("requestSampleBarcodeMaps", () => {
         status: "released",
         summary: "Yet another sample of primary cells.",
       },
-    ] as SampleObject[];
+    ] as MultiplexedSampleObject[];
 
     const mockResult = {
       "@graph": [mockBarcodeMapFile, archivedFile, revokedFile],

--- a/lib/__tests__/ontology-terms.test.ts
+++ b/lib/__tests__/ontology-terms.test.ts
@@ -1,14 +1,16 @@
 // lib
 import FetchRequest from "../fetch-request";
+import { type FileSetObject } from "../file-sets";
 import {
   getAssayTitleDescriptionMap,
   getPreferredAssayTitleDescriptionMap,
   getAssayTitleDescription,
   getMeasurementSetAssayTitleDescriptionMap,
-  AssayTermObject,
+  type AssayTermObject,
+  type OntologyTermObject,
 } from "../ontology-terms";
 // root
-import { FileSetObject, OntologyTermObject, Profiles } from "../../globals";
+import type { Profiles } from "../../globals";
 
 const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
 global.fetch = mockFetch;

--- a/lib/common-requests.ts
+++ b/lib/common-requests.ts
@@ -8,8 +8,13 @@ import { trimDeprecatedFiles } from "./deprecated-files";
 import FetchRequest from "./fetch-request";
 import { type FileSetObject } from "./file-sets";
 import { type DatasetSummary } from "./home";
+import { type OntologyTermObject } from "./ontology-terms";
 import { type QualityMetricObject } from "./quality-metric";
-import { type BiosampleObject, type SampleObject } from "./samples";
+import {
+  type BiosampleObject,
+  type MultiplexedSampleObject,
+  type SampleObject,
+} from "./samples";
 import { type WorkflowObject } from "./workflow";
 // root
 import type {
@@ -23,7 +28,6 @@ import type {
   FileObject,
   GeneObject,
   LabObject,
-  OntologyTermObject,
   PageObject,
   PhenotypicFeatureObject,
   PublicationObject,
@@ -413,7 +417,7 @@ export async function requestOntologyTerms(
   return (
     await request.getMultipleObjectsBulk<OntologyTermObject>(
       paths,
-      ["term_id", "term_name"],
+      ["definition", "term_id", "term_name"],
       ["OntologyTerm"]
     )
   ).unwrap_or([]);
@@ -783,9 +787,9 @@ export async function requestSupersedes<T extends DatabaseObject>(
 }
 
 /**
- * Request the barcode_map tabular files for a given set of samples. You can optionally exclude
- * files with deleted or deprecated status by setting the `exclude` parameter to "deleted" or
- * "deprecated", respectively. By default, no files get excluded based on status.
+ * Request the barcode_map tabular files for a given set of multiplexed samples. You can optionally
+ * exclude files with deleted or deprecated status by setting the `exclude` parameter to "deleted"
+ * or "deprecated", respectively. By default, no files get excluded based on status.
  *
  * @param samples - Samples from which to request barcode_map tabular files
  * @param request - Request object to use to make the request
@@ -793,7 +797,7 @@ export async function requestSupersedes<T extends DatabaseObject>(
  * @returns Requested barcode_map tabular files, or an empty array if none found
  */
 export async function requestSampleBarcodeMaps(
-  samples: SampleObject[],
+  samples: MultiplexedSampleObject[],
   request: FetchRequest,
   exclude: "deleted" | "deprecated" | "none" = "none"
 ): Promise<FileObject[]> {

--- a/lib/database-object.ts
+++ b/lib/database-object.ts
@@ -1,8 +1,10 @@
 // lib
 import { isErrorObject } from "./fetch-request";
 import { type FileSetObject } from "./file-sets";
+import { type OntologyTermObject } from "./ontology-terms";
 import { type SampleObject } from "./samples";
 import { isPathArray } from "./types";
+import { type WorkflowObject } from "./workflow";
 // root
 import type {
   AnalysisStepObject,
@@ -15,7 +17,6 @@ import type {
   GeneObject,
   HumanDonorObject,
   LabObject,
-  OntologyTermObject,
   PageObject,
   PublicationObject,
   SoftwareObject,
@@ -45,6 +46,7 @@ type DatabaseTypeMap = {
   Software: SoftwareObject;
   SoftwareVersion: SoftwareVersionObject;
   User: UserObject;
+  Workflow: WorkflowObject;
 };
 
 /**

--- a/lib/file-sets.ts
+++ b/lib/file-sets.ts
@@ -10,7 +10,10 @@ import {
   pathsFromDatabaseObjects,
 } from "./database-object";
 import FetchRequest from "./fetch-request";
-import { type AssayTermObject } from "./ontology-terms";
+import {
+  type AssayTermObject,
+  type OntologyTermObject,
+} from "./ontology-terms";
 import { type SampleObject } from "./samples";
 import { type LinkTo, type LinkToArray } from "./types";
 import { type WorkflowObject } from "./workflow";
@@ -22,7 +25,6 @@ import type {
   FileObject,
   GeneObject,
   LabObject,
-  OntologyTermObject,
   OpenReadingFrameObject,
   PublicationObject,
   SourceObject,
@@ -216,6 +218,7 @@ export interface PredictionSetObject extends FileSetObject {
 
 export interface PseudobulkSetObject extends FileSetObject {
   assay_titles?: string[];
+  cell_annotation?: string;
   cell_qualifier?: string;
   cell_type?: LinkTo<OntologyTermObject>;
   dbxrefs?: string[];

--- a/lib/modifications.ts
+++ b/lib/modifications.ts
@@ -1,40 +1,46 @@
 // lib
 // Note: circular import type with ./samples.ts. This is a deliberate, safe choice.
 import { type BiosampleObject } from "./samples";
-import { type LinkTo } from "./types";
+import { type LinkToArray } from "./types";
 // root
 import type {
   DatabaseObject,
-  DocumentObject,
   GeneObject,
   LabObject,
   SourceObject,
 } from "../globals";
 
+/**
+ * Base type for modification objects (@type Modification).
+ */
 export interface ModificationObject extends DatabaseObject {
   activated?: boolean;
   activating_agent_term_id?: string;
   activating_agent_term_name?: string;
   aliases?: string[];
-  biosamples_modified?: LinkTo<BiosampleObject>[];
+  biosamples_modified?: LinkToArray<BiosampleObject>;
   description?: string;
-  documents?: LinkTo<DocumentObject>[];
   lot_id?: string;
   modality: string;
   notes?: string;
   product_id?: string;
-  sources?: LinkTo<SourceObject | LabObject>[];
-  summary?: string;
+  sources?: LinkToArray<SourceObject | LabObject>;
 }
 
-export interface DegronModificationObject extends ModificationObject {
-  degron_system: string;
-  tagged_proteins: LinkTo<GeneObject>[];
-}
-
+/**
+ * Type for CRISPR modification objects (@type CrisprModification).
+ */
 export interface CrisprModificationObject extends ModificationObject {
   cas: string;
   cas_species: string;
   fused_domain?: string;
-  tagged_proteins?: LinkTo<GeneObject>[];
+  tagged_proteins?: LinkToArray<GeneObject>;
+}
+
+/**
+ * Type for degron modification objects (@type DegronModification).
+ */
+export interface DegronModificationObject extends ModificationObject {
+  degron_system: string;
+  tagged_proteins: LinkToArray<GeneObject>;
 }

--- a/lib/ontology-terms.ts
+++ b/lib/ontology-terms.ts
@@ -2,26 +2,61 @@
 import FetchRequest from "./fetch-request";
 import { extractSchema } from "./profiles";
 import { isFileSetObjectType, type FileSetObject } from "./file-sets";
+import { type LinkToArray } from "./types";
 // root
-import { DatabaseObject, OntologyTermObject, Profiles } from "../globals";
+import { DatabaseObject, Profiles } from "../globals";
 
-export interface AssayTermObject extends DatabaseObject {
+/**
+ * Base interface for ontology term objects.
+ */
+export interface OntologyTermObject extends DatabaseObject {
+  aliases?: string[];
   ancestors?: string[];
-  assay_slims?: string[];
-  category_slims?: string[];
   comments?: string[];
   definition?: string;
   deprecated_ntr_terms?: string[];
   description?: string;
-  is_a?: string[] | DatabaseObject[];
-  name?: string;
-  notes?: string[];
-  objective_slims?: string[];
+  is_a?: LinkToArray<OntologyTermObject>;
+  notes?: string;
   ontology?: string;
-  preferred_assay_titles?: string[];
+  summary?: string;
   synonyms?: string[];
   term_id: string;
   term_name: string;
+}
+
+/**
+ * Interface for assay term objects, which have an @type of `AssayTerm`.
+ */
+export interface AssayTermObject extends OntologyTermObject {
+  assay_slims?: string[];
+  category_slims?: string[];
+  objective_slims?: string[];
+  preferred_assay_titles?: string[];
+}
+
+/**
+ * Interface for phenotype term objects, which have an @type of `PhenotypeTerm`.
+ */
+export interface PhenotypeTermObject extends OntologyTermObject {}
+
+/**
+ * Interface for platform term objects, which have an @type of `PlatformTerm`.
+ */
+export interface PlatformTermObject extends OntologyTermObject {
+  company?: string;
+  sequencing_kits?: string[];
+}
+
+/**
+ * Interface for sample term objects, which have an @type of `SampleTerm`.
+ */
+export interface SampleTermObject extends OntologyTermObject {
+  cell_slims?: string[];
+  dbxrefs?: string[];
+  developmental_slims?: string[];
+  organ_slims?: string[];
+  system_slims?: string[];
 }
 
 /**

--- a/lib/samples.ts
+++ b/lib/samples.ts
@@ -1,10 +1,16 @@
 // lib
+import { requestOntologyTerms } from "./common-requests";
 import { type InstitutionalCertificateObject } from "./data-use-limitation";
+import {
+  isDatabaseObjectArrayOfType,
+  pathsFromDatabaseObjects,
+} from "./database-object";
+import FetchRequest from "./fetch-request";
 import { type FileSetObject } from "./file-sets";
 // Note: circular import type with ./modifications.ts. This is a deliberate, safe choice.
 import { type ModificationObject } from "./modifications";
-import { type LinkTo } from "./types";
-
+import { type SampleTermObject } from "./ontology-terms";
+import { type LinkTo, type LinkToArray } from "./types";
 // root
 import type {
   BiomarkerObject,
@@ -13,61 +19,164 @@ import type {
   DonorObject,
   FileObject,
   LabObject,
-  OntologyTermObject,
+  PhenotypicFeatureObject,
   PublicationObject,
   SourceObject,
   TreatmentObject,
 } from "../globals";
 
+/**
+ * Base type for sample and biosample objects (Sample @type).
+ */
 export interface SampleObject extends DatabaseObject {
   aliases?: string[];
-  barcode_map?: LinkTo<FileObject>;
-  biomarkers?: LinkTo<BiomarkerObject>[];
   classifications?: string[];
-  collections?: string[];
-  construct_library_sets?: LinkTo<FileSetObject>[];
+  construct_delivery_methods?: string[];
+  construct_library_sets?: LinkToArray<FileSetObject>;
+  date_obtained?: string;
   dbxrefs?: string[];
-  demultiplexed_to?: LinkTo<SampleObject>[];
-  disease_terms?: LinkTo<OntologyTermObject>[];
-  documents?: LinkTo<DocumentObject>[];
-  donors?: LinkTo<DonorObject>[];
-  file_sets?: LinkTo<FileSetObject>[];
-  institutional_certificates?: LinkTo<InstitutionalCertificateObject>[];
-  modifications?: LinkTo<ModificationObject>[];
-  multiplexed_in?: LinkTo<SampleObject>[];
-  name?: string;
+  file_sets?: LinkToArray<FileSetObject>;
+  institutional_certificates?: LinkToArray<InstitutionalCertificateObject>;
+  is_on_anvil?: boolean;
+  moi?: number;
+  multiplexed_in?: LinkToArray<SampleObject>;
   notes?: string;
-  origin_of?: LinkTo<SampleObject>[];
+  origin_of?: LinkToArray<SampleObject>;
   part_of?: LinkTo<BiosampleObject>;
-  parts?: LinkTo<SampleObject>[];
-  publications?: LinkTo<PublicationObject>[];
-  sample_terms?: LinkTo<OntologyTermObject>[];
-  sorted_fractions?: LinkTo<SampleObject>[];
-  sources?: LinkTo<SourceObject | LabObject>[];
-  study_sets?: string[];
-  submitter_comment?: string;
-  summary: string;
+  parts?: LinkToArray<SampleObject>;
+  protocols?: string[];
+  publications?: LinkToArray<PublicationObject>;
+  sample_terms?: LinkToArray<SampleTermObject>;
+  selection_conditions?: string[];
+  sorted_fractions?: LinkToArray<SampleObject>;
+  sorted_from?: LinkTo<SampleObject>;
+  sorted_from_detail?: string;
+  sources?: LinkToArray<SourceObject | LabObject>;
+  starting_amount?: number;
+  starting_amount_units?: string;
   taxa?: string;
-  title?: string;
-  transcriptome_annotation?: string;
-  treatments?: LinkTo<TreatmentObject>[];
+  time_post_library_delivery?: number;
+  time_post_library_delivery_units?: string;
+  treatments?: LinkToArray<TreatmentObject>;
+  url?: string;
+  virtual?: boolean;
 }
 
+/**
+ * Base type for biosample objects (Biosample @type).
+ */
 export interface BiosampleObject extends SampleObject {
+  age?: string;
+  age_units?: string;
   annotated_from?: LinkTo<SampleObject>;
-  biosample_qualifiers?: string[];
-  pooled_from?: LinkTo<BiosampleObject>[];
-  pooled_in?: LinkTo<BiosampleObject>[];
+  biomarkers?: LinkToArray<BiomarkerObject>;
+  cellular_sub_pool?: string;
+  donors?: LinkToArray<DonorObject>;
+  embryonic: boolean;
+  lot_id?: string;
+  lower_bound_age?: number;
+  lower_bound_age_in_hours?: number;
+  modifications?: LinkToArray<ModificationObject>;
+  originated_from?: LinkTo<SampleObject>;
+  phenotypic_features?: LinkToArray<PhenotypicFeatureObject>;
+  pooled_from?: LinkToArray<BiosampleObject>;
+  pooled_in?: LinkToArray<BiosampleObject>;
+  product_id?: string;
+  sex?: string;
+  upper_bound_age?: number;
+  upper_bound_age_in_hours?: number;
 }
 
+/**
+ * Type for in-vitro system objects (InVitroSystem @type).
+ */
 export interface InVitroSystemObject extends BiosampleObject {
+  biosample_qualifiers?: string[];
   cell_fate_change_protocol?: LinkTo<DocumentObject>;
   demultiplexed_from?: LinkTo<SampleObject>;
+  demultiplexed_to?: LinkToArray<SampleObject>;
   growth_medium?: string;
   passage_number?: number;
-  targeted_sample_term?: LinkTo<OntologyTermObject>;
+  targeted_sample_term?: LinkTo<SampleTermObject>;
   time_post_change?: number;
   time_post_change_units?: string;
   time_post_culture?: number;
   time_post_culture_units?: string;
+}
+
+/**
+ * Type for primary cell objects (PrimaryCell @type).
+ */
+export interface PrimaryCellObject extends BiosampleObject {
+  biosample_qualifiers?: string[];
+  passage_number?: number;
+}
+
+/**
+ * Type for tissue/organ objects (Tissue @type).
+ */
+export interface TissueOrganObject extends BiosampleObject {
+  pmi?: number;
+  pmi_units?: string;
+  preservation_method?: string;
+}
+
+/**
+ * Type for whole organism objects (WholeOrganismSample @type).
+ */
+export interface WholeOrganismSampleObject extends BiosampleObject {}
+
+/**
+ * Type for multiplexed sample objects (MultiplexedSample @type).
+ */
+export interface MultiplexedSampleObject extends SampleObject {
+  barcode_map?: LinkTo<FileObject>;
+  biomarkers?: LinkToArray<BiomarkerObject>;
+  cellular_sub_pool?: string;
+  demultiplexed_to?: LinkToArray<SampleObject>;
+  donors?: LinkToArray<DonorObject>;
+  modifications?: LinkToArray<ModificationObject>;
+  multiplexed_samples?: LinkToArray<SampleObject>;
+  multiplexing_methods?: string[];
+  phenotypic_features?: LinkToArray<PhenotypicFeatureObject>;
+  targeted_sample_terms?: LinkToArray<SampleTermObject>;
+}
+
+/**
+ * Type for technical sample objects (TechnicalSample @type).
+ */
+export interface TechnicalSampleObject extends SampleObject {
+  lot_id?: string;
+  originated_from?: LinkTo<SampleObject>;
+  product_id?: string;
+  sample_material?: string;
+}
+
+/**
+ * Given an array of sample objects, request the ontology term objects corresponding to the sample
+ * terms linked to by those samples.
+ *
+ * @param samples - Sample objects from which to extract ontology terms
+ * @param request - FetchRequest object to use for the request
+ * @returns Ontology term objects corresponding to the sample terms linked to by the given samples
+ */
+export async function getSamplesTerms(
+  samples: SampleObject[],
+  request: FetchRequest
+): Promise<SampleTermObject[]> {
+  if (!isDatabaseObjectArrayOfType(samples, "Sample")) {
+    return [];
+  }
+
+  // Collect unique paths for all the samples' `sample_terms` properties. We want to fetch all the sample terms in a single request, so we need to collect all the unique paths to those sample terms.
+  const termPaths = new Set<string>();
+  samples.forEach((sample) => {
+    const paths = pathsFromDatabaseObjects(sample.sample_terms);
+    paths.forEach((path) => termPaths.add(path));
+  });
+
+  // Fetch the sample terms for all the collected paths in a single request and return them as an array.
+  return termPaths.size > 0
+    ? await requestOntologyTerms(Array.from(termPaths), request)
+    : [];
 }

--- a/pages/in-vitro-systems/[id].tsx
+++ b/pages/in-vitro-systems/[id].tsx
@@ -36,7 +36,6 @@ import {
   requestDonors,
   requestFileSets,
   requestInstitutionalCertificates,
-  requestOntologyTerms,
   requestPublications,
   requestSamples,
   requestSupersedes,
@@ -66,7 +65,6 @@ import type {
   DocumentObject,
   DonorObject,
   LabObject,
-  OntologyTermObject,
   PublicationObject,
   SourceObject,
   TreatmentObject,
@@ -78,7 +76,6 @@ export default function InVitroSystem({
   constructLibrarySets,
   demultiplexedFrom,
   demultiplexedTo,
-  diseaseTerms,
   annotatedFrom,
   documents,
   donors,
@@ -104,7 +101,6 @@ export default function InVitroSystem({
   constructLibrarySets: FileSetObject[];
   demultiplexedFrom: SampleObject | null;
   demultiplexedTo: SampleObject[];
-  diseaseTerms: OntologyTermObject[];
   annotatedFrom: BiosampleObject | null;
   documents: DocumentObject[];
   donors: DonorObject[];
@@ -146,7 +142,6 @@ export default function InVitroSystem({
                 item={inVitroSystem}
                 classifications={inVitroSystem.classifications}
                 constructLibrarySets={constructLibrarySets}
-                diseaseTerms={diseaseTerms}
                 annotatedFrom={annotatedFrom}
                 partOf={partOf}
                 publications={publications}
@@ -375,13 +370,6 @@ export async function getServerSideProps({
     const demultiplexedTo = isPathArray(inVitroSystem.demultiplexed_to)
       ? await requestBiosamples(inVitroSystem.demultiplexed_to, request)
       : [];
-    let diseaseTerms: OntologyTermObject[] = [];
-    if (isEmbeddedArray(inVitroSystem.disease_terms)) {
-      const diseaseTermPaths = inVitroSystem.disease_terms.map(
-        (diseaseTerm) => diseaseTerm["@id"]
-      );
-      diseaseTerms = await requestOntologyTerms(diseaseTermPaths, request);
-    }
     const documents = isPathArray(inVitroSystem.documents)
       ? await requestDocuments(inVitroSystem.documents, request)
       : [];
@@ -494,7 +482,6 @@ export async function getServerSideProps({
         demultiplexedFrom,
         demultiplexedTo,
         annotatedFrom,
-        diseaseTerms,
         documents,
         donors,
         originOf,

--- a/pages/pseudobulk-sets/[id].tsx
+++ b/pages/pseudobulk-sets/[id].tsx
@@ -4,7 +4,6 @@ import { useContext, useEffect, useState } from "react";
 // components
 import AliasList from "../../components/alias-list";
 import { AlternativeIdentifiers } from "../../components/alternative-identifiers";
-import { AnnotatedValue } from "../../components/annotated-value";
 import Attribution from "../../components/attribution";
 import { BatchDownloadFileSet } from "../../components/batch-download-fileset";
 import Breadcrumbs from "../../components/breadcrumbs";
@@ -31,6 +30,7 @@ import JsonDisplay from "../../components/json-display";
 import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
+import { SampleAnnotatedSummary } from "../../components/sample-annotated-summary";
 import SampleTable from "../../components/sample-table";
 import { useSecDir } from "../../components/section-directory";
 import SessionContext from "../../components/session-context";
@@ -65,8 +65,11 @@ import { type PageProps } from "../../lib/next-js";
 import {
   getAssayTitleDescriptionMap,
   getPreferredAssayTitleDescriptionMap,
+  type SampleTermObject,
 } from "../../lib/ontology-terms";
+import { QualityMetricObject } from "../../lib/quality-metric";
 import { isJsonFormat } from "../../lib/query-utils";
+import { getSamplesTerms, type SampleObject } from "../../lib/samples";
 import { isEmbedded, isPathArray } from "../../lib/types";
 // root
 import type {
@@ -75,8 +78,6 @@ import type {
   FileObject,
   PublicationObject,
 } from "../../globals";
-import { SampleObject } from "../../lib/samples";
-import { QualityMetricObject } from "../../lib/quality-metric";
 
 /**
  * Props for the pseudobulk set page component. This includes the pseudobulk set object itself, as well
@@ -97,6 +98,7 @@ interface ThisPageProps extends PageProps {
   controlFor: FileSetObject[];
   constructLibrarySets: FileSetObject[];
   samples: SampleObject[];
+  samplesTerms: SampleTermObject[];
   donors: DonorObject[];
   qualityMetrics: QualityMetricObject[];
   assayTitleDescriptionMap: Record<string, string>;
@@ -124,6 +126,7 @@ export default function PseudobulkSet({
   controlFor,
   constructLibrarySets,
   samples,
+  samplesTerms,
   donors,
   qualityMetrics,
   assayTitleDescriptionMap,
@@ -136,6 +139,11 @@ export default function PseudobulkSet({
   const { profiles } = useContext(SessionContext);
   const preferredAssayTitleDescriptionMap =
     getPreferredAssayTitleDescriptionMap(profiles);
+
+  // Combine all sample-associated terms to pass to the SampleAnnotatedSummary component, ensuring that if the pseudobulk set has a cell type, it is included as a term (since the cell annotation may reference the cell type), along with all terms from the samples.
+  const allSampleTerms = isEmbedded(pseudobulkSet.cell_type)
+    ? [pseudobulkSet.cell_type, ...samplesTerms]
+    : samplesTerms;
 
   // State for whether to include deprecated files in the file table and graph.
   const [areDeprecatedFilesVisible, setAreDeprecatedFilesVisible] = useState(
@@ -222,32 +230,27 @@ export default function PseudobulkSet({
                     </DataItemValueAnnotated>
                   </>
                 )}
-              {pseudobulkSet.cell_type &&
-                isEmbedded(pseudobulkSet.cell_type) && (
-                  <>
-                    <DataItemLabel>Cell Annotation</DataItemLabel>
-                    <DataItemValue>
-                      {pseudobulkSet.cell_qualifier && (
-                        <>{pseudobulkSet.cell_qualifier} </>
-                      )}
-                      <AnnotatedValue
-                        externalAnnotations={{
-                          [pseudobulkSet.cell_type.term_name]:
-                            pseudobulkSet.cell_type.definition || "",
-                        }}
-                      >
-                        {pseudobulkSet.cell_type.term_name}
-                      </AnnotatedValue>
-                    </DataItemValue>
-
-                    <DataItemLabel>Cell Ontology ID</DataItemLabel>
-                    <DataItemValue>
-                      <Link href={pseudobulkSet.cell_type["@id"]}>
-                        {pseudobulkSet.cell_type.term_id}
-                      </Link>
-                    </DataItemValue>
-                  </>
-                )}
+              {pseudobulkSet.cell_annotation && (
+                <>
+                  <DataItemLabel>Cell Annotation</DataItemLabel>
+                  <DataItemValue>
+                    <SampleAnnotatedSummary
+                      summary={pseudobulkSet.cell_annotation}
+                      terms={allSampleTerms}
+                    />
+                  </DataItemValue>
+                </>
+              )}
+              {isEmbedded(pseudobulkSet.cell_type) && (
+                <>
+                  <DataItemLabel>Cell Ontology ID</DataItemLabel>
+                  <DataItemValue>
+                    <Link href={pseudobulkSet.cell_type["@id"]}>
+                      {pseudobulkSet.cell_type.term_id}
+                    </Link>
+                  </DataItemValue>
+                </>
+              )}
               {referenceFiles.length > 0 && (
                 <>
                   <DataItemLabel>Reference Files</DataItemLabel>
@@ -420,6 +423,7 @@ export async function getServerSideProps({
     const combinedFiles = files.concat(derivedFromFiles);
     const fileFileSets = await getFilesFileSets(combinedFiles, request);
     const samples = await requestFileSetSamples([pseudobulkSet], request);
+    const samplesTerms = await getSamplesTerms(samples, request);
     const donors = await requestFileSetDonors(pseudobulkSet, request);
     const publications = await requestFileSetPublications(
       pseudobulkSet,
@@ -488,6 +492,7 @@ export async function getServerSideProps({
         constructLibrarySets,
         controlFor,
         samples,
+        samplesTerms,
         donors,
         qualityMetrics,
         assayTitleDescriptionMap,


### PR DESCRIPTION
# Code Review: IGVF-3512-pseudobulk-cell-annotation

Model: GPT-5.3-Codex

## Scope

Reviewed changes in branch IGVF-3512-pseudobulk-cell-annotation against dev.

## Findings

No blocking or non-blocking defects identified in the current diff.

The previously noted coverage gap for boundary matching has been addressed by the new regression test in [components/__tests__/sample-annotated-summary.test.tsx](components/__tests__/sample-annotated-summary.test.tsx#L76).

## Validation Run

- npx jest components/__tests__/sample-annotated-summary.test.tsx --runInBand
- npx jest components/__tests__/sample-annotated-summary.test.tsx --runInBand --silent
- npx jest lib/__tests__/ontology-terms.test.ts --runInBand --silent
- npx jest lib/__tests__/common-requests.test.ts --runInBand --silent

All commands above passed.

## Summary

Verdict: Approve.

There are no blocking defects in the current diff, and the boundary-matching behavior now has explicit regression coverage.
