### PR TITLE
IGVF-3480 Display descriptions on relevant object pages

### DIFF
--- a/components/common-data-items.js
+++ b/components/common-data-items.js
@@ -66,6 +66,12 @@ export function DonorDataItems({ item, publications = [], children }) {
         </>
       )}
       {children}
+      {item.description && (
+        <>
+          <DataItemLabel>Description</DataItemLabel>
+          <DataItemValue>{item.description}</DataItemValue>
+        </>
+      )}
       {item.submitter_comment && (
         <>
           <DataItemLabel>Submitter Comment</DataItemLabel>
@@ -121,6 +127,7 @@ DonorDataItems.propTypes = {
 
 DonorDataItems.commonProperties = [
   "aliases",
+  "description",
   "ethnicities",
   "publications",
   "revoke_detail",
@@ -989,6 +996,32 @@ FileSetDataItems.commonProperties = [
   "summary",
   "url",
 ];
+
+/**
+ * Display data items common to all quality-metric-derived objects.
+ */
+export function QualityMetricDataItems({ item, children }) {
+  return (
+    <>
+      {children}
+      {item.summary && (
+        <>
+          <DataItemLabel>Summary</DataItemLabel>
+          <DataItemValue>{item.summary}</DataItemValue>
+        </>
+      )}
+    </>
+  );
+}
+
+QualityMetricDataItems.propTypes = {
+  // Quality metric object
+  item: PropTypes.object.isRequired,
+  // Children elements to render
+  children: PropTypes.node,
+};
+
+QualityMetricDataItems.commonProperties = ["summary"];
 
 /**
  * `UnknownTypePanel` uses the following data and functions to use common data item renderers based

--- a/pages/genes/[id].js
+++ b/pages/genes/[id].js
@@ -47,6 +47,12 @@ export default function Gene({ gene, isJson }) {
               <DataItemValue>
                 <EnsemblLink geneid={gene.geneid} taxa={gene.taxa} />
               </DataItemValue>
+              {gene.description && (
+                <>
+                  <DataItemLabel>Description</DataItemLabel>
+                  <DataItemValue>{gene.description}</DataItemValue>
+                </>
+              )}
               {gene.allele && (
                 <>
                   <DataItemLabel>Allele</DataItemLabel>

--- a/pages/images/[id].js
+++ b/pages/images/[id].js
@@ -47,6 +47,12 @@ export default function Image({ image, attribution = null, isJson }) {
               </DataItemValue>
               <DataItemLabel>md5sum</DataItemLabel>
               <DataItemValue>{image.attachment.md5sum}</DataItemValue>
+              {image.description && (
+                <>
+                  <DataItemLabel>Description</DataItemLabel>
+                  <DataItemValue>{image.description}</DataItemValue>
+                </>
+              )}
               {image.summary && (
                 <>
                   <DataItemLabel>Summary</DataItemLabel>

--- a/pages/institutional-certificates/[...id].tsx
+++ b/pages/institutional-certificates/[...id].tsx
@@ -84,6 +84,15 @@ export default function InstitutionalCertificate({
                 </a>
               </DataItemValueUrl>
 
+              {institutionalCertificate.description && (
+                <>
+                  <DataItemLabel>Description</DataItemLabel>
+                  <DataItemValue>
+                    {institutionalCertificate.description}
+                  </DataItemValue>
+                </>
+              )}
+
               <DataItemLabel>Creation Timestamp</DataItemLabel>
               <DataItemValue>
                 {formatDate(institutionalCertificate.creation_timestamp)}

--- a/pages/labs/[name].js
+++ b/pages/labs/[name].js
@@ -50,6 +50,12 @@ export default function Lab({ lab, awards = null, pi = null, isJson }) {
                   </DataItemValueUrl>
                 </>
               )}
+              {lab.description && (
+                <>
+                  <DataItemLabel>Description</DataItemLabel>
+                  <DataItemValue>{lab.description}</DataItemValue>
+                </>
+              )}
               {awards?.length > 0 && (
                 <>
                   <DataItemLabel>Awards</DataItemLabel>

--- a/pages/mpra-quality-metrics/[id].tsx
+++ b/pages/mpra-quality-metrics/[id].tsx
@@ -2,6 +2,7 @@
 import _ from "lodash";
 // components
 import Breadcrumbs from "../../components/breadcrumbs";
+import { QualityMetricDataItems } from "../../components/common-data-items";
 import { DataArea, DataPanel } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import FileTable from "../../components/file-table";
@@ -46,17 +47,19 @@ export default function MpraQualityMetric({
           <StatusPreviewDetail item={qualityMetric} />
           <DataPanel>
             <DataArea>
-              {mpraFields.map((fieldAttr) => {
-                if (qualityMetric[fieldAttr.name]) {
-                  return (
-                    <QualityMetricField
-                      key={fieldAttr.name}
-                      fieldAttr={fieldAttr}
-                      qualityMetric={qualityMetric}
-                    />
-                  );
-                }
-              })}
+              <QualityMetricDataItems item={qualityMetric}>
+                {mpraFields.map((fieldAttr) => {
+                  if (qualityMetric[fieldAttr.name]) {
+                    return (
+                      <QualityMetricField
+                        key={fieldAttr.name}
+                        fieldAttr={fieldAttr}
+                        qualityMetric={qualityMetric}
+                      />
+                    );
+                  }
+                })}
+              </QualityMetricDataItems>
             </DataArea>
           </DataPanel>
 

--- a/pages/perturb-seq-quality-metrics/[id].tsx
+++ b/pages/perturb-seq-quality-metrics/[id].tsx
@@ -2,6 +2,7 @@
 import _ from "lodash";
 // components
 import Breadcrumbs from "../../components/breadcrumbs";
+import { QualityMetricDataItems } from "../../components/common-data-items";
 import { DataArea, DataPanel } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import FileTable from "../../components/file-table";
@@ -46,17 +47,19 @@ export default function PerturbSeqQualityMetric({
           <StatusPreviewDetail item={qualityMetric} />
           <DataPanel>
             <DataArea>
-              {perturbSeqFields.map((fieldAttr) => {
-                if (qualityMetric[fieldAttr.name]) {
-                  return (
-                    <QualityMetricField
-                      key={fieldAttr.name}
-                      fieldAttr={fieldAttr}
-                      qualityMetric={qualityMetric}
-                    />
-                  );
-                }
-              })}
+              <QualityMetricDataItems item={qualityMetric}>
+                {perturbSeqFields.map((fieldAttr) => {
+                  if (qualityMetric[fieldAttr.name]) {
+                    return (
+                      <QualityMetricField
+                        key={fieldAttr.name}
+                        fieldAttr={fieldAttr}
+                        qualityMetric={qualityMetric}
+                      />
+                    );
+                  }
+                })}
+              </QualityMetricDataItems>
             </DataArea>
           </DataPanel>
 

--- a/pages/phenotypic-features/[id].js
+++ b/pages/phenotypic-features/[id].js
@@ -50,6 +50,12 @@ export default function PhenotypicFeature({
               <DataItemValue>
                 <Link href={phenotypicFeature.feature["@id"]}>{feature}</Link>
               </DataItemValue>
+              {phenotypicFeature.description && (
+                <>
+                  <DataItemLabel>Description</DataItemLabel>
+                  <DataItemValue>{phenotypicFeature.description}</DataItemValue>
+                </>
+              )}
               {truthyOrZero(phenotypicFeature.quantity) && (
                 <>
                   <DataItemLabel>Quantity</DataItemLabel>

--- a/pages/publications/[id].js
+++ b/pages/publications/[id].js
@@ -70,6 +70,12 @@ export default function Publication({
             <DataArea>
               <DataItemLabel>Title</DataItemLabel>
               <DataItemValue>{publication.title}</DataItemValue>
+              {publication.description && (
+                <>
+                  <DataItemLabel>Description</DataItemLabel>
+                  <DataItemValue>{publication.description}</DataItemValue>
+                </>
+              )}
               {publication.authors && (
                 <>
                   <DataItemLabel>Authors</DataItemLabel>

--- a/pages/single-cell-atac-seq-quality-metrics/[id].tsx
+++ b/pages/single-cell-atac-seq-quality-metrics/[id].tsx
@@ -2,6 +2,7 @@
 import _ from "lodash";
 // components
 import Breadcrumbs from "../../components/breadcrumbs";
+import { QualityMetricDataItems } from "../../components/common-data-items";
 import { DataArea, DataPanel } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import FileTable from "../../components/file-table";
@@ -25,7 +26,7 @@ import { isJsonFormat } from "../../lib/query-utils";
 // root
 import type { FileObject } from "../../globals";
 
-export default function PerturbSeqQualityMetric({
+export default function SingleCellAtacSeqQualityMetric({
   qualityMetric,
   qualityMetricOf,
   isJson,
@@ -46,17 +47,19 @@ export default function PerturbSeqQualityMetric({
           <StatusPreviewDetail item={qualityMetric} />
           <DataPanel>
             <DataArea>
-              {singleCellAtacSeqFields.map((fieldAttr) => {
-                if (qualityMetric[fieldAttr.name]) {
-                  return (
-                    <QualityMetricField
-                      key={fieldAttr.name}
-                      fieldAttr={fieldAttr}
-                      qualityMetric={qualityMetric}
-                    />
-                  );
-                }
-              })}
+              <QualityMetricDataItems item={qualityMetric}>
+                {singleCellAtacSeqFields.map((fieldAttr) => {
+                  if (qualityMetric[fieldAttr.name]) {
+                    return (
+                      <QualityMetricField
+                        key={fieldAttr.name}
+                        fieldAttr={fieldAttr}
+                        qualityMetric={qualityMetric}
+                      />
+                    );
+                  }
+                })}
+              </QualityMetricDataItems>
             </DataArea>
           </DataPanel>
 

--- a/pages/single-cell-rna-seq-quality-metrics/[id].tsx
+++ b/pages/single-cell-rna-seq-quality-metrics/[id].tsx
@@ -2,6 +2,7 @@
 import _ from "lodash";
 // components
 import Breadcrumbs from "../../components/breadcrumbs";
+import { QualityMetricDataItems } from "../../components/common-data-items";
 import { DataArea, DataPanel } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import FileTable from "../../components/file-table";
@@ -25,7 +26,7 @@ import { isJsonFormat } from "../../lib/query-utils";
 // root
 import type { FileObject } from "../../globals";
 
-export default function PerturbSeqQualityMetric({
+export default function SingleCellRnaSeqQualityMetric({
   qualityMetric,
   qualityMetricOf,
   isJson,
@@ -46,17 +47,19 @@ export default function PerturbSeqQualityMetric({
           <StatusPreviewDetail item={qualityMetric} />
           <DataPanel>
             <DataArea>
-              {singleCellRnaSeqFields.map((fieldAttr) => {
-                if (qualityMetric[fieldAttr.name]) {
-                  return (
-                    <QualityMetricField
-                      key={fieldAttr.name}
-                      fieldAttr={fieldAttr}
-                      qualityMetric={qualityMetric}
-                    />
-                  );
-                }
-              })}
+              <QualityMetricDataItems item={qualityMetric}>
+                {singleCellRnaSeqFields.map((fieldAttr) => {
+                  if (qualityMetric[fieldAttr.name]) {
+                    return (
+                      <QualityMetricField
+                        key={fieldAttr.name}
+                        fieldAttr={fieldAttr}
+                        qualityMetric={qualityMetric}
+                      />
+                    );
+                  }
+                })}
+              </QualityMetricDataItems>
             </DataArea>
           </DataPanel>
 

--- a/pages/starr-seq-quality-metrics/[id].tsx
+++ b/pages/starr-seq-quality-metrics/[id].tsx
@@ -2,6 +2,7 @@
 import _ from "lodash";
 // components
 import Breadcrumbs from "../../components/breadcrumbs";
+import { QualityMetricDataItems } from "../../components/common-data-items";
 import { DataArea, DataPanel } from "../../components/data-area";
 import { EditableItem } from "../../components/edit";
 import FileTable from "../../components/file-table";
@@ -45,17 +46,19 @@ export default function PerturbSeqQualityMetric({
           <StatusPreviewDetail item={qualityMetric} />
           <DataPanel>
             <DataArea>
-              {starrSeqFields.map((fieldAttr) => {
-                if (qualityMetric[fieldAttr.name]) {
-                  return (
-                    <QualityMetricField
-                      key={fieldAttr.name}
-                      fieldAttr={fieldAttr}
-                      qualityMetric={qualityMetric}
-                    />
-                  );
-                }
-              })}
+              <QualityMetricDataItems item={qualityMetric}>
+                {starrSeqFields.map((fieldAttr) => {
+                  if (qualityMetric[fieldAttr.name]) {
+                    return (
+                      <QualityMetricField
+                        key={fieldAttr.name}
+                        fieldAttr={fieldAttr}
+                        qualityMetric={qualityMetric}
+                      />
+                    );
+                  }
+                })}
+              </QualityMetricDataItems>
             </DataArea>
           </DataPanel>
 

--- a/pages/treatments/[uuid].js
+++ b/pages/treatments/[uuid].js
@@ -119,6 +119,12 @@ export default function Treatment({
                   </DataItemValue>
                 </>
               )}
+              {treatment.description && (
+                <>
+                  <DataItemLabel>Description</DataItemLabel>
+                  <DataItemValue>{treatment.description}</DataItemValue>
+                </>
+              )}
               {treatment.submitter_comment && (
                 <>
                   <DataItemLabel>Submitter Comment</DataItemLabel>

--- a/pages/users/[uuid].tsx
+++ b/pages/users/[uuid].tsx
@@ -41,13 +41,23 @@ export default function User({ user, lab, isJson }: UserPageProps) {
         <PagePreamble />
         <ObjectPageHeader item={user} isJsonFormat={isJson} />
         <JsonDisplay item={user} isJsonFormat={isJson}>
-          {user.job_title || lab || user.email || user.submitter_comment ? (
+          {user.job_title ||
+          lab ||
+          user.email ||
+          user.submitter_comment ||
+          user.description ? (
             <DataPanel>
               <DataArea>
                 {user.job_title && (
                   <>
                     <DataItemLabel>Job Title</DataItemLabel>
                     <DataItemValue>{user.job_title}</DataItemValue>
+                  </>
+                )}
+                {user.description && (
+                  <>
+                    <DataItemLabel>Description</DataItemLabel>
+                    <DataItemValue>{user.description}</DataItemValue>
                   </>
                 )}
                 {lab && (


### PR DESCRIPTION
# PR Review: IGVF-3480-object-description

## Model
GPT-5.3-Codex

## Final Verdict
Approve with one verification note.

## Summary
This branch adds Description display support across multiple object pages and introduces a shared renderer for quality metric common data items. The changes are consistent with existing rendering patterns and do not introduce clear behavioral regressions in the reviewed diff.

## Findings
No blocking, high, or medium severity issues found in the current diff.

## Verification Note
Type/build verification could not be fully confirmed in this environment because the Typecheck task exits with code 127 due to missing tsc in the current shell/task fallback path.

## Suggested PR Comment (Paste-Ready)
Reviewed with GPT-5.3-Codex.

Final verdict: Approve with one verification note.

- No blocking/high/medium issues found in the current branch diff.
- The Description field additions across object pages follow existing conditional rendering conventions.
- The shared quality metric common-data renderer is implemented consistently and conditionally renders Summary.
- Verification note: local typecheck task in this environment exits 127 (missing tsc fallback), so please rely on CI or a fully provisioned local env for final type/build confirmation.
