### PR TITLE
IGVF-3468 Add tooltip descriptions for file format types

### DIFF
--- a/components/common-data-items.js
+++ b/components/common-data-items.js
@@ -681,7 +681,12 @@ export function FileDataItems({ item, children = null }) {
       {item.file_format_type && (
         <>
           <DataItemLabel>File Format Type</DataItemLabel>
-          <DataItemValue>{item.file_format_type}</DataItemValue>
+          <DataItemValueAnnotated
+            objectType={item["@type"][0]}
+            propertyName="file_format_type"
+          >
+            {item.file_format_type}
+          </DataItemValueAnnotated>
         </>
       )}
       <DataItemLabel>Content Type</DataItemLabel>

--- a/package.json
+++ b/package.json
@@ -93,5 +93,11 @@
     "prettier-plugin-tailwindcss": "^0.6.12",
     "pretty-format": "^29.5.0",
     "tailwindcss": "^4.3.0"
+  },
+  "allowScripts": {
+    "cypress@14.5.4": true,
+    "fsevents@2.3.3": true,
+    "unrs-resolver@1.11.1": true,
+    "browser-tabs-lock@1.3.0": true
   }
 }


### PR DESCRIPTION
# Code Review: IGVF-3468-file-format-type-tooltip

## Reviewer
- Model: GPT-5.3-Codex (GitHub Copilot)
- Repository: IGVF-DACC/igvf-ui
- Branch: IGVF-3468-file-format-type-tooltip
- Base branch: dev
- Date: 2026-07-24

## Scope Reviewed
- components/common-data-items.js
- package.json

## Summary of Changes
- Updated File data rendering so `file_format_type` uses `DataItemValueAnnotated` instead of plain `DataItemValue`, enabling schema-backed tooltip annotations when available.
- Added an `allowScripts` block in `package.json` with explicit allowed package/version entries:
  - cypress@14.5.4
  - fsevents@2.3.3
  - unrs-resolver@1.11.1
  - browser-tabs-lock@1.3.0

## Findings (Ordered by Severity)
### 1. No blocking issues found
I did not identify functional regressions or correctness bugs in the branch diff.

## Validation Performed
- Reviewed unified diff against `dev` for all changed files.
- Confirmed `DataItemValueAnnotated` behavior: when no annotation exists, it still renders plain text value, so behavior remains backward-compatible.
- Ran workspace build task (`npm run -s build`): **successful**.

## Notes / Residual Risks
- The repo's "Typecheck (tsc)" task is currently not a reliable signal in this environment because it falls through to `tsc -p tsconfig.json` and `tsc` is not available on PATH in that task context.
- The version-pinned `allowScripts` entries may require upkeep when dependencies update to new patch versions.
- No targeted UI test was added in this branch for tooltip behavior on `file_format_type`; this is a minor test coverage gap.

## Final Verdict
**Approve** — changes are low risk, aligned with existing annotation patterns, and build successfully.
