### PR TITLE
IGVF-3581 Show prediction set cell annotations

### DIFF
--- a/components/search/__tests__/list-renderer.test.js
+++ b/components/search/__tests__/list-renderer.test.js
@@ -3088,8 +3088,8 @@ describe("Test Workflow component", () => {
   });
 });
 
-describe("Test Prediction Set component with alternate_accessions but no files or samples.summary", () => {
-  it("renders a prediction set item", () => {
+describe("Test Prediction Set component", () => {
+  it("renders a prediction set item with alternate_accessions but no files or samples.summary", () => {
     const item = {
       "@id": "/prediction-sets/IGVFDS8323PSET/",
       "@type": ["PredictionSet", "FileSet", "Item"],
@@ -3135,10 +3135,8 @@ describe("Test Prediction Set component with alternate_accessions but no files o
     const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
-});
 
-describe("Test Prediction Set component with files but no alternate_accessions or samples", () => {
-  it("renders a prediction set item", () => {
+  it("renders a prediction set item with files but no alternate_accessions or samples", () => {
     const item = {
       "@id": "/prediction-sets/IGVFDS8323PSET/",
       "@type": ["PredictionSet", "FileSet", "Item"],
@@ -3183,10 +3181,8 @@ describe("Test Prediction Set component with files but no alternate_accessions o
     const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
   });
-});
 
-describe("Test Prediction Set component with samples but no files or alternate_accessions", () => {
-  it("renders a prediction set item", () => {
+  it("renders a prediction set item with samples but no files or alternate_accessions", () => {
     const item = {
       "@id": "/prediction-sets/IGVFDS8323PSET/",
       "@type": ["PredictionSet", "FileSet", "Item"],
@@ -3251,11 +3247,18 @@ describe("Test Prediction Set component with samples but no files or alternate_a
 
     const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");
-  });
-});
 
-describe("Test Prediction Set component with no samples,  no files or alternate_accessions", () => {
-  it("renders a prediction set item", () => {
+    const paths = PredictionSet.getAccessoryDataPaths([item]);
+    expect(paths).toEqual([
+      {
+        type: "PredictionSet",
+        paths: ["/prediction-sets/IGVFDS8323PSET/"],
+        fields: ["cell_annotation", "cell_type"],
+      },
+    ]);
+  });
+
+  it("renders a prediction set item with no samples, no files or alternate_accessions", () => {
     const item = {
       "@id": "/prediction-sets/IGVFDS8323PSET/",
       "@type": ["PredictionSet", "FileSet", "Item"],
@@ -3294,6 +3297,66 @@ describe("Test Prediction Set component with no samples,  no files or alternate_
 
     const supplement = screen.queryByTestId("search-list-item-supplement");
     expect(supplement).not.toBeInTheDocument();
+
+    const status = screen.getByTestId("search-list-item-quality");
+    expect(status).toHaveTextContent("released");
+  });
+
+  it("renders a prediction set item with accessory data", () => {
+    const item = {
+      "@id": "/prediction-sets/IGVFDS8323PSET/",
+      "@type": ["PredictionSet", "FileSet", "Item"],
+      accession: "IGVFDS8323PSET",
+      award: "/awards/HG012012/",
+      lab: "/labs/j-michael-cherry/",
+      files: [],
+      status: "released",
+      file_set_type: "functional effect",
+      summary: "binding effect prediction for FOXM1 using SEMVAR v1.0.0",
+      scope: "genes",
+      uuid: "a053168a-82aa-4f7e-10e3-c19fa3cd13f6",
+    };
+
+    render(
+      <SessionContext.Provider value={{ profiles }}>
+        <PredictionSet
+          item={item}
+          accessoryData={{
+            "/prediction-sets/IGVFDS8323PSET/": {
+              "@id": "/prediction-sets/IGVFDS8323PSET/",
+              "@type": ["PredictionSet", "FileSet", "Item"],
+              cell_annotation: "Cell annotation value",
+              cell_type: {
+                "@id": "/sample-terms/UBERON_0005439/",
+                definition:
+                  "An embryonic structure that is the internal layer of the embryonic gut, formed by the recruitment of epiblast cells through the primitive streak.",
+                status: "released",
+                term_id: "UBERON:0005439",
+                term_name: "definitive endoderm",
+              },
+            },
+          }}
+        />
+      </SessionContext.Provider>
+    );
+
+    const uniqueId = screen.getByTestId("search-list-item-unique-id");
+    expect(uniqueId).toHaveTextContent(/Prediction Set/);
+    expect(uniqueId).toHaveTextContent(/IGVFDS8323PSET/);
+
+    const title = screen.getByTestId("search-list-item-title");
+    expect(title).toHaveTextContent(
+      "binding effect prediction for FOXM1 using SEMVAR v1.0.0"
+    );
+
+    const meta = screen.getByTestId("search-list-item-meta");
+    expect(meta).toHaveTextContent("/labs/j-michael-cherry/");
+    expect(meta).toHaveTextContent("genes");
+
+    const supplementContent = screen.getAllByTestId(
+      "search-list-item-supplement-content"
+    );
+    expect(supplementContent[0]).toHaveTextContent("Cell annotation value");
 
     const status = screen.getByTestId("search-list-item-quality");
     expect(status).toHaveTextContent("released");

--- a/components/search/list-renderer/prediction-set.tsx
+++ b/components/search/list-renderer/prediction-set.tsx
@@ -1,5 +1,4 @@
 // node_modules
-import PropTypes from "prop-types";
 // components/search/list-renderer
 import {
   SearchListItemContent,
@@ -18,8 +17,27 @@ import {
 // components
 import { ControlledAccessIndicator } from "../../controlled-access";
 import { DataUseLimitationSummaries } from "../../data-use-limitation-status";
+import { SampleAnnotatedSummary } from "../../sample-annotated-summary";
+// lib
+import { type PredictionSetObject } from "../../../lib/file-sets";
+import { isEmbedded } from "../../../lib/types";
 
-export default function PredictionSet({ item: predictionSet }) {
+/**
+ * A subset of the `PseudobulkSetObject` fields that appears in accessory data for the pseudobulk
+ * set list renderer.
+ */
+type PredictionSetSubset = Pick<
+  PredictionSetObject,
+  "@id" | "@type" | "cell_annotation" | "cell_type"
+>;
+
+export default function PredictionSet({
+  item: predictionSet,
+  accessoryData,
+}: {
+  item: PredictionSetObject;
+  accessoryData?: Record<string, PredictionSetSubset> | null;
+}) {
   // Collect all files.content_type and deduplicate
   const fileContentType =
     predictionSet.files?.length > 0
@@ -34,8 +52,17 @@ export default function PredictionSet({ item: predictionSet }) {
         ].sort()
       : [];
 
+  // If the accessory data has a `cell_type` property, use it to get definitions for tooltips on
+  // `cell_annotation` summary. We eventually need to also retrieve sample terms to get more
+  // complete tooltips.
+  const accessoryPredictionSet = accessoryData?.[predictionSet["@id"]];
+  const allSampleTerms = isEmbedded(accessoryPredictionSet?.cell_type)
+    ? [accessoryPredictionSet.cell_type]
+    : [];
+
   const isSupplementsVisible =
     predictionSet.alternate_accessions ||
+    accessoryPredictionSet?.cell_annotation ||
     fileContentType.length > 0 ||
     sampleSummaries.length > 0;
 
@@ -48,7 +75,11 @@ export default function PredictionSet({ item: predictionSet }) {
         </SearchListItemUniqueId>
         <SearchListItemTitle>{predictionSet.summary}</SearchListItemTitle>
         <SearchListItemMeta>
-          <span key="lab">{predictionSet.lab.title}</span>
+          <span key="lab">
+            {isEmbedded(predictionSet.lab)
+              ? predictionSet.lab.title
+              : predictionSet.lab}
+          </span>
           {predictionSet.scope && (
             <span key="scope">{predictionSet.scope}</span>
           )}
@@ -63,6 +94,19 @@ export default function PredictionSet({ item: predictionSet }) {
                 </SearchListItemSupplementLabel>
                 <SearchListItemSupplementContent>
                   {fileContentType.join(", ")}
+                </SearchListItemSupplementContent>
+              </SearchListItemSupplementSection>
+            )}
+            {accessoryPredictionSet?.cell_annotation && (
+              <SearchListItemSupplementSection>
+                <SearchListItemSupplementLabel>
+                  Cell Annotation
+                </SearchListItemSupplementLabel>
+                <SearchListItemSupplementContent>
+                  <SampleAnnotatedSummary
+                    summary={accessoryPredictionSet.cell_annotation}
+                    terms={allSampleTerms}
+                  />
                 </SearchListItemSupplementContent>
               </SearchListItemSupplementSection>
             )}
@@ -89,7 +133,12 @@ export default function PredictionSet({ item: predictionSet }) {
   );
 }
 
-PredictionSet.propTypes = {
-  // Single prediction set search-result object to display on a search-result list page
-  item: PropTypes.object.isRequired,
+PredictionSet.getAccessoryDataPaths = (items) => {
+  return [
+    {
+      type: "PredictionSet",
+      paths: items.map((item) => item["@id"]),
+      fields: ["cell_annotation", "cell_type"],
+    },
+  ];
 };

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -8,18 +8,6 @@ import { type LinkTo, LinkToArray } from "./lib/types";
 import { type WorkflowObject } from "./lib/workflow";
 
 /**
- * Template for props passed from Next.js `getServerSideProps` to page components. Extend this for
- * the props specific to each page.
- *
- * @param isJson - Whether the page is being rendered in JSON format
- * @param pageContext - Additional context for the page, such as title
- */
-export interface PageComponentProps {
-  isJson: boolean;
-  pageContext: { title: string };
-}
-
-/**
  * Single audit within an audit category.
  */
 export interface Audit {

--- a/lib/file-sets.ts
+++ b/lib/file-sets.ts
@@ -10,6 +10,7 @@ import {
   pathsFromDatabaseObjects,
 } from "./database-object";
 import FetchRequest from "./fetch-request";
+import { type GeneLocation } from "./genes";
 import {
   type AssayTermObject,
   type OntologyTermObject,
@@ -27,6 +28,7 @@ import type {
   LabObject,
   OpenReadingFrameObject,
   PublicationObject,
+  SoftwareVersionObject,
   SourceObject,
 } from "../globals";
 
@@ -198,15 +200,21 @@ export interface MeasurementSetObject extends FileSetObject {
 
 export interface ModelSetObject extends FileSetObject {
   assay_titles?: string[];
+  assessed_genes?: LinkToArray<GeneObject>;
   dbxrefs?: string[];
   doi?: string;
   file_sets?: LinkToArray<FileSetObject>;
   input_file_sets?: LinkToArray<FileSetObject>;
   preferred_assay_titles?: string[];
+  software_versions?: LinkToArray<SoftwareVersionObject>;
 }
 
 export interface PredictionSetObject extends FileSetObject {
   associated_phenotypes?: LinkToArray<OntologyTermObject>;
+  assessed_genes?: LinkToArray<GeneObject>;
+  cell_annotation?: string;
+  cell_qualifier?: string;
+  cell_type?: LinkTo<OntologyTermObject>;
   dbxrefs?: string[];
   doi?: string;
   file_sets?: LinkToArray<FileSetObject>;
@@ -214,6 +222,9 @@ export interface PredictionSetObject extends FileSetObject {
   large_scale_gene_list?: LinkTo<FileObject>;
   large_scale_loci_list?: LinkTo<FileObject>;
   scope?: string;
+  small_scale_gene_list?: LinkToArray<GeneObject>;
+  small_scale_loci_list?: GeneLocation[];
+  software_versions?: LinkToArray<SoftwareVersionObject>;
 }
 
 export interface PseudobulkSetObject extends FileSetObject {

--- a/lib/next-js.ts
+++ b/lib/next-js.ts
@@ -1,16 +1,26 @@
 // lib
 import { AttributionData } from "./attribution";
+// root
+import type { DatabaseObject } from "../globals";
 
 /**
  * Return value from `getServerSideProps` for pages in this project. This also defines the shape of
  * the `pageContext` object that is passed to page components in this project. You likely need to
  * extend this for the actual props returned by `getServerSideProps` in your page, adding the
  * properties needed to display that page.
+ *
+ * @param attribution - Attribution data for the page, or `null` if no attribution data is available
+ * @param isJson - True to display the page as JSON
+ * @param pageContext - Contextual information about the page, usually its title
+ * @param supersededBy - Optional array of database objects that supersede this object
+ * @param supersedes - Optional array of database objects that this object supersedes
  */
 export interface PageProps {
+  attribution?: AttributionData | null;
+  isJson: boolean;
   pageContext: {
     title: string;
   };
-  attribution: AttributionData | null;
-  isJson: boolean;
+  supersededBy?: DatabaseObject[] | null;
+  supersedes?: DatabaseObject[] | null;
 }

--- a/pages/prediction-sets/[id].tsx
+++ b/pages/prediction-sets/[id].tsx
@@ -1,5 +1,8 @@
 // node_modules
-import PropTypes from "prop-types";
+import {
+  type GetServerSidePropsContext,
+  type GetServerSidePropsResult,
+} from "next";
 import { useEffect, useState } from "react";
 // components
 import { AlternativeIdentifiers } from "../../components/alternative-identifiers";
@@ -29,6 +32,7 @@ import JsonDisplay from "../../components/json-display";
 import Link from "../../components/link-no-prefetch";
 import ObjectPageHeader from "../../components/object-page-header";
 import PagePreamble from "../../components/page-preamble";
+import { SampleAnnotatedSummary } from "../../components/sample-annotated-summary";
 import SampleTable from "../../components/sample-table";
 import { useSecDir } from "../../components/section-directory";
 import SeparatedList from "../../components/separated-list";
@@ -38,21 +42,83 @@ import buildAttribution from "../../lib/attribution";
 import { createCanonicalUrlRedirect } from "../../lib/canonical-redirect";
 import {
   requestDocuments,
-  requestDonors,
   requestFiles,
-  requestFileSets,
   requestGenes,
-  requestPublications,
-  requestQualityMetrics,
-  requestSamples,
   requestSupersedes,
 } from "../../lib/common-requests";
+import {
+  isDatabaseObject,
+  isDatabaseObjectArray,
+  pathsFromDatabaseObjects,
+} from "../../lib/database-object";
 import { isDeprecatedStatus } from "../../lib/deprecated-files";
+import DonorTable from "../../components/donor-table";
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
-import { getAllDerivedFromFiles } from "../../lib/files";
+import {
+  requestAssociatedFileSets,
+  requestFileSetDonors,
+  requestFileSetPublications,
+  requestFileSetSamples,
+  type FileSetObject,
+  type PredictionSetObject,
+} from "../../lib/file-sets";
+import {
+  getAllDerivedFromFiles,
+  getFilesFileSets,
+  requestFilesQualityMetrics,
+  requestFilesReferenceFiles,
+} from "../../lib/files";
+import { PageProps } from "../../lib/next-js";
+import { SampleTermObject } from "../../lib/ontology-terms";
+import { type QualityMetricObject } from "../../lib/quality-metric";
 import { isJsonFormat } from "../../lib/query-utils";
-import DonorTable from "../../components/donor-table";
+import { getSamplesTerms, type SampleObject } from "../../lib/samples";
+import { isEmbedded, isPathArray } from "../../lib/types";
+// root
+import {
+  type DocumentObject,
+  type DonorObject,
+  type FileObject,
+  type GeneObject,
+  type PublicationObject,
+} from "../../globals";
+
+/**
+ * Props for the prediction set page, sourced from `getServerSideProps`.
+ *
+ * @param predictionSet - Prediction set object to display
+ * @param inputFileSets - Input file sets that this prediction set is an input for
+ * @param inputFileSetFor - Input file sets for this prediction set
+ * @param controlFor - Control file sets for this prediction set
+ * @param documents - Documents associated with this prediction set
+ * @param publications - Publications associated with this prediction set
+ * @param files - Files to display
+ * @param fileFileSets - File sets that `files` refer to in their `file_sets` property
+ * @param referenceFiles - Reference files to display
+ * @param derivedFromFiles - All derived_from files not included in `files`
+ * @param samples - Samples associated with this prediction set
+ * @param donors - Donors associated with this prediction set
+ * @param assessedGenes - Genes that are assessed in this prediction set
+ * @param qualityMetrics - Quality metrics associated with this analysis set
+ */
+interface PredictionSetPageProps extends PageProps {
+  predictionSet: PredictionSetObject;
+  inputFileSets: FileSetObject[];
+  inputFileSetFor: FileSetObject[];
+  controlFor: FileSetObject[];
+  documents: DocumentObject[];
+  publications: PublicationObject[];
+  files: FileObject[];
+  fileFileSets: FileSetObject[];
+  referenceFiles: FileObject[];
+  derivedFromFiles: FileObject[];
+  samples: SampleObject[];
+  samplesTerms: SampleTermObject[];
+  donors: DonorObject[];
+  assessedGenes: GeneObject[];
+  qualityMetrics: QualityMetricObject[];
+}
 
 export default function PredictionSet({
   predictionSet,
@@ -66,20 +132,26 @@ export default function PredictionSet({
   referenceFiles,
   derivedFromFiles,
   samples,
+  samplesTerms,
   donors,
   assessedGenes,
   qualityMetrics,
   supersedes,
   supersededBy,
-  attribution = null,
+  attribution,
   isJson,
-}) {
+}: PredictionSetPageProps) {
   const sections = useSecDir({ isJson });
 
   // State for whether to include deprecated files in the file table and graph.
   const [areDeprecatedFilesVisible, setAreDeprecatedFilesVisible] = useState(
     isDeprecatedStatus(predictionSet.status)
   );
+
+  // Combine all sample-associated terms to pass to the SampleAnnotatedSummary component, ensuring that if the pseudobulk set has a cell type, it is included as a term (since the cell annotation may reference the cell type), along with all terms from the samples.
+  const allSampleTerms = isEmbedded(predictionSet.cell_type)
+    ? [predictionSet.cell_type, ...samplesTerms]
+    : samplesTerms;
 
   useEffect(() => {
     setAreDeprecatedFilesVisible(isDeprecatedStatus(predictionSet.status));
@@ -156,7 +228,7 @@ export default function PredictionSet({
                     </DataItemValue>
                   </>
                 )}
-                {predictionSet.large_scale_gene_list && (
+                {isDatabaseObject(predictionSet.large_scale_gene_list) && (
                   <>
                     <DataItemLabel>Large Scale Gene List</DataItemLabel>
                     <DataItemValue>
@@ -169,7 +241,7 @@ export default function PredictionSet({
                     </DataItemValue>
                   </>
                 )}
-                {predictionSet.large_scale_loci_list && (
+                {isDatabaseObject(predictionSet.large_scale_loci_list) && (
                   <>
                     <DataItemLabel>Large Scale Loci List</DataItemLabel>
                     <DataItemValue>
@@ -215,6 +287,27 @@ export default function PredictionSet({
                     </DataItemValue>
                   </>
                 )}
+                {predictionSet.cell_annotation && (
+                  <>
+                    <DataItemLabel>Cell Annotation</DataItemLabel>
+                    <DataItemValue>
+                      <SampleAnnotatedSummary
+                        summary={predictionSet.cell_annotation}
+                        terms={allSampleTerms}
+                      />
+                    </DataItemValue>
+                  </>
+                )}
+                {isEmbedded(predictionSet.cell_type) && (
+                  <>
+                    <DataItemLabel>Cell Ontology ID</DataItemLabel>
+                    <DataItemValue>
+                      <Link href={predictionSet.cell_type["@id"]}>
+                        {predictionSet.cell_type.term_id}
+                      </Link>
+                    </DataItemValue>
+                  </>
+                )}
                 {referenceFiles.length > 0 && (
                   <>
                     <DataItemLabel>Reference Files</DataItemLabel>
@@ -233,7 +326,7 @@ export default function PredictionSet({
                     </DataItemValue>
                   </>
                 )}
-                {predictionSet.software_versions?.length > 0 && (
+                {isDatabaseObjectArray(predictionSet.software_versions) && (
                   <>
                     <DataItemLabel>Software Versions</DataItemLabel>
                     <DataItemValue>
@@ -264,17 +357,16 @@ export default function PredictionSet({
                 }}
               />
               <FileGraph
-                fileSet={predictionSet}
                 files={files}
-                referenceFiles={referenceFiles}
                 fileFileSets={fileFileSets}
+                referenceFiles={referenceFiles}
                 derivedFromFiles={derivedFromFiles}
                 qualityMetrics={qualityMetrics}
-                fileId={predictionSet.accession}
                 externalDeprecated={{
                   visible: areDeprecatedFilesVisible,
                   setVisible: setAreDeprecatedFilesVisible,
                 }}
+                fileId={predictionSet.accession}
               />
             </>
           )}
@@ -288,7 +380,7 @@ export default function PredictionSet({
             />
           )}
           {donors.length > 0 && <DonorTable donors={donors} />}
-          {predictionSet.construct_library_sets?.length > 0 && (
+          {isDatabaseObjectArray(predictionSet.construct_library_sets) && (
             <ConstructLibraryTable
               constructLibrarySets={predictionSet.construct_library_sets}
               title="Associated Construct Library Sets"
@@ -330,50 +422,20 @@ export default function PredictionSet({
   );
 }
 
-PredictionSet.propTypes = {
-  // Prediction set to display
-  predictionSet: PropTypes.object.isRequired,
-  // Input file sets that this prediction set is an input for
-  inputFileSets: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Input file sets for this prediction set
-  inputFileSetFor: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Control file sets for this prediction set
-  controlFor: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Files to display
-  files: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // File sets that `files` refer to in their `file_sets` property
-  fileFileSets: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Reference files to display
-  referenceFiles: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // All derived_from files not included in `files`
-  derivedFromFiles: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Genes that are assessed in this prediction set
-  assessedGenes: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Samples associated with this prediction set
-  samples: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Donors associated with this prediction set
-  donors: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Documents associated with this prediction set
-  documents: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Quality metrics associated with this analysis set
-  qualityMetrics: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Publications associated with this prediction set
-  publications: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // File sets that supersede this file set
-  supersedes: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // File sets that are superseded by this file set
-  supersededBy: PropTypes.arrayOf(PropTypes.object).isRequired,
-  // Attribution for this prediction set
-  attribution: PropTypes.object,
-  // Is the format JSON?
-  isJson: PropTypes.bool.isRequired,
-};
-
-export async function getServerSideProps({ params, req, query, resolvedUrl }) {
+export async function getServerSideProps({
+  params,
+  req,
+  query,
+  resolvedUrl,
+}: GetServerSidePropsContext<{ id: string }>): Promise<
+  GetServerSidePropsResult<PredictionSetPageProps>
+> {
   const isJson = isJsonFormat(query);
   const request = new FetchRequest({ cookie: req.headers.cookie });
   const predictionSet = (
-    await request.getObject(`/prediction-sets/${params.id}/`)
+    await request.getObject<PredictionSetObject>(
+      `/prediction-sets/${params.id}/`
+    )
   ).union();
   if (FetchRequest.isResponseSuccess(predictionSet)) {
     const canonicalRedirect = createCanonicalUrlRedirect(
@@ -385,99 +447,52 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
       return canonicalRedirect;
     }
 
-    const documents = predictionSet.documents
+    const files = isDatabaseObjectArray(predictionSet.files)
+      ? await requestFiles(
+          pathsFromDatabaseObjects(predictionSet.files),
+          request
+        )
+      : [];
+
+    const samples = await requestFileSetSamples([predictionSet], request);
+    const samplesTerms = await getSamplesTerms(samples, request);
+    const donors = await requestFileSetDonors(predictionSet, request);
+    const derivedFromFiles = await getAllDerivedFromFiles(files, request);
+    const combinedFiles = files.concat(derivedFromFiles);
+    const fileFileSets = await getFilesFileSets(combinedFiles, request);
+    const publications = await requestFileSetPublications(
+      predictionSet,
+      request
+    );
+    const referenceFiles = await requestFilesReferenceFiles(files, request);
+    const qualityMetrics = await requestFilesQualityMetrics(files, request);
+
+    const documents = isPathArray(predictionSet.documents)
       ? await requestDocuments(predictionSet.documents, request)
       : [];
 
-    let samples = [];
-    if (predictionSet.samples?.length > 0) {
-      const samplePaths = predictionSet.samples.map((sample) => sample["@id"]);
-      samples = await requestSamples(samplePaths, request);
-    }
+    const inputFileSets = await requestAssociatedFileSets(
+      [predictionSet],
+      "input_file_sets",
+      request,
+      ["analysis_set", "curated_set"]
+    );
 
-    const donors = await requestDonors(
-      predictionSet.donors?.map((donor) => donor["@id"]) || [],
+    const inputFileSetFor = await requestAssociatedFileSets(
+      [predictionSet],
+      "input_for",
       request
     );
 
-    const inputFileSets =
-      predictionSet.input_file_sets?.length > 0
-        ? await requestFileSets(predictionSet.input_file_sets, request)
-        : [];
+    const controlFor = await requestAssociatedFileSets(
+      [predictionSet],
+      "control_for",
+      request
+    );
 
-    const inputFileSetFor =
-      predictionSet.input_for?.length > 0
-        ? await requestFileSets(predictionSet.input_for, request)
-        : [];
-
-    let controlFor = [];
-    if (predictionSet.control_for?.length > 0) {
-      const controlForPaths = predictionSet.control_for.map(
-        (controlFor) => controlFor["@id"]
-      );
-      controlFor = await requestFileSets(controlForPaths, request);
-    }
-
-    let files = [];
-    if (predictionSet.files?.length > 0) {
-      const filePaths = predictionSet.files.map((file) => file["@id"]) || [];
-      files = await requestFiles(filePaths, request);
-    }
-
-    const derivedFromFiles = await getAllDerivedFromFiles(files, request);
-    const combinedFiles = files.concat(derivedFromFiles);
-    let fileFileSets = [];
-    if (combinedFiles.length > 0) {
-      const fileSetPaths = combinedFiles.reduce((acc, file) => {
-        return acc.includes(file.file_set["@id"])
-          ? acc
-          : acc.concat(file.file_set["@id"]);
-      }, []);
-      fileFileSets = await requestFileSets(fileSetPaths, request);
-    }
-
-    const assessedGenes =
-      predictionSet.assessed_genes?.length > 0
-        ? await requestGenes(predictionSet.assessed_genes, request)
-        : [];
-
-    let publications = [];
-    if (predictionSet.publications?.length > 0) {
-      const publicationPaths = predictionSet.publications.map(
-        (publication) => publication["@id"]
-      );
-      publications = await requestPublications(publicationPaths, request);
-    }
-
-    let qualityMetrics = [];
-    if (files.length > 0) {
-      let qualityMetricsPaths = files.reduce((acc, file) => {
-        return file.quality_metrics?.length > 0
-          ? acc.concat(file.quality_metrics)
-          : acc;
-      }, []);
-      qualityMetricsPaths = [...new Set(qualityMetricsPaths)];
-      qualityMetrics =
-        qualityMetricsPaths.length > 0
-          ? await requestQualityMetrics(qualityMetricsPaths, request)
-          : [];
-    }
-
-    // Get all reference file paths from the files in the prediction set, then request those files
-    // from the server. `reference_files` has a `minItems` of 1, so just check its existence.
-    const referenceFilePathsSet = files.reduce((acc, file) => {
-      if (file.reference_files) {
-        file.reference_files.forEach((referenceFilePath) => {
-          acc.add(referenceFilePath);
-        });
-      }
-      return acc;
-    }, new Set());
-    const referenceFilePaths = [...referenceFilePathsSet];
-    const referenceFiles =
-      referenceFilePaths.length > 0
-        ? await requestFiles(referenceFilePaths, request)
-        : [];
+    const assessedGenes = isPathArray(predictionSet.assessed_genes)
+      ? await requestGenes(predictionSet.assessed_genes, request)
+      : [];
 
     const { supersedes, supersededBy } = await requestSupersedes(
       predictionSet,
@@ -504,6 +519,7 @@ export async function getServerSideProps({ params, req, query, resolvedUrl }) {
         referenceFiles,
         derivedFromFiles,
         samples,
+        samplesTerms,
         donors,
         qualityMetrics,
         supersedes,

--- a/pages/pseudobulk-sets/[id].tsx
+++ b/pages/pseudobulk-sets/[id].tsx
@@ -104,9 +104,6 @@ interface ThisPageProps extends PageProps {
   assayTitleDescriptionMap: Record<string, string>;
   publications: PublicationObject[];
   documents: DocumentObject[];
-  supersedes: FileSetObject[];
-  supersededBy: FileSetObject[];
-  isJson: boolean;
 }
 
 /**

--- a/pages/users/[uuid].tsx
+++ b/pages/users/[uuid].tsx
@@ -17,9 +17,10 @@ import PagePreamble from "../../components/page-preamble";
 // lib
 import { errorObjectToProps } from "../../lib/errors";
 import FetchRequest from "../../lib/fetch-request";
+import { type PageProps } from "../../lib/next-js";
 import { isJsonFormat } from "../../lib/query-utils";
 // root
-import type { LabObject, PageComponentProps, UserObject } from "../../globals";
+import type { LabObject, UserObject } from "../../globals";
 
 /**
  * Props for the User page component.
@@ -27,12 +28,12 @@ import type { LabObject, PageComponentProps, UserObject } from "../../globals";
  * @property user - User object containing user details
  * @property lab - Lab object associated with the user, if any
  */
-interface UserProps extends PageComponentProps {
+interface UserPageProps extends PageProps {
   user: UserObject;
   lab: LabObject | null;
 }
 
-export default function User({ user, lab, isJson }: UserProps) {
+export default function User({ user, lab, isJson }: UserPageProps) {
   return (
     <>
       <Breadcrumbs item={user} />
@@ -88,7 +89,7 @@ export async function getServerSideProps({
   query,
 }: GetServerSidePropsContext<{
   uuid: string;
-}>): Promise<GetServerSidePropsResult<UserProps>> {
+}>): Promise<GetServerSidePropsResult<UserPageProps>> {
   if (!params) {
     return { notFound: true };
   }


### PR DESCRIPTION
# Code Review: IGVF-3581-cell-annotation-prediction

## Model

GPT-5.3-Codex

## Summary

This branch introduces Prediction Set support updates in search list rendering and object page typing/migration, including shared page-prop typing updates.

## Verdict

Approved with no blocking issues found in this revision.

## Findings

No actionable defects were identified in the latest diff.

### Notes

- The previous PageProps nullability concern appears resolved.
- Shared page prop typing now aligns with current page usage patterns.

## Validation Performed

- Next production build succeeded (type-check + compile).
- Targeted tests passed:
  - `npm test -- --runInBand components/search/__tests__/list-renderer.test.js`

## Residual Risk / Coverage Gaps

- Full repository test suites were not executed in this pass; review confidence is strongest for the modified areas and targeted renderer behavior.

## Suggested PR Comment (Copy/Paste)

Reviewed this branch with **GPT-5.3-Codex**.

**Verdict: Approved** (no blocking issues found).

I re-reviewed the updated changes (including PageProps updates), and did not find actionable defects in the current diff.

Validation performed:

- Next production build succeeded (type-check + compile)
- `npm test -- --runInBand components/search/__tests__/list-renderer.test.js` passed

Residual risk:

- Full repository test suites were not run in this pass.