### PR TITLE
IGVF-3549 Allow the user to zoom file graphs

### DIFF
--- a/components/file-graph/__tests__/lib.test.ts
+++ b/components/file-graph/__tests__/lib.test.ts
@@ -1557,6 +1557,13 @@ describe("countFileNodes", () => {
 });
 
 describe("generateSVGContent", () => {
+  const mockGraphBounds = {
+    x: 0,
+    y: 0,
+    width: 250,
+    height: 280,
+  };
+
   // Mock DOM-elements factory that creates a fake DOM element for use in Jest tests. It returns a
   // plain object that mimics the interface of a real HTMLElement
   function createMockElement(tagName: string): any {
@@ -1594,7 +1601,7 @@ describe("generateSVGContent", () => {
       .mockImplementation(() => {});
     jest.spyOn(document, "getElementById").mockReturnValue(null);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     expect(result).toBeUndefined();
     expect(consoleSpy).toHaveBeenCalledWith(
@@ -1616,7 +1623,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     expect(result).toBeUndefined();
     expect(consoleSpy).toHaveBeenCalledWith(
@@ -1641,7 +1648,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     expect(result).toContain("<svg");
     expect(result).toContain('xmlns="http://www.w3.org/2000/svg"');
@@ -1677,7 +1684,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     expect(result).toContain('<path d="M10,10 L20,20"');
     expect(result).toContain('stroke="#000000"');
@@ -1713,7 +1720,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     expect(result).toContain('<polygon points="0,0 10,5 0,10"');
     expect(result).toContain('fill="#6b7280"');
@@ -1746,7 +1753,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     expect(result).toContain('<path d="M10,10 L20,20"');
     expect(result).toContain('stroke="#6b7280"'); // Default color
@@ -1793,7 +1800,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
     expect(result).toContain('font-family="Helvetica, Arial, sans-serif"');
   });
 
@@ -1851,7 +1858,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     expect(result).toContain("Measurement FileSet");
     expect(result).toContain(`rx="${NODE_HEIGHT / 2}"`);
@@ -1911,7 +1918,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     expect(result).toContain('width="156"');
     expect(result).toContain('height="60"');
@@ -1972,7 +1979,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     expect(result).toContain("Unknown FileSet");
     expect(result).toContain(`rx="${NODE_HEIGHT / 2}"`); // Should still have rounded corners
@@ -2025,7 +2032,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     expect(result).toContain("No Type FileSet");
   });
@@ -2062,7 +2069,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     expect(result).toBeDefined();
     expect(result).toContain("<svg");
@@ -2097,7 +2104,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     expect(result).toBeDefined();
   });
@@ -2163,11 +2170,11 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
-    expect(result).toContain('width="260px"');
-    expect(result).toContain('height="290px"');
-    expect(result).toContain('viewBox="-5 -5 260 290"');
+    expect(result).toContain('width="270px"');
+    expect(result).toContain('height="300px"');
+    expect(result).toContain('viewBox="-10 -10 270 300"');
   });
 
   it("should handle nodes with invalid transform values", () => {
@@ -2212,7 +2219,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     // Should default to position (0, 0) when transform doesn't match expected pattern
     expect(result).toContain('transform="translate(0, 0)"');
@@ -2265,7 +2272,7 @@ describe("generateSVGContent", () => {
       .mockReturnValue(mockContainer as any);
 
     // Call `generateSVGContent` to make sure it does the color variable conversion to hex values.
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     // CSS variables should be converted to hex values.
     expect(result).toContain('fill="#00a651"');
@@ -2348,7 +2355,10 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id") as string;
+    const result = generateSVGContent(
+      "test-graph-id",
+      mockGraphBounds
+    ) as string;
 
     const groupIndex = result.indexOf('transform="translate(5, 10)"');
     const edgeIndex = result.indexOf('<path d="M0,0 L100,100"');
@@ -2408,7 +2418,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     expect(result).toContain('width="321"');
     expect(result).toContain('height="123"');
@@ -2468,7 +2478,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     expect(result).toContain('width="444"');
     expect(result).toContain('height="222"');
@@ -2528,7 +2538,7 @@ describe("generateSVGContent", () => {
       .spyOn(document, "getElementById")
       .mockReturnValue(mockContainer as any);
 
-    const result = generateSVGContent("test-graph-id");
+    const result = generateSVGContent("test-graph-id", mockGraphBounds);
 
     expect(result).toContain(`width="${NODE_WIDTH - 2}"`);
     expect(result).toContain(`height="${NODE_HEIGHT - 2}"`);

--- a/components/file-graph/download.tsx
+++ b/components/file-graph/download.tsx
@@ -1,4 +1,5 @@
 // node_modules
+import { type Rect } from "@floating-ui/react";
 import { ArrowDownTrayIcon } from "@heroicons/react/20/solid";
 // components
 import { Button } from "../form-elements";
@@ -12,18 +13,25 @@ import { generateSVGContent } from "./lib";
  *
  * @param graphId - ID of the HTML element containing the ReactFlow graph
  * @param fileId - ID of the file the graph is for; used to customize download filename
+ * @param graphBounds - Bounds of the graph, used to determine SVG dimensions
  */
 export function DownloadTrigger({
   graphId,
   fileId = "",
+  graphBounds,
   isDisabled = false,
 }: {
   graphId: string;
   fileId?: string;
+  graphBounds: Rect | null;
   isDisabled?: boolean;
 }) {
   function downloadSVG() {
-    const svgContent = generateSVGContent(graphId);
+    if (!graphBounds) {
+      return;
+    }
+
+    const svgContent = generateSVGContent(graphId, graphBounds);
     if (svgContent) {
       // Create download link and "click" it to start the download.
       const blob = new Blob([svgContent], { type: "image/svg+xml" });

--- a/components/file-graph/file-graph.tsx
+++ b/components/file-graph/file-graph.tsx
@@ -2,18 +2,29 @@
 import ELK from "elkjs/lib/elk.bundled.js";
 import type { ElkNode } from "elkjs/lib/elk-api";
 import _ from "lodash";
-import { CSSProperties, Fragment, useEffect, useState } from "react";
 import {
+  CSSProperties,
+  Fragment,
+  MutableRefObject,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  Controls,
   Handle,
+  getBezierPath,
+  getViewportForBounds,
   Position,
   ReactFlow,
   ReactFlowProvider,
   useReactFlow,
-  getBezierPath,
+  type CoordinateExtent,
   type Edge,
   type EdgeProps,
   type Node,
   type NodeProps,
+  type Rect,
 } from "@xyflow/react";
 // components
 import Checkbox from "../checkbox";
@@ -84,7 +95,7 @@ const edgeTypes = {
 /**
  * Padding around the graph in pixels.
  */
-const GRAPH_PADDING = 5;
+const GRAPH_PADDING = 38;
 
 /**
  * Position of the first line of text in a file node.
@@ -105,6 +116,17 @@ const NODE_LINE_HEIGHT = 13;
  * Padding of the container around the graph.
  */
 const CONTAINER_PADDING = 16;
+
+/**
+ * Maximum height of the graph in pixels. If the graph is taller than this, it will be scrollable.
+ */
+const MAXIMUM_GRAPH_HEIGHT = 1000;
+
+/**
+ * Padding to apply when fitting the graph to the view. This is a fraction of the graph size, so 0.1
+ * means 10% padding around the graph.
+ */
+const FIT_ZOOM_PADDING = 0.1;
 
 /**
  * Styles for the node handles. This puts the handles in the correct place for the edges to hook up
@@ -404,13 +426,11 @@ function GraphCore({
   graphData: ElkNode;
   nativeFiles: FileObject[];
   graphId?: string;
-  onNodeLayout?: (nodes: Node<NodeMetadata>[]) => void;
+  onNodeLayout?: (graphBounds: Rect) => void;
 }) {
   const [elk] = useState(() => new ELK());
   const [laidOutNodes, setLaidOutNodes] = useState<Node<NodeMetadata>[]>([]);
   const [laidOutEdges, setLaidOutEdges] = useState<Edge[]>([]);
-  const [graphHeight, setGraphHeight] = useState(0);
-  const [graphWidth, setGraphWidth] = useState(0);
   const [selectedNode, setSelectedNode] = useState<Node<NodeMetadata> | null>(
     null
   );
@@ -420,6 +440,9 @@ function GraphCore({
   const [qualityMetricFile, setQualityMetricFile] = useState<FileObject | null>(
     null
   );
+  const [graphBounds, setGraphBounds] = useState<Rect | null>(null);
+  const [minZoom, setMinZoom] = useState(0.25);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const rf = useReactFlow();
   const fileSetStats = collectRelevantFileSetStats(laidOutNodes);
@@ -449,7 +472,6 @@ function GraphCore({
         const { nodes, edges } = elkToReactFlow(graphDataWithLayout);
         setLaidOutNodes(nodes as Node<NodeMetadata>[]);
         setLaidOutEdges(edges);
-        onNodeLayout?.(nodes);
       })
       .catch((error) => {
         console.error("ELK layout failed:", error);
@@ -457,40 +479,125 @@ function GraphCore({
   }, [elk, graphData]);
 
   useEffect(() => {
-    // Runs after layout to determine the height of the graph so we can set the height of the
-    // container appropriately.
+    if (laidOutNodes.length === 0) {
+      return;
+    }
+
+    const frameId = requestAnimationFrame(() => {
+      setGraphBounds(rf.getNodesBounds(laidOutNodes));
+    });
+
+    return () => cancelAnimationFrame(frameId);
+  }, [rf, laidOutNodes]);
+
+  useEffect(() => {
+    if (!graphBounds || !onNodeLayout) {
+      return;
+    }
+
+    onNodeLayout(graphBounds);
+  }, [graphBounds, onNodeLayout]);
+
+  useEffect(() => {
+    if (!graphBounds) {
+      return;
+    }
+
+    // Once the graph has been laid out, fit the graph to the view so that it's rendered in full
+    // within the container in case the graph is larger than the container.
+    const frameId = requestAnimationFrame(() => {
+      void rf.fitView({
+        padding: FIT_ZOOM_PADDING,
+        duration: 0,
+      });
+    });
+
+    // Next frame, after React Flow applies the viewport.
     requestAnimationFrame(() => {
-      const graphBounds = rf.getNodesBounds(rf.getNodes());
-      setGraphHeight(
-        Math.ceil(
-          graphBounds.y + graphBounds.height + GRAPH_PADDING + CONTAINER_PADDING
-        )
+      setMinZoom(rf.getZoom());
+    });
+
+    return () => cancelAnimationFrame(frameId);
+  }, [rf, graphBounds]);
+
+  useEffect(() => {
+    if (!containerRef.current || !graphBounds) {
+      return;
+    }
+
+    function updateMinZoom() {
+      const containerWidth = containerRef.current.clientWidth;
+      const containerHeight = containerRef.current.clientHeight;
+
+      const viewport = getViewportForBounds(
+        graphBounds,
+        containerWidth,
+        containerHeight,
+        0,
+        2,
+        FIT_ZOOM_PADDING
       );
-      setGraphWidth(
-        Math.ceil(
-          graphBounds.x + graphBounds.width + GRAPH_PADDING + CONTAINER_PADDING
-        )
+
+      setMinZoom(viewport.zoom);
+    }
+
+    // Called when the width of the file graph container changes, so that we can center the graph
+    // within the container.
+    const observer = new ResizeObserver(() => {
+      updateMinZoom();
+      void rf.setCenter(
+        graphBounds.x + graphBounds.width / 2,
+        graphBounds.y + graphBounds.height / 2,
+        {
+          zoom: rf.getZoom(),
+          duration: 0,
+        }
       );
     });
-  }, [rf, laidOutNodes, laidOutEdges]);
 
-  return (
-    <div className="relative">
-      <div className="max-h-[calc(100vh-8rem)] overflow-x-auto overflow-y-auto">
-        <div
-          className="mx-auto"
-          style={{
-            height: graphHeight + 8,
-            width: graphWidth,
-          }}
-        >
-          <div className="h-full w-full p-2" id={graphId}>
+    updateMinZoom();
+
+    observer.observe(containerRef.current);
+
+    return () => observer.disconnect();
+  }, [rf, graphBounds]);
+
+  // Determine the height of the graph and the extent to which the user can pan around the graph. We
+  // add padding to the graph bounds so that the user can pan a bit beyond the edges of the graph.
+  const graphHeight = graphBounds
+    ? Math.ceil(graphBounds.height + GRAPH_PADDING + CONTAINER_PADDING)
+    : 0;
+  const translateExtent: CoordinateExtent = graphBounds
+    ? [
+        [graphBounds.x - 20, graphBounds.y - 20],
+        [
+          graphBounds.x + graphBounds.width + 20,
+          graphBounds.y + graphBounds.height + 20,
+        ],
+      ]
+    : [
+        [0, 0],
+        [0, 0],
+      ];
+
+  if (graphBounds) {
+    return (
+      <div className="relative">
+        <div className="overflow-auto">
+          <div
+            ref={containerRef}
+            id={graphId}
+            className="mx-auto w-full"
+            style={{
+              height: Math.min(graphHeight, MAXIMUM_GRAPH_HEIGHT),
+            }}
+          >
             <ReactFlow
+              translateExtent={translateExtent}
               nodes={laidOutNodes}
               edges={laidOutEdges}
-              defaultViewport={{ x: 0, y: 0, zoom: 1 }}
-              minZoom={1}
-              maxZoom={1}
+              minZoom={minZoom}
+              maxZoom={2}
               nodeOrigin={[0, 0]}
               nodeTypes={nodeTypes}
               edgeTypes={edgeTypes}
@@ -498,7 +605,7 @@ function GraphCore({
               nodesConnectable={false}
               elementsSelectable={false}
               onNodeClick={onNodeClick}
-              panOnDrag={false}
+              panOnDrag={true}
               panOnScroll={false}
               zoomOnScroll={false}
               zoomOnPinch={false}
@@ -510,39 +617,46 @@ function GraphCore({
                   strokeWidth: 1,
                 },
               }}
-            />
+            >
+              <Controls
+                showInteractive={false}
+                position="bottom-right"
+                orientation="horizontal"
+              />
+            </ReactFlow>
           </div>
+          {selectedNode && isFileNodeMetadata(selectedNode.data) && (
+            <FileModal
+              node={selectedNode as Node<FileMetadata>}
+              onClose={() => setSelectedNode(null)}
+            />
+          )}
+          {selectedNode && isFileSetNodeMetadata(selectedNode.data) && (
+            <FileSetModal
+              node={selectedNode as Node<FileSetMetadata>}
+              nativeFiles={nativeFiles}
+              onClose={() => setSelectedNode(null)}
+            />
+          )}
+          {selectedQualityMetrics.length > 0 && (
+            <QualityMetricModal
+              file={qualityMetricFile}
+              qualityMetrics={selectedQualityMetrics}
+              onClose={() => {
+                setSelectedQualityMetrics([]);
+                setQualityMetricFile(null);
+              }}
+            />
+          )}
         </div>
-        {selectedNode && isFileNodeMetadata(selectedNode.data) && (
-          <FileModal
-            node={selectedNode as Node<FileMetadata>}
-            onClose={() => setSelectedNode(null)}
-          />
-        )}
-        {selectedNode && isFileSetNodeMetadata(selectedNode.data) && (
-          <FileSetModal
-            node={selectedNode as Node<FileSetMetadata>}
-            nativeFiles={nativeFiles}
-            onClose={() => setSelectedNode(null)}
-          />
-        )}
-        {selectedQualityMetrics.length > 0 && (
-          <QualityMetricModal
-            file={qualityMetricFile}
-            qualityMetrics={selectedQualityMetrics}
-            onClose={() => {
-              setSelectedQualityMetrics([]);
-              setQualityMetricFile(null);
-            }}
-          />
-        )}
+        <Legend
+          fileSetStats={fileSetStats}
+          fileCount={countFileNodes(laidOutNodes)}
+        />
       </div>
-      <Legend
-        fileSetStats={fileSetStats}
-        fileCount={countFileNodes(laidOutNodes)}
-      />
-    </div>
-  );
+    );
+  }
+  return null;
 }
 
 /**
@@ -562,7 +676,7 @@ function Graph({
   graphData: ElkNode;
   nativeFiles: FileObject[];
   graphId?: string;
-  onNodeLayout?: (nodes: Node<NodeMetadata>[]) => void;
+  onNodeLayout?: (graphBounds: Rect) => void;
 }) {
   return (
     <ReactFlowProvider>
@@ -669,6 +783,84 @@ function GraphCycleError({ cycles }: { cycles: string[][] }) {
 }
 
 /**
+ * Display the title of the file graph panel, including the download button and deprecated file
+ * toggle if applicable.
+ *
+ * @param panelId - ID of the file-graph panel unique on the page for the section directory
+ * @param graphId - ID of the graph container element unique on the page
+ * @param title - Title that appears above the graph panel
+ * @param secDirTitle - Title for the section directory if the graph is within a section.
+ * @param showDeprecatedToggle - True to show the deprecated file toggle control
+ * @param localDeprecated - Props for handling the visibility of deprecated files in the graph.
+ * @param fileId - ID of the file the graph is for; used to customize download filename
+ * @param isDisabled - True to disable the download button (e.g., when cycles are detected)
+ * @param graphBounds - The bounds of the graph for download purposes
+ */
+function FileGraphTitle({
+  panelId,
+  graphId,
+  title,
+  secDirTitle,
+  showDeprecatedToggle,
+  localDeprecated,
+  fileId,
+  isDisabled,
+  graphBounds,
+}: {
+  panelId: string;
+  graphId: string;
+  title: string;
+  secDirTitle: string;
+  showDeprecatedToggle: boolean;
+  localDeprecated: DeprecatedFileFilterProps;
+  fileId: string;
+  isDisabled: boolean;
+  graphBounds: MutableRefObject<Rect | null>;
+}) {
+  const tooltipAttr = useTooltip(`tooltip-${graphId}`);
+
+  return (
+    <DataAreaTitle id={panelId} secDirTitle={secDirTitle}>
+      <div id="file-graph">{title}</div>
+      <div className="flex gap-1">
+        {showDeprecatedToggle && (
+          <Checkbox
+            id={`file-graph-deprecated-${panelId}`}
+            checked={localDeprecated.visible}
+            name="Include deprecated files"
+            onClick={() => localDeprecated.setVisible(!localDeprecated.visible)}
+            className="items-center [&>input]:mr-0"
+          >
+            <div className="order-first mr-1 text-sm">
+              {localDeprecated.controlTitle}
+            </div>
+          </Checkbox>
+        )}
+        <TooltipRef tooltipAttr={tooltipAttr}>
+          <DownloadTrigger
+            graphId={graphId}
+            fileId={fileId}
+            graphBounds={graphBounds.current}
+            isDisabled={isDisabled || !graphBounds.current}
+          />
+        </TooltipRef>
+      </div>
+      <Tooltip tooltipAttr={tooltipAttr}>
+        Download the graph as an SVG file. See{" "}
+        <Link
+          href="/help/graph-download"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          tutorial
+        </Link>{" "}
+        for details.
+      </Tooltip>
+    </DataAreaTitle>
+  );
+}
+
+/**
  * Display a graph of the file associations for a file set in a collapsible panel. We use files in
  * `files` instead of those embedded in `fileSet` because the embedded file objects do not include
  * enough properties of the files to generate the graph.
@@ -712,7 +904,8 @@ export function FileGraph({
   graphId?: string;
   fileId?: string;
 }) {
-  const tooltipAttr = useTooltip(`tooltip-${graphId}`);
+  // Stores the bounds of the graph after layout so that we can use it for SVG download.
+  const graphBounds = useRef<Rect | null>(null);
 
   // Local state for deprecated file visibility if not controlled externally via props
   const defaultDeprecatedVisible = computeDefaultDeprecatedVisibility(
@@ -779,50 +972,26 @@ export function FileGraph({
   if (graphData || cycles.length > 0 || isEmptyGraphAfterFiltering) {
     return (
       <section role="region" aria-labelledby="file-graph">
-        <DataAreaTitle id={panelId} secDirTitle={secDirTitle}>
-          <div id="file-graph">{title}</div>
-          <div className="flex gap-1">
-            {showDeprecatedToggle && (
-              <Checkbox
-                id={`file-graph-deprecated-${panelId}`}
-                checked={localDeprecated.visible}
-                name="Include deprecated files"
-                onClick={() =>
-                  localDeprecated.setVisible(!localDeprecated.visible)
-                }
-                className="items-center [&>input]:mr-0"
-              >
-                <div className="order-first mr-1 text-sm">
-                  {localDeprecated.controlTitle}
-                </div>
-              </Checkbox>
-            )}
-            <TooltipRef tooltipAttr={tooltipAttr}>
-              <DownloadTrigger
-                graphId={graphId}
-                fileId={fileId}
-                isDisabled={cycles.length > 0 || isEmptyGraphAfterFiltering}
-              />
-            </TooltipRef>
-          </div>
-          <Tooltip tooltipAttr={tooltipAttr}>
-            Download the graph as an SVG file. See{" "}
-            <Link
-              href="/help/graph-download"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              tutorial
-            </Link>{" "}
-            for details.
-          </Tooltip>
-        </DataAreaTitle>
+        <FileGraphTitle
+          panelId={panelId}
+          graphId={graphId}
+          title={title}
+          secDirTitle={secDirTitle}
+          showDeprecatedToggle={showDeprecatedToggle}
+          localDeprecated={localDeprecated}
+          fileId={fileId}
+          isDisabled={cycles.length > 0 || isEmptyGraphAfterFiltering}
+          graphBounds={graphBounds}
+        />
         {graphData ? (
           <DataPanel isPaddingSuppressed>
             <Graph
               graphData={graphData}
               nativeFiles={includedFiles}
               graphId={graphId}
+              onNodeLayout={(layedOutBounds) => {
+                graphBounds.current = layedOutBounds;
+              }}
             />
           </DataPanel>
         ) : isEmptyGraphAfterFiltering ? (

--- a/components/file-graph/lib.ts
+++ b/components/file-graph/lib.ts
@@ -2,7 +2,7 @@
 import type { ElkNode, ElkExtendedEdge } from "elkjs/lib/elk-api";
 import _ from "lodash";
 import XXH from "xxhashjs";
-import { type Edge, type Node } from "@xyflow/react";
+import { type Edge, type Node, type Rect } from "@xyflow/react";
 // lib
 import { colorVariableToColorHex } from "../../lib/color";
 import { type FileSetObject } from "../../lib/file-sets";
@@ -50,7 +50,7 @@ const HASH_SEED = 0xe8c0f852;
 /**
  * Padding (in pixels) added around SVG export content for visual spacing.
  */
-const SVG_CONTENT_PADDING = 5;
+const SVG_CONTENT_PADDING = 10;
 
 /**
  * Resolve rendered node dimensions so exported geometry matches the browser rendering.
@@ -648,6 +648,8 @@ export function elkToReactFlowNodes(
         type: elkNode.metadata.kind,
         data: elkNode.metadata,
         position: { x: elkNode.x, y: elkNode.y },
+        width: elkNode.width,
+        height: elkNode.height,
         style: { width: elkNode.width, height: elkNode.height },
         draggable: false,
         selectable: false,
@@ -742,9 +744,13 @@ export function countFileNodes(nodes: Node<NodeMetadata>[]): number {
  * to extract SVG content.
  *
  * @param graphId - ID of the graph container element in case we have multiple graphs on the page
+ * @param graphBounds - Bounds of the graph, used to determine SVG dimensions
  * @returns SVG content as a string that can be downloaded
  */
-export function generateSVGContent(graphId: string): string | undefined {
+export function generateSVGContent(
+  graphId: string,
+  graphBounds: Rect
+): string | undefined {
   // Get ReactFlow's rendered SVG elements within the specified container.
   const graphContainer = document.getElementById(graphId);
   const reactFlowRenderer = graphContainer?.querySelector(
@@ -756,22 +762,16 @@ export function generateSVGContent(graphId: string): string | undefined {
     return;
   }
 
-  // Get all node elements and calculate viewport bounds from ReactFlow.
-  const viewportElement = reactFlowRenderer.querySelector(
-    ".react-flow__viewport"
-  );
-
-  // Use the viewport's bounding box for dimensions (it contains all positioned content).
-  const viewportBounds = viewportElement?.getBoundingClientRect();
-  const contentWidth = viewportBounds?.width || 800;
-  const contentHeight = viewportBounds?.height || 600;
-
-  // Add padding to all sides: left/right and top/bottom
-  const width = contentWidth + SVG_CONTENT_PADDING * 2;
-  const height = contentHeight + SVG_CONTENT_PADDING * 2;
-
   // Generate SVG header with calculated dimensions and viewBox starting at negative padding.
-  const svgHeader = `<?xml version="1.0" encoding="UTF-8"?><svg width="${width}px" height="${height}px" viewBox="${-SVG_CONTENT_PADDING} ${-SVG_CONTENT_PADDING} ${width} ${height}" xmlns="http://www.w3.org/2000/svg">`;
+  const viewBoxWidth = graphBounds.width + SVG_CONTENT_PADDING * 2;
+  const viewBoxHeight = graphBounds.height + SVG_CONTENT_PADDING * 2;
+  const svgHeader =
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<svg width="${viewBoxWidth}px" height="${viewBoxHeight}px"` +
+    ` viewBox="${graphBounds.x - SVG_CONTENT_PADDING} ${
+      graphBounds.y - SVG_CONTENT_PADDING
+    } ${viewBoxWidth} ${viewBoxHeight}"` +
+    ` xmlns="http://www.w3.org/2000/svg">`;
 
   // Build node layers separately so group nodes can be painted behind edges and regular nodes.
   let groupNodeLayer = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -2111,67 +2111,76 @@
       }
     },
     "node_modules/@redis/bloom": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.11.0.tgz",
-      "integrity": "sha512-KYiVilAhAFN3057afUb/tfYJpsEyTkQB+tQcn5gVVA7DgcNOAj8lLxe4j8ov8BF6I9C1Fe/kwlbuAICcTMX8Lw==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
+      "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.19.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.11.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@redis/client": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
-      "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+      "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.19.0"
       },
       "peerDependencies": {
-        "@node-rs/xxhash": "^1.1.0"
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
       },
       "peerDependenciesMeta": {
         "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
           "optional": true
         }
       }
     },
     "node_modules/@redis/json": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.11.0.tgz",
-      "integrity": "sha512-1iAy9kAtcD0quB21RbPTbUqqy+T2Uu2JxucwE+B4A+VaDbIRvpZR6DMqV8Iqaws2YxJYB3GC5JVNzPYio2ErUg==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
+      "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.19.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.11.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@redis/search": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.11.0.tgz",
-      "integrity": "sha512-g1l7f3Rnyk/xI99oGHIgWHSKFl45Re5YTIcO8j/JE8olz389yUFyz2+A6nqVy/Zi031VgPDWscbbgOk8hlhZ3g==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
+      "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.19.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.11.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@redis/time-series": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.11.0.tgz",
-      "integrity": "sha512-TWFeOcU4xkj0DkndnOyhtxvX1KWD+78UHT3XX3x3XRBUGWeQrKo3jqzDsZwxbggUgf9yLJr/akFHXru66X5UQA==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
+      "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.19.0"
       },
       "peerDependencies": {
-        "@redis/client": "^5.11.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -2227,49 +2236,49 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
-      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
+      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.21.0",
-        "jiti": "^2.6.1",
+        "enhanced-resolve": "5.21.6",
+        "jiti": "^2.7.0",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.0"
+        "tailwindcss": "4.3.1"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
-      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
+      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.0",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
-        "@tailwindcss/oxide-darwin-x64": "4.3.0",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+        "@tailwindcss/oxide-android-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-x64": "4.3.1",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.1",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
-      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
+      "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
       "cpu": [
         "arm64"
       ],
@@ -2284,9 +2293,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
-      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
       "cpu": [
         "arm64"
       ],
@@ -2301,9 +2310,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
-      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
+      "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
       "cpu": [
         "x64"
       ],
@@ -2318,9 +2327,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
-      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
+      "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
       "cpu": [
         "x64"
       ],
@@ -2335,9 +2344,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
-      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
+      "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
       "cpu": [
         "arm"
       ],
@@ -2352,9 +2361,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
-      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
+      "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
       "cpu": [
         "arm64"
       ],
@@ -2369,9 +2378,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
-      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
+      "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
       "cpu": [
         "arm64"
       ],
@@ -2386,9 +2395,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
-      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
+      "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
       "cpu": [
         "x64"
       ],
@@ -2403,9 +2412,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
-      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
+      "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
       "cpu": [
         "x64"
       ],
@@ -2420,9 +2429,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
-      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
+      "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -2442,7 +2451,7 @@
         "@emnapi/runtime": "^1.10.0",
         "@emnapi/wasi-threads": "^1.2.1",
         "@napi-rs/wasm-runtime": "^1.1.4",
-        "@tybys/wasm-util": "^0.10.1",
+        "@tybys/wasm-util": "^0.10.2",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -2450,9 +2459,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
-      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
+      "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
       "cpu": [
         "arm64"
       ],
@@ -2467,9 +2476,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
-      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
+      "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
       "cpu": [
         "x64"
       ],
@@ -2484,29 +2493,30 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.0.tgz",
-      "integrity": "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.1.tgz",
+      "integrity": "sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.3.0",
-        "@tailwindcss/oxide": "4.3.0",
-        "postcss": "^8.5.10",
-        "tailwindcss": "4.3.0"
+        "@tailwindcss/node": "4.3.1",
+        "@tailwindcss/oxide": "4.3.1",
+        "postcss": "8.5.15",
+        "tailwindcss": "4.3.1"
       }
     },
     "node_modules/@tailwindcss/typography": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
-      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "postcss-selector-parser": "6.0.10"
       },
       "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
       }
     },
     "node_modules/@tanstack/react-virtual": {
@@ -3014,12 +3024,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/pako": {
@@ -3042,9 +3052,10 @@
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
     },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4360,24 +4371,34 @@
       }
     },
     "node_modules/@xyflow/react": {
-      "version": "12.10.2",
-      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
-      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.0.tgz",
+      "integrity": "sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==",
       "license": "MIT",
       "dependencies": {
-        "@xyflow/system": "0.0.76",
+        "@xyflow/system": "0.0.77",
         "classcat": "^5.0.3",
         "zustand": "^4.4.0"
       },
       "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
         "react": ">=17",
         "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@xyflow/system": {
-      "version": "0.0.76",
-      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
-      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "version": "0.0.77",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.77.tgz",
+      "integrity": "sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-drag": "^3.0.7",
@@ -5464,6 +5485,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
       "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6428,9 +6450,10 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
@@ -6687,9 +6710,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
-      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -6774,9 +6797,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
-      "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9757,12 +9780,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/isomorphic-dompurify": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.16.0.tgz",
-      "integrity": "sha512-KzTJsMuVPqPwBOD0F6jKXoV/+v8CSx0rxVp+/67KV6Xbw++0zD/avT3bZsgwR0M5QRMiOE+QqQtoZLEJYy1C4Q==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.18.0.tgz",
+      "integrity": "sha512-ajp0D8laIHeoYlhBTevpE2HUhqWaqLXFk6K/wV3Ok8kDraBZpZsifwVWaY8IfJntMRIo1VSksgKV+lXyet9Q7A==",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "^3.4.8",
+        "dompurify": "^3.4.11",
         "jsdom": "^29.1.1"
       },
       "engines": {
@@ -13138,9 +13161,10 @@
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/papaparse": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
-      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A=="
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.4.tgz",
+      "integrity": "sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -13407,9 +13431,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -13875,18 +13899,19 @@
       }
     },
     "node_modules/redis": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-5.11.0.tgz",
-      "integrity": "sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
+      "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
+      "license": "MIT",
       "dependencies": {
-        "@redis/bloom": "5.11.0",
-        "@redis/client": "5.11.0",
-        "@redis/json": "5.11.0",
-        "@redis/search": "5.11.0",
-        "@redis/time-series": "5.11.0"
+        "@redis/bloom": "5.12.1",
+        "@redis/client": "5.12.1",
+        "@redis/json": "5.12.1",
+        "@redis/search": "5.12.1",
+        "@redis/time-series": "5.12.1"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18.19.0"
       }
     },
     "node_modules/reduce-css-calc": {
@@ -15125,9 +15150,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
-      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
       "license": "MIT",
       "peer": true
     },
@@ -15572,9 +15597,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -406,6 +406,11 @@
   --color-file-graph-file-count: oklch(0.5 0 0);
   --color-file-graph-file-border: oklch(0.4891 0 0);
   --color-file-graph-group: oklch(0.9791 0 0);
+  --color-file-graph-controls-background: oklch(1 0 0);
+  --color-file-graph-controls-background-hover: oklch(0.9 0 0);
+  --color-file-graph-controls-border: oklch(0.8 0 0);
+  --color-file-graph-controls-foreground: oklch(0.1 0 0);
+  --color-file-graph-controls-foreground-disabled: oklch(0.5 0 0);
 
   /** Modal */
   --color-modal-border: #cecfd3;
@@ -704,6 +709,11 @@
   --color-file-graph-file: oklch(0.3092 0 0);
   --color-file-graph-file-border: oklch(0.5999 0 0);
   --color-file-graph-group: oklch(0.1703 0 0);
+  --color-file-graph-controls-background: oklch(0.15 0 0);
+  --color-file-graph-controls-background-hover: oklch(0.3 0 0);
+  --color-file-graph-controls-border: oklch(0.4 0 0);
+  --color-file-graph-controls-foreground: oklch(0.9 0 0);
+  --color-file-graph-controls-foreground-disabled: oklch(0.5 0 0);
 
   --color-modal-border: #68799c;
   --color-modal-backdrop: oklch(0 0 0 / 60%);
@@ -1051,4 +1061,28 @@
 
 .dark .react-flow__node:focus-visible {
   box-shadow: 0 0 0 2px #a0a0a0 !important;
+}
+
+.react-flow__controls {
+  border: 1px solid var(--color-file-graph-controls-border) !important;
+  background-color: var(
+    --color-file-graph-controls-background-hover
+  ) !important;
+  @apply overflow-hidden rounded-md;
+}
+
+.react-flow__controls-button {
+  color: var(--color-file-graph-controls-foreground) !important;
+  background-color: var(--color-file-graph-controls-background) !important;
+  border-color: var(--color-file-graph-controls-border) !important;
+}
+
+.react-flow__controls-button:hover {
+  background-color: var(
+    --color-file-graph-controls-background-hover
+  ) !important;
+}
+
+.react-flow__controls-button:disabled {
+  color: var(--color-file-graph-controls-foreground-disabled) !important;
 }


### PR DESCRIPTION
# Code Review: IGVF-3549 File Graph Zoom

Model: GPT-5.3-Codex

## Scope Reviewed
- components/file-graph/file-graph.tsx
- package-lock.json

## Findings
No blocking issues found.

## Behavior and Risk Assessment
- The file graph now computes bounds from laid-out nodes and recenters based on those bounds, which avoids initialization timing issues from instance-based bounds reads.
- Zoom and pan settings appear internally consistent with the feature goal.
- The dependency lockfile changes are acceptable for this repository context where Node 24 is mandated across local, Docker, and AWS environments.

## Validation Performed
- Ran production build: npm run -s build
- Result: successful compile and static generation completed

## Remaining Testing Gaps
- No automated tests were identified for interactive graph zoom and pan behavior.
- Recommended manual QA:
  - Very small graph (few nodes)
  - Very large graph (many nodes)
  - Container resize behavior while zoomed
  - Pan boundary behavior near graph edges

## PR Recommendation
Approve, with optional follow-up to add focused interaction tests for graph viewport behavior.
