### PR TITLE
IGVF-3523 Add file-set grouping input-file-set stage

### DIFF
--- a/components/file-graph/grouping-pipeline/__tests__/input-file-set-grouping.test.ts
+++ b/components/file-graph/grouping-pipeline/__tests__/input-file-set-grouping.test.ts
@@ -1,0 +1,129 @@
+import { inputFileSetStage } from "../input-file-set-grouping";
+import {
+  type AnalysisSetObject,
+  type MeasurementSetObject,
+} from "../../../../lib/file-sets";
+import { type FileSetNode } from "../../types";
+
+describe("inputFileSetStage", () => {
+  it("groups together file-set nodes that are connected by input file set relationships", () => {
+    const experimentalData: MeasurementSetObject = {
+      "@id": "/measurement-sets/IGVFDS0000EXPD",
+      "@type": ["MeasurementSet", "FileSet", "Item"],
+      assay_term: {
+        "@id": "/assay-terms/OBI_0000185/",
+        "@type": ["AssayTerm", "OntologyTerm", "Item"],
+        term_id: "OBI:0000185",
+        term_name: "imaging assay",
+        status: "in progress",
+      },
+      file_set_type: "experimental data",
+      status: "in progress",
+      summary: "Experimental data for imaging assay",
+    };
+    const intermediateAnalysis: AnalysisSetObject = {
+      "@id": "/analysis-sets/IGVFDS0000INTA",
+      "@type": ["AnalysisSet", "FileSet", "Item"],
+      file_set_type: "intermediate analysis",
+      input_file_sets: [experimentalData],
+      status: "in progress",
+      summary: "Intermediate analysis for imaging assay",
+    };
+
+    const targetFileSetNodes: FileSetNode[] = [
+      {
+        id: "file-set-1",
+        metadata: {
+          fileSet: experimentalData,
+          kind: "fileset",
+          externalFiles: [],
+          downstreamFiles: [],
+        },
+      },
+      {
+        id: "file-set-2",
+        metadata: {
+          fileSet: intermediateAnalysis,
+          kind: "fileset",
+          externalFiles: [],
+          downstreamFiles: [],
+        },
+      },
+    ];
+
+    const nodesByFileSetPath = new Map([
+      ["/measurement-sets/IGVFDS0000EXPD", [targetFileSetNodes[0]]],
+      ["/analysis-sets/IGVFDS0000INTA", [targetFileSetNodes[1]]],
+    ]);
+
+    const nodeById = new Map(targetFileSetNodes.map((node) => [node.id, node]));
+
+    const result = inputFileSetStage(
+      targetFileSetNodes,
+      nodeById,
+      nodesByFileSetPath
+    );
+
+    expect(result.groups.size).toBe(1);
+    const [group] = [...result.groups.values()];
+    expect(group).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "file-set-1",
+        }),
+        expect.objectContaining({
+          id: "file-set-2",
+        }),
+      ])
+    );
+    expect(result.remainingNodes).toEqual([]);
+  });
+
+  it("returns all nodes as remaining nodes if there are no nodes to group", () => {
+    const node1 = {
+      id: "file-set-1",
+      metadata: {
+        fileSet: {
+          "@id": "/file-set-1",
+          "@type": ["AuxiliarySet", "FileSet", "Item"],
+        },
+      },
+    };
+
+    const node2 = {
+      id: "file-set-2",
+      metadata: {
+        fileSet: {
+          "@id": "/file-set-2",
+          "@type": ["AuxiliarySet", "FileSet", "Item"],
+        },
+      },
+    };
+
+    const allFileSetNodes = [node1, node2];
+
+    const nodesByFileSetPath = new Map([
+      ["/file-set-1", [node1]],
+      ["/file-set-2", [node2]],
+    ]);
+
+    const result = inputFileSetStage(
+      allFileSetNodes as any,
+      new Map(allFileSetNodes.map((node) => [node.id, node as any])),
+      nodesByFileSetPath as any
+    );
+
+    expect(result.groups.size).toBe(0);
+    expect(result.remainingNodes).toHaveLength(2);
+    expect(result.remainingNodes[0]).toEqual(
+      expect.objectContaining({
+        id: "file-set-1",
+      })
+    );
+    expect(result.remainingNodes[1]).toEqual(
+      expect.objectContaining({
+        id: "file-set-2",
+      })
+    );
+  });
+});

--- a/components/file-graph/grouping-pipeline/index.ts
+++ b/components/file-graph/grouping-pipeline/index.ts
@@ -4,6 +4,7 @@ import { type FileSetNode } from "../types";
 import { auxiliarySetStage } from "./auxiliary-set-grouping";
 import { constructLibrarySetStage } from "./construct-library-set-grouping";
 import { controlFileSetStage } from "./control-file-set-groupings";
+import { inputFileSetStage } from "./input-file-set-grouping";
 import { buildNodesByFileSetPath } from "./lib";
 import { relatedMeasurementSetStage } from "./related-measurement-set-grouping";
 import {
@@ -37,6 +38,7 @@ const groupingPipelineStages: GroupPipelineStageFunction[] = [
   relatedMeasurementSetStage,
   constructLibrarySetStage,
   controlFileSetStage,
+  inputFileSetStage,
 ];
 
 /**

--- a/components/file-graph/grouping-pipeline/input-file-set-grouping.ts
+++ b/components/file-graph/grouping-pipeline/input-file-set-grouping.ts
@@ -1,0 +1,48 @@
+// file-graph
+import { type FileSetNode } from "../types";
+// file-graph/grouping-pipeline
+import {
+  buildStandardAdjacency,
+  standardGroupingStage,
+} from "./standard-grouping";
+import { type GroupStageResult } from "./types";
+
+/**
+ * Runs the input-file-set stage of the grouping pipeline. In this stage, file sets are grouped by
+ * their `input_file_sets` property for file sets already included in the graph. Any file sets that
+ * this function groups together are added to the `groups` mapping in the result that maps a group
+ * ID to the array of nodes in that group. Any nodes not part of any group are returned in the
+ * `remainingNodes` array in the result.
+ *
+ * @param fileSetNodes - File set nodes to group in this stage
+ * @param nodeById - Mapping of node IDs to the corresponding file-set nodes for all nodes in the
+ *                   graph
+ * @param nodesByFileSetPath - Mapping of file-set paths to the corresponding file-set nodes for all
+ *                             nodes in the graph
+ * @returns Result of this grouping stage, including the groups that were formed and any remaining
+ *          ungrouped nodes
+ */
+export function inputFileSetStage(
+  fileSetNodes: FileSetNode[],
+  nodeById: Map<string, FileSetNode>,
+  nodesByFileSetPath: Map<string, FileSetNode[]>
+): GroupStageResult {
+  const adjacency = buildStandardAdjacency(
+    fileSetNodes,
+    fileSetNodes,
+    nodesByFileSetPath,
+    "input_file_sets"
+  );
+  const results = standardGroupingStage(fileSetNodes, nodeById, adjacency);
+  /* istanbul ignore next */
+  if (process.env.NODE_ENV === "development") {
+    console.log(
+      `GROUPING: Input file set stage grouped ${[...results.groups.values()]
+        .map((group) => group.length)
+        .reduce((sum, length) => sum + length, 0)} nodes into ${
+        results.groups.size
+      } groups and left ${results.remainingNodes.length} nodes ungrouped.`
+    );
+  }
+  return results;
+}

--- a/lib/__tests__/common-requests.test.ts
+++ b/lib/__tests__/common-requests.test.ts
@@ -678,7 +678,7 @@ describe("Test all the common requests", () => {
       request
     );
     expect(mockFetch).toHaveBeenCalledWith(
-      "/search-quick/?type=FileSet&field=@type&field=accession&field=aliases&field=auxiliary_sets&field=cell_qualifier&field=cell_type&field=construct_library_sets&field=control_file_sets&field=file_set_type&field=lab.title&field=preferred_assay_titles&field=related_measurement_sets&field=samples&field=status&field=summary&@id=/auxiliary-sets/IGVFDS0001AUXI/&@id=/measurement-sets/IGVFDS4649TBFS/&limit=2",
+      "/search-quick/?type=FileSet&field=@type&field=accession&field=aliases&field=auxiliary_sets&field=cell_qualifier&field=cell_type&field=construct_library_sets&field=control_file_sets&field=file_set_type&field=input_file_sets&field=lab.title&field=preferred_assay_titles&field=related_measurement_sets&field=samples&field=status&field=summary&@id=/auxiliary-sets/IGVFDS0001AUXI/&@id=/measurement-sets/IGVFDS4649TBFS/&limit=2",
       expect.anything()
     );
     expect(result).toHaveLength(2);

--- a/lib/common-requests.ts
+++ b/lib/common-requests.ts
@@ -294,6 +294,7 @@ export async function requestFileSets(
         "construct_library_sets",
         "control_file_sets",
         "file_set_type",
+        "input_file_sets",
         "lab.title",
         "preferred_assay_titles",
         "related_measurement_sets",


### PR DESCRIPTION
# PR Review: IGVF-3523 Input File Set Grouping Stage

## Model
GPT-5.3-Codex

## Verdict
Approve: no blocking issues found.

## Scope Reviewed
- Added input file set grouping stage in the grouping pipeline
- Added request field support for input_file_sets in common file set requests
- Added and updated tests for the above behavior

## Findings
No blocking bugs, regressions, or missing required tests were identified for the intended scope.

## Change Assessment
- The new stage is integrated into the grouping pipeline in the expected order.
- The request layer now includes input_file_sets, which is required for this grouping behavior.
- Unit tests cover the new stage behavior and the request field update.

## Validation Performed
- Ran targeted tests for changed areas:
  - components/file-graph/grouping-pipeline/__tests__/input-file-set-grouping.test.ts
  - lib/__tests__/common-requests.test.ts
- Result: 2 passed suites, 58 passed tests.

## Residual Risk
Low. The change is focused and test-backed, with no broad cross-cutting behavior changes detected.
